### PR TITLE
Add OSX support for mujoco training and evaluation

### DIFF
--- a/scripts/setup_inference.sh
+++ b/scripts/setup_inference.sh
@@ -71,11 +71,19 @@ if [[ ! -f $SENTINEL_FILE ]]; then
   source $CONDA_ROOT/bin/activate hsinference
 
   # Install libstdcxx-ng to fix the error: `version `GLIBCXX_3.4.32' not found` on Ubuntu 24.04
-  conda install -c conda-forge -y libstdcxx-ng
+  # Only needed on Linux (not macOS)
+  if [[ $OS == "Linux" ]]; then
+    conda install -c conda-forge -y libstdcxx-ng
+  fi
 
   # Install holosoma_inference
-  pip install -e $ROOT_DIR/src/holosoma_inference[unitree,booster]
-
+  # Note: On macOS, only Unitree SDK is supported (Booster SDK is Linux-only)
+  if [[ $OS == "Darwin" ]]; then
+    echo "Note: Installing Unitree SDK only (Booster SDK is not supported on macOS)"
+    pip install -e $ROOT_DIR/src/holosoma_inference[unitree]
+  else
+    pip install -e $ROOT_DIR/src/holosoma_inference[unitree,booster]
+  fi
   # Setup a few things for ARM64 Linux (G1 Jetson)
   # Otherwise we get this error:
   # /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/stl_vector.h:1130: ...

--- a/src/holosoma/README.md
+++ b/src/holosoma/README.md
@@ -79,6 +79,20 @@ python src/holosoma/holosoma/train_agent.py \
 > - These examples use `--training.num-envs=4096`, but you may need to adjust this value based on your hardware.
 > - When training T1 with PPO on mixed terrain, use `--terrain.terrain-term.scale-factor=0.5` to avoid training instabilities.
 
+## MUJOCO and OSX Training for Locomotion
+```bash
+source scripts/source_mujoco_setup.sh
+mjpython src/holosom/holosoma/train_agent.py \
+   exp:g1-29dof \
+   simulator:mujoco \
+   --training.num-envs 1 \
+   --randomization.ignore_unsupported=True \
+   logger:wandb
+
+```
+> **Note:**
+> - Training is only supported with MuJoCo simulation using the mjpython interpreter
+> - Training is limited to a single environment
 
 ### Whole-Body Tracking
 
@@ -134,6 +148,18 @@ python src/holosoma/holosoma/eval_agent.py \
 python src/holosoma/holosoma/eval_agent.py \
     --checkpoint=<CHECKPOINT_PATH>
 # e.g., --checkpoint=/home/username/checkpoints/fastsac-t1-locomotion/model_0010000.pt
+```
+
+> **OSX Note:**
+> - When evaluating with MuJoCo on macOS, you must use `mjpython` instead of `python` for interactive viewer support:
+> - If the simulator continually disappears you may need to set the following env variable
+>  - ```export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ```
+```bash
+# macOS evaluation with interactive viewer
+mjpython src/holosoma/holosoma/eval_agent.py \
+        simulator:mujoco \
+        --randomization.ignore_unsupported=True \
+        --checkpoint=wandb://<ENTITY>/<PROJECT>/<RUN_ID>/<CHECKPOINT_NAME>
 ```
 
 This evaluation mode:

--- a/src/holosoma/pyproject.toml
+++ b/src/holosoma/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "types-requests",
     "types-tqdm",
     "tyro>=1.0.0",
-    "wandb==0.22.0", # pin version until https://github.com/wandb/wandb/issues/10647 is fixed
+    "wandb>=0.23.0", # Updated to support 86-character API keys
     "warp-lang==1.10.0",
     "yourdfpy>=0.0.58",
     "zmq",

--- a/src/holosoma/setup.py
+++ b/src/holosoma/setup.py
@@ -8,13 +8,29 @@ UNITREE_REPO = "https://github.com/amazon-far/unitree_sdk2"
 BOOSTER_VERSION = "0.1.0"
 BOOSTER_REPO = "https://github.com/amazon-far/booster_robotics_sdk"
 
-PLATFORM_MAP = {
-    "x86_64": "linux_x86_64",
-    "aarch64": "linux_aarch64",
-}
+
+def get_platform_tag():
+    """Get the correct platform tag for wheel installation."""
+    machine = platform.machine()
+    system = platform.system()
+
+    if system == "Linux":
+        if machine == "x86_64":
+            return "linux_x86_64"
+        if machine in ("aarch64", "arm64"):
+            return "linux_aarch64"
+    elif system == "Darwin":
+        # Get macOS version for proper wheel tag
+        mac_ver = platform.mac_ver()[0]  # Returns version like "14.1.0"
+        major_version = mac_ver.split(".")[0] if mac_ver else "11"
+        assert major_version == "26"
+        return f"macosx_{major_version}_0_{machine}"
+    # Fallback
+    return "linux_x86_64"
+
 
 pyvers = f"cp{sys.version_info.major}{sys.version_info.minor}"
-platform_str = PLATFORM_MAP.get(platform.machine(), "linux_x86_64")
+platform_str = get_platform_tag()
 
 unitree_url = f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/unitree_sdk2-{UNITREE_VERSION}-{pyvers}-{pyvers}-{platform_str}.whl"  # noqa: E501
 booster_url = f"{BOOSTER_REPO}/releases/download/{BOOSTER_VERSION}/booster_robotics_sdk-{BOOSTER_VERSION}-{pyvers}-{pyvers}-{platform_str}.whl"  # noqa: E501

--- a/src/holosoma_inference/setup.py
+++ b/src/holosoma_inference/setup.py
@@ -1,23 +1,38 @@
 import platform
+import sys
 
 from setuptools import find_packages, setup
 
-UNITREE_VERSION = "0.1.1"
+UNITREE_VERSION = "0.1.2"
 UNITREE_REPO = "https://github.com/amazon-far/unitree_sdk2"
 BOOSTER_VERSION = "0.1.0"
 BOOSTER_REPO = "https://github.com/amazon-far/booster_robotics_sdk"
 
-PLATFORM_MAP = {
-    "x86_64": "linux_x86_64",
-    "aarch64": "linux_aarch64",
-}
 
-platform_tag = PLATFORM_MAP.get(platform.machine(), "linux_x86_64")
+def get_platform_tag():
+    """Get the correct platform tag for wheel installation."""
+    machine = platform.machine()
+    system = platform.system()
 
+    if system == "Linux":
+        if machine == "x86_64":
+            return "linux_x86_64"
+        if machine in ("aarch64", "arm64"):
+            return "linux_aarch64"
+    elif system == "Darwin":
+        # Get macOS version for proper wheel tag
+        mac_ver = platform.mac_ver()[0]  # Returns version like "14.1.0"
+        major_version = mac_ver.split(".")[0] if mac_ver else "11"
+        assert major_version == "26"
+        return f"macosx_{major_version}_0_{machine}"
+    # Fallback
+    return "linux_x86_64"
+
+
+platform_tag = get_platform_tag()
+pyvers = f"cp{sys.version_info.major}{sys.version_info.minor}"
 unitree_extras = []
-unitree_url = (
-    f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/unitree_sdk2-{UNITREE_VERSION}-cp310-cp310-{platform_tag}.whl"
-)
+unitree_url = f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/unitree_sdk2-{UNITREE_VERSION}-{pyvers}-{pyvers}-{platform_tag}.whl"  # noqa: E501
 unitree_extras.append(f"unitree_sdk2 @ {unitree_url}")
 
 booster_extras = []


### PR DESCRIPTION

# Summary
Added macOS support to the Holosoma robotics framework by:

Detecting OS/architecture and installing appropriate Miniconda version
Conditionally installing Linux-only dependencies
Adding macOS-specific installation and usage instructions to README
Updating platform tag detection for proper wheel installation
Upgrading wandb to v0.23+ to support longer API keys

# OSX Performance Benchmark

**Platform:** macOS (Darwin)  
**Simulator:** MuJoCo CPU (Classic backend)  
**Date:** January 30, 2026  
**Configuration:** 100 iterations, 1 environment, seed 42

## Performance Results

| Robot | Algorithm | **Eval Time** | **Training Time** | **Time/Iter** | **Eval Steps/s** | **Train Iter/s** |
|-------|-----------|---------------|-------------------|---------------|------------------|------------------|
| G1 (29-DOF) | PPO | 16s | 71s | 0.71s | 62.5 | 1.41 |
| G1 (29-DOF) | FastSAC | 16s | 313s | 3.13s | 62.5 | 0.32 |

## Key Findings

### Evaluation Performance
- Both algorithms take exactly **16 seconds** for evaluation (1000 steps)
- Identical throughput: **62.5 steps/second** regardless of algorithm
- Algorithm choice has **zero impact** on inference speed

### Training Performance
- **PPO is 4.4x faster** than FastSAC (71s vs 313s)
- PPO achieves **1.41 iterations/second** vs FastSAC's **0.32 iter/s**
- PPO completes 100 iterations in just over 1 minute vs FastSAC's 5+ minutes

### CPU Utilization
- Extremely low: **0.001-0.01% average**, **0.4-1.1% peak**
- Training is simulation-bound, not compute-bound
- Single environment bottleneck confirmed


## Configuration Details

**Test Configuration:**
- Iterations: 100
- Environments: 1 (Single environments only for CPU MuJoCo)
- Seed: 42
- Simulator: MuJoCo Classic backend
- Python: mjpython interpreter

**Hardware:**
- Platform: macOS (Darwin)
- CPU utilization: 0.001-0.01% average, 0.4-1.1% peak
- Memory utilization: 0% (negligible)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
