### PR TITLE
Add note that replay buffer size is per env

### DIFF
--- a/src/holosoma/holosoma/config_types/algo.py
+++ b/src/holosoma/holosoma/config_types/algo.py
@@ -204,7 +204,7 @@ class FastSACConfig:
     """the learning rate for the alpha"""
 
     buffer_size: int = 1024
-    """the replay memory buffer size"""
+    """the replay memory buffer size per environment"""
 
     num_steps: int = 1
     """the number of steps to use for the multi-step return"""


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

Tiny update: add buffer_size docstring in FastSACConfig to state it is per environment.

Clarifies the meaning of buffer_size in FastSACConfig. Currently the docstring suggests it is a single replay buffer size, but per [fast_sac_utils.py#L42](https://github.com/amazon-far/holosoma/blob/9c238cf80f531c0e65d818348c3c1a5cc2764f5b/src/holosoma/holosoma/agents/fast_sac/fast_sac_utils.py#L42), the buffer is allocated per environment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
