### PR TITLE
Remove physics stepping for replay

### DIFF
--- a/src/holosoma/holosoma/replay.py
+++ b/src/holosoma/holosoma/replay.py
@@ -29,7 +29,7 @@ def replay(tyro_config: ExperimentConfig):
 
     done = False
     while not done:
-        env.simulator.sim.step()
+        # We don't need to step the simulator here because we are just visualizing the motion
         done = env.step_visualize_motion(None)  # type: ignore[attr-defined]
 
     close_simulation_app(simulation_app)


### PR DESCRIPTION
*Issue #, if available:*

Refer to #18 

Robot is very shaky during motion replay.

*Description of changes:*

Simulation physics stepping is removed for replay.

Reference:
https://github.com/HybridRobotics/whole_body_tracking/blob/cd65172032893724b445448818c34165846d847d/scripts/replay_npz.py#L103

Result:

https://github.com/user-attachments/assets/af4d8a81-0def-493a-9e51-393d14022108


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
