### PR TITLE
Unify the robot SDK interface

### DIFF
--- a/src/holosoma/README.md
+++ b/src/holosoma/README.md
@@ -79,20 +79,6 @@ python src/holosoma/holosoma/train_agent.py \
 > - These examples use `--training.num-envs=4096`, but you may need to adjust this value based on your hardware.
 > - When training T1 with PPO on mixed terrain, use `--terrain.terrain-term.scale-factor=0.5` to avoid training instabilities.
 
-## MUJOCO and OSX Training for Locomotion
-```bash
-source scripts/source_mujoco_setup.sh
-mjpython src/holosom/holosoma/train_agent.py \
-   exp:g1-29dof \
-   simulator:mujoco \
-   --training.num-envs 1 \
-   --randomization.ignore_unsupported=True \
-   logger:wandb
-
-```
-> **Note:**
-> - Training is only supported with MuJoCo simulation using the mjpython interpreter
-> - Training is limited to a single environment
 
 ### Whole-Body Tracking
 
@@ -148,18 +134,6 @@ python src/holosoma/holosoma/eval_agent.py \
 python src/holosoma/holosoma/eval_agent.py \
     --checkpoint=<CHECKPOINT_PATH>
 # e.g., --checkpoint=/home/username/checkpoints/fastsac-t1-locomotion/model_0010000.pt
-```
-
-> **OSX Note:**
-> - When evaluating with MuJoCo on macOS, you must use `mjpython` instead of `python` for interactive viewer support:
-> - If the simulator continually disappears you may need to set the following env variable
->  - ```export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ```
-```bash
-# macOS evaluation with interactive viewer
-mjpython src/holosoma/holosoma/eval_agent.py \
-        simulator:mujoco \
-        --randomization.ignore_unsupported=True \
-        --checkpoint=wandb://<ENTITY>/<PROJECT>/<RUN_ID>/<CHECKPOINT_NAME>
 ```
 
 This evaluation mode:

--- a/src/holosoma/holosoma/bridge/base/basic_sdk2py_bridge.py
+++ b/src/holosoma/holosoma/bridge/base/basic_sdk2py_bridge.py
@@ -5,13 +5,14 @@ import numpy as np
 import pygame
 from loguru import logger
 
+from holosoma.config_types.robot import RobotConfig
 from holosoma.utils.safe_torch_import import torch
 
 
 class BasicSdk2Bridge(ABC):
     """Abstract base class for SDK2Py bridge implementations."""
 
-    def __init__(self, simulator, robot_config, bridge_config, lcm=None):
+    def __init__(self, simulator, robot_config: RobotConfig, bridge_config, lcm=None):
         self.lcm = lcm
         self.robot = robot_config
         self.bridge_config = bridge_config
@@ -101,7 +102,6 @@ class BasicSdk2Bridge(ABC):
 
         # PD control computation
         torques = tau + kp_t * (q_des - q_actual) + kd_t * (dq_des - dq_actual)
-
         # Convert to numpy and apply limits
         torques_np = torques.detach().cpu().numpy()
         self.torques = np.clip(torques_np, -self.torque_limit, self.torque_limit)

--- a/src/holosoma/holosoma/config_types/experiment.py
+++ b/src/holosoma/holosoma/config_types/experiment.py
@@ -78,9 +78,6 @@ class TrainingConfig:
     name: str = "run"
     """Run name for logging. `logger.name` takes precedence if set."""
 
-    tags: tuple[str, ...] = ()
-    """Optional tags to attach to the run for logging."""
-
     # Evaluation settings
     max_eval_steps: int | None = None
     """Maximum number of evaluation steps (None for unlimited)."""

--- a/src/holosoma/pyproject.toml
+++ b/src/holosoma/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "types-requests",
     "types-tqdm",
     "tyro>=1.0.0",
-    "wandb>=0.23.0", # Updated to support 86-character API keys
+    "wandb==0.22.0", # pin version until https://github.com/wandb/wandb/issues/10647 is fixed
     "warp-lang==1.10.0",
     "yourdfpy>=0.0.58",
     "zmq",

--- a/src/holosoma/setup.py
+++ b/src/holosoma/setup.py
@@ -8,29 +8,13 @@ UNITREE_REPO = "https://github.com/amazon-far/unitree_sdk2"
 BOOSTER_VERSION = "0.1.0"
 BOOSTER_REPO = "https://github.com/amazon-far/booster_robotics_sdk"
 
-
-def get_platform_tag():
-    """Get the correct platform tag for wheel installation."""
-    machine = platform.machine()
-    system = platform.system()
-
-    if system == "Linux":
-        if machine == "x86_64":
-            return "linux_x86_64"
-        if machine in ("aarch64", "arm64"):
-            return "linux_aarch64"
-    elif system == "Darwin":
-        # Get macOS version for proper wheel tag
-        mac_ver = platform.mac_ver()[0]  # Returns version like "14.1.0"
-        major_version = mac_ver.split(".")[0] if mac_ver else "11"
-        assert major_version == "26"
-        return f"macosx_{major_version}_0_{machine}"
-    # Fallback
-    return "linux_x86_64"
-
+PLATFORM_MAP = {
+    "x86_64": "linux_x86_64",
+    "aarch64": "linux_aarch64",
+}
 
 pyvers = f"cp{sys.version_info.major}{sys.version_info.minor}"
-platform_str = get_platform_tag()
+platform_str = PLATFORM_MAP.get(platform.machine(), "linux_x86_64")
 
 unitree_url = f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/unitree_sdk2-{UNITREE_VERSION}-{pyvers}-{pyvers}-{platform_str}.whl"  # noqa: E501
 booster_url = f"{BOOSTER_REPO}/releases/download/{BOOSTER_VERSION}/booster_robotics_sdk-{BOOSTER_VERSION}-{pyvers}-{pyvers}-{platform_str}.whl"  # noqa: E501
@@ -39,5 +23,11 @@ setup(
     extras_require={
         "unitree": [f"unitree_sdk2 @ {unitree_url}"],
         "booster": [f"booster_robotics_sdk @ {booster_url}"],
+    },
+    entry_points={
+        "holosoma.bridge": [
+            "unitree = holosoma.bridge.unitree:UnitreeSdk2Bridge",
+            "booster = holosoma.bridge.booster:BoosterSdk2Bridge",
+        ],
     },
 )

--- a/src/holosoma_inference/docker/run.sh
+++ b/src/holosoma_inference/docker/run.sh
@@ -2,29 +2,42 @@
 
 # Parse command line arguments
 NEW_CONTAINER=false
-if [ "$1" == "--new" ]; then
-    NEW_CONTAINER=true
-fi
+EXT_DIR=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --new) NEW_CONTAINER=true; shift ;;
+        --ext-repo-path) EXT_DIR="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
 
 # Get the project root directory dynamically
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # holosoma/holosoma_inference/docker
-PROJECT_ROOT="$( cd "$SCRIPT_DIR/../../.." && pwd )" # holosoma/
-
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$( cd "$SCRIPT_DIR/../../.." && pwd )"
 CONTAINER_NAME="far-jetson-container"
 IMAGE_NAME="holosoma-onboard"
 
 # Function to create a new container
 create_container() {
+    local mounts=(
+        -v "$PROJECT_ROOT":/workspace/holosoma
+        -v ~/cyclonedds_ws/:/workspace/cyclonedds_ws
+        -v /tmp/.X11-unix:/tmp/.X11-unix
+        -v $HOME/.Xauthority:/root/.Xauthority:ro
+        -v /dev/shm:/dev/shm
+    )
+    [[ -d "$EXT_DIR" ]] && mounts+=(-v "$EXT_DIR":/workspace/holosoma-extension) # optionally mount extension repo
+
     docker run -it \
         --privileged \
         --name ${CONTAINER_NAME} \
         --network host \
+        --ipc host \
         -e DISPLAY=$DISPLAY \
         -e XAUTHORITY=/root/.Xauthority \
-        -v /tmp/.X11-unix:/tmp/.X11-unix \
-        -v ~/cyclonedds_ws/:/workspace/cyclonedds_ws \
-        -v $HOME/.Xauthority:/root/.Xauthority:ro \
-        -v "$PROJECT_ROOT":/workspace/holosoma \
+        -e ROS_DOMAIN_ID=${ROS_DOMAIN_ID} \
+        -e ROS_LOCALHOST_ONLY=${ROS_LOCALHOST_ONLY} \
+        "${mounts[@]}" \
         -w /workspace/holosoma \
         "$IMAGE_NAME"
 }

--- a/src/holosoma_inference/holosoma_inference/config/config_types/robot.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_types/robot.py
@@ -146,8 +146,12 @@ class RobotConfig:
     # SDK Configuration (OPTIONAL - with defaults)
     # =========================================================================
 
-    sdk_type: typing.Literal["unitree", "booster", "ros2"] = "unitree"
-    """SDK type for robot communication."""
+    sdk_type: str = "unitree"
+    """SDK type for robot communication.
+
+    Built-in types: 'unitree', 'booster'.
+    Extensions can register additional SDK types.
+    """
 
     motor_type: typing.Literal["serial", "parallel"] = "serial"
     """Motor communication type."""

--- a/src/holosoma_inference/holosoma_inference/config/config_types/task.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_types/task.py
@@ -54,3 +54,6 @@ class TaskConfig:
 
     use_ros: bool = False
     """Use ROS2 for rate limiting."""
+
+    print_observations: bool = False
+    """Print observation vectors for debugging."""

--- a/src/holosoma_inference/holosoma_inference/config/config_values/inference.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_values/inference.py
@@ -1,8 +1,7 @@
 """Default inference configurations for holosoma_inference."""
 
-from __future__ import annotations
-
 from dataclasses import replace
+from importlib.metadata import entry_points
 
 import tyro
 from typing_extensions import Annotated
@@ -10,46 +9,45 @@ from typing_extensions import Annotated
 from holosoma_inference.config.config_types.inference import InferenceConfig
 from holosoma_inference.config.config_values import observation, robot, task
 
-# G1 Locomotion
 g1_29dof_loco = InferenceConfig(
     robot=robot.g1_29dof,
     observation=observation.loco_g1_29dof,
     task=task.locomotion,
 )
 
-# T1 Locomotion
 t1_29dof_loco = InferenceConfig(
     robot=robot.t1_29dof,
     observation=observation.loco_t1_29dof,
     task=task.locomotion,
 )
 
-# G1 Whole-Body Tracking
+# fmt: off
 g1_29dof_wbt = InferenceConfig(
     robot=replace(
         robot.g1_29dof,
         stiff_startup_pos=(
-            -0.312, 0.0, 0.0, 0.669, -0.363, 0.0,  # left leg
-            -0.312, 0.0, 0.0, 0.669, -0.363, 0.0,  # right leg
-            0.0, 0.0, 0.0,  # waist
-            0.2, 0.2, 0.0, 0.6, 0.0, 0.0, 0.0,  # left arm
-            0.2, -0.2, 0.0, 0.6, 0.0, 0.0, 0.0,  # right arm
+            -0.312, 0.0, 0.0, 0.669, -0.363, 0.0,   # left leg
+            -0.312, 0.0, 0.0, 0.669, -0.363, 0.0,   # right leg
+            0.0, 0.0, 0.0,                          # waist
+            0.2, 0.2, 0.0, 0.6, 0.0, 0.0, 0.0,      # left arm
+            0.2, -0.2, 0.0, 0.6, 0.0, 0.0, 0.0,     # right arm
         ),
         stiff_startup_kp=(
-            350.0, 200.0, 200.0, 300.0, 300.0, 150.0,  # left leg
-            350.0, 200.0, 200.0, 300.0, 300.0, 150.0,  # right leg
-            200.0, 200.0, 200.0,  # waist
-            40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0,  # left arm
-            40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0,  # right arm
+            350.0, 200.0, 200.0, 300.0, 300.0, 150.0,
+            350.0, 200.0, 200.0, 300.0, 300.0, 150.0,
+            200.0, 200.0, 200.0,
+            40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0,
+            40.0, 40.0, 40.0, 40.0, 40.0, 40.0, 40.0,
         ),
         stiff_startup_kd=(
-            5.0, 5.0, 5.0, 10.0, 5.0, 5.0,  # left leg
-            5.0, 5.0, 5.0, 10.0, 5.0, 5.0,  # right leg
-            5.0, 5.0, 5.0,  # waist
-            3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,  # left arm
-            3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,  # right arm
+            5.0, 5.0, 5.0, 10.0, 5.0, 5.0,
+            5.0, 5.0, 5.0, 10.0, 5.0, 5.0,
+            5.0, 5.0, 5.0,
+            3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
+            3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
         ),
     ),
+# fmt: on
     observation=observation.wbt,
     task=task.wbt,
 )
@@ -60,10 +58,13 @@ DEFAULTS = {
     "g1-29dof-wbt": g1_29dof_wbt,
 }
 
-# Annotated version for Tyro CLI with subcommands
+# Auto-discover inference configs from installed extensions
+for ep in entry_points(group="holosoma.config.inference"):
+    DEFAULTS[ep.name] = ep.load()
+
 AnnotatedInferenceConfig = Annotated[
     InferenceConfig,
     tyro.conf.arg(
         constructor=tyro.extras.subcommand_type_from_defaults({f"inference:{k}": v for k, v in DEFAULTS.items()})
-    ),
+        ),
 ]

--- a/src/holosoma_inference/holosoma_inference/config/config_values/observation.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_values/observation.py
@@ -6,6 +6,8 @@ robot types and tasks, converted from the original YAML configurations.
 
 from __future__ import annotations
 
+from importlib.metadata import entry_points
+
 from holosoma_inference.config.config_types.observation import ObservationConfig
 
 # =============================================================================
@@ -35,8 +37,8 @@ loco_g1_29dof = ObservationConfig(
         "dof_pos": 29,
         "dof_vel": 29,
         "actions": 29,
-        "sin_phase": 1,
-        "cos_phase": 1,
+        "sin_phase": 2,
+        "cos_phase": 2,
     },
     obs_scales={
         "base_lin_vel": 2.0,
@@ -154,3 +156,7 @@ DEFAULTS = {
 
 Keys use hyphen-case naming convention for CLI compatibility.
 """
+
+# Auto-discover observation configs from installed extensions
+for ep in entry_points(group="holosoma.config.observation"):
+    DEFAULTS[ep.name] = ep.load()

--- a/src/holosoma_inference/holosoma_inference/config/config_values/robot.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_values/robot.py
@@ -6,6 +6,8 @@ for different robot types.
 
 from __future__ import annotations
 
+from importlib.metadata import entry_points
+
 from holosoma_inference.config.config_types.robot import RobotConfig
 
 # =============================================================================
@@ -198,3 +200,7 @@ DEFAULTS = {
 
 Keys use hyphen-case naming convention for CLI compatibility.
 """
+
+# Auto-discover robot configs from installed extensions
+for ep in entry_points(group="holosoma.config.robot"):
+    DEFAULTS[ep.name] = ep.load()

--- a/src/holosoma_inference/holosoma_inference/run_policy.py
+++ b/src/holosoma_inference/holosoma_inference/run_policy.py
@@ -117,11 +117,11 @@ def run_policy(config: InferenceConfig):
         restore_terminal_settings()
 
 
-def main():
-    config = tyro.cli(
-        AnnotatedInferenceConfig,
-        config=TYRO_CONFIG,
-    )
+def main(annotated_config=None):
+    """Main entry point. Extensions can pass their own AnnotatedInferenceConfig."""
+    if annotated_config is None:
+        annotated_config = AnnotatedInferenceConfig
+    config = tyro.cli(annotated_config, config=TYRO_CONFIG)
     run_policy(config)
 
 

--- a/src/holosoma_inference/holosoma_inference/sdk/__init__.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/__init__.py
@@ -1,16 +1,23 @@
-"""
-Robot communication package.
+"""Robot communication package."""
 
-This package provides unified interfaces for robot state processing and command sending
-across different robot platforms (Unitree, Booster, etc.).
-"""
+from __future__ import annotations
 
-from .command_sender import create_command_sender
-from .interface_wrapper import InterfaceWrapper
-from .state_processor import create_state_processor
+from importlib.metadata import entry_points
 
-__all__ = [
-    "InterfaceWrapper",
-    "create_command_sender",
-    "create_state_processor",
-]
+# Auto-discover SDK interfaces from installed packages using lazy loading.
+# Lazy loading is to avoid errors from SDK dependencies from extensions (e.g. ROS2) when working with other SDKs.
+_entry_points = {ep.name: ep for ep in entry_points(group="holosoma.sdk")}
+_registry = {}  # Cache for loaded interfaces
+
+
+def create_interface(robot_config, domain_id=0, interface_str=None, use_joystick=True):
+    """Create interface from registry."""
+    sdk_type = robot_config.sdk_type
+    if sdk_type not in _entry_points:
+        raise ValueError(f"Unknown sdk_type: {sdk_type}. Available: {sorted(_entry_points.keys())}")
+
+    # Lazy load: only load the entry point when actually needed
+    if sdk_type not in _registry:
+        _registry[sdk_type] = _entry_points[sdk_type].load()
+
+    return _registry[sdk_type](robot_config, domain_id, interface_str, use_joystick)

--- a/src/holosoma_inference/holosoma_inference/sdk/base/base_interface.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/base/base_interface.py
@@ -1,0 +1,186 @@
+"""Base interface for robot control."""
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from holosoma_inference.config.config_types import RobotConfig
+
+
+class BaseInterface(ABC):
+    """
+    Abstract base class for robot control interfaces.
+    """
+
+    def __init__(self, robot_config: RobotConfig, domain_id=0, interface_str=None, use_joystick=True):
+        self.robot_config = robot_config
+        self.domain_id = domain_id
+        self.interface_str = interface_str
+        self.use_joystick = use_joystick
+        # Initialize key state tracking for joystick
+        self._key_states: dict[str, bool] = {}
+        self._last_key_states: dict[str, bool] = {}
+        self._wc_key_map = self._default_wc_key_map()
+
+    @abstractmethod
+    def get_low_state(self) -> np.ndarray:
+        """
+        Get robot state as numpy array.
+
+        Returns:
+            np.ndarray with shape (1, 3+4+N+3+3+N) containing:
+            [base_pos(3), quat(4), joint_pos(N), lin_vel(3), ang_vel(3), joint_vel(N)]
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def send_low_command(
+        self,
+        cmd_q: np.ndarray,
+        cmd_dq: np.ndarray,
+        cmd_tau: np.ndarray,
+        dof_pos_latest: np.ndarray = None,
+        kp_override: np.ndarray = None,
+        kd_override: np.ndarray = None,
+    ):
+        """
+        Send low-level command to robot.
+
+        Args:
+            cmd_q: target joint positions (N,)
+            cmd_dq: target joint velocities (N,)
+            cmd_tau: feedforward torques (N,)
+            dof_pos_latest: latest joint positions (N,)
+            kp_override: optional KP gains override (N,)
+            kd_override: optional KD gains override (N,)
+        """
+        raise NotImplementedError
+
+    def update_config(self, robot_config: RobotConfig):
+        """
+        Update the robot configuration and propagate to internal components.
+
+        Override in subclasses that need to update internal SDK components
+        when the config changes (e.g., after loading KP/KD from ONNX metadata).
+
+        Args:
+            robot_config: The new robot configuration.
+        """
+        self.robot_config = robot_config
+
+    @abstractmethod
+    def get_joystick_msg(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_joystick_key(self, wc_msg=None):
+        raise NotImplementedError
+
+    def process_joystick_input(self, lin_vel_command, ang_vel_command, stand_command, upper_body_motion_active):
+        """
+        Process joystick input and update commands in a unified way.
+
+        Args:
+            lin_vel_command: np.ndarray, shape (1, 2)
+            ang_vel_command: np.ndarray, shape (1, 1)
+            stand_command: np.ndarray, shape (1, 1)
+            upper_body_motion_active: bool
+
+        Returns:
+            (lin_vel_command, ang_vel_command, key_states): updated values
+        """
+        wc_msg = self.get_joystick_msg()
+        if wc_msg is None:
+            return lin_vel_command, ang_vel_command, self._key_states
+        # Process stick input
+        if getattr(wc_msg, "keys", 0) == 0 and not upper_body_motion_active:
+            lx = getattr(wc_msg, "lx", 0.0)
+            ly = getattr(wc_msg, "ly", 0.0)
+            rx = getattr(wc_msg, "rx", 0.0)
+            lin_vel_command[0, 1] = -(lx if abs(lx) > 0.1 else 0.0) * stand_command[0, 0]
+            lin_vel_command[0, 0] = (ly if abs(ly) > 0.1 else 0.0) * stand_command[0, 0]
+            ang_vel_command[0, 0] = -(rx if abs(rx) > 0.1 else 0.0) * stand_command[0, 0]
+        # Process button input
+        cur_key = self.get_joystick_key(wc_msg)
+        self._last_key_states = self._key_states.copy()
+        if cur_key:
+            self._key_states[cur_key] = True
+        else:
+            self._key_states = dict.fromkeys(self._wc_key_map.values(), False)
+
+        return lin_vel_command, ang_vel_command, self._key_states
+
+    def _default_wc_key_map(self):
+        """Default wireless controller key mapping."""
+        return {
+            1: "R1",
+            2: "L1",
+            3: "L1+R1",
+            4: "start",
+            8: "select",
+            10: "L1+select",
+            16: "R2",
+            32: "L2",
+            64: "F1",
+            128: "F2",
+            256: "A",
+            264: "select+A",
+            512: "B",
+            520: "select+B",
+            768: "A+B",
+            1024: "X",
+            1032: "select+X",
+            1280: "A+X",
+            1536: "B+X",
+            2048: "Y",
+            2304: "A+Y",
+            2560: "B+Y",
+            2056: "select+Y",
+            3072: "X+Y",
+            4096: "up",
+            4097: "R1+up",
+            4352: "A+up",
+            4608: "B+up",
+            4104: "select+up",
+            5120: "X+up",
+            6144: "Y+up",
+            8192: "right",
+            8193: "R1+right",
+            8448: "A+right",
+            9216: "X+right",
+            10240: "Y+right",
+            8200: "select+right",
+            16384: "down",
+            16392: "select+down",
+            16385: "R1+down",
+            16640: "A+down",
+            16896: "B+down",
+            17408: "X+down",
+            18432: "Y+down",
+            32768: "left",
+            32769: "R1+left",
+            32776: "select+left",
+            33024: "A+left",
+            33792: "X+left",
+            34816: "Y+left",
+        }
+
+    @property
+    @abstractmethod
+    def kp_level(self):
+        raise NotImplementedError
+
+    @kp_level.setter
+    @abstractmethod
+    def kp_level(self, value):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def kd_level(self):
+        raise NotImplementedError
+
+    @kd_level.setter
+    @abstractmethod
+    def kd_level(self, value):
+        raise NotImplementedError

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/booster_interface.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/booster_interface.py
@@ -1,0 +1,102 @@
+"""Booster robot interface using sdk2py."""
+
+import numpy as np
+from termcolor import colored
+
+from holosoma_inference.config.config_types import RobotConfig
+from holosoma_inference.sdk.base.base_interface import BaseInterface
+
+
+class BoosterInterface(BaseInterface):
+    """Interface for Booster robots using sdk2py."""
+
+    def __init__(self, robot_config: RobotConfig, domain_id=0, interface_str=None, use_joystick=True):
+        super().__init__(robot_config, domain_id, interface_str, use_joystick)
+        self._init_sdk2py()
+        if use_joystick:
+            self._init_joystick()
+
+    def _init_sdk2py(self):
+        """Initialize sdk2py components."""
+        from holosoma_inference.sdk.booster.command_sender import create_command_sender
+        from holosoma_inference.sdk.booster.state_processor import create_state_processor
+
+        self.command_sender = create_command_sender(self.robot_config)
+        self.state_processor = create_state_processor(self.robot_config)
+
+    def _init_joystick(self):
+        """Initialize booster joystick/remote control."""
+        from holosoma_inference.sdk.booster.command_sender.booster.joystick_message import BoosterJoystickMessage
+        from holosoma_inference.sdk.booster.command_sender.booster.remote_control_service import (
+            BoosterRemoteControlService,
+        )
+
+        try:
+            self.booster_remote_control = BoosterRemoteControlService()
+            self.booster_joystick_msg = BoosterJoystickMessage(self.booster_remote_control)
+            print(colored("Booster Remote Control Service Initialized", "green"))
+        except ImportError as e:
+            print(colored(f"Warning: Failed to initialize booster remote control: {e}", "yellow"))
+            self.booster_remote_control = None
+            self.booster_joystick_msg = None
+
+    def update_config(self, robot_config: RobotConfig):
+        """Update config and propagate to sdk2py components."""
+        super().update_config(robot_config)
+        self.command_sender.config = robot_config
+        self.state_processor.config = robot_config
+
+    def get_low_state(self) -> np.ndarray:
+        """Get robot state as numpy array."""
+        return self.state_processor.get_robot_state_data()
+
+    def send_low_command(
+        self,
+        cmd_q: np.ndarray,
+        cmd_dq: np.ndarray,
+        cmd_tau: np.ndarray,
+        dof_pos_latest: np.ndarray = None,
+        kp_override: np.ndarray = None,
+        kd_override: np.ndarray = None,
+    ):
+        """Send low-level command to robot."""
+        self.command_sender.send_command(
+            cmd_q,
+            cmd_dq,
+            cmd_tau,
+            dof_pos_latest,
+            kp_override=kp_override,
+            kd_override=kd_override,
+        )
+
+    def get_joystick_msg(self):
+        """Get wireless controller message."""
+        return self.booster_joystick_msg if hasattr(self, "booster_joystick_msg") else None
+
+    def get_joystick_key(self, wc_msg=None):
+        """Get current key from joystick message."""
+        if wc_msg is None:
+            wc_msg = self.get_joystick_msg()
+        if wc_msg is None:
+            return None
+        return self._wc_key_map.get(getattr(wc_msg, "keys", 0), None)
+
+    @property
+    def kp_level(self):
+        """Get proportional gain level."""
+        return self.command_sender.kp_level
+
+    @kp_level.setter
+    def kp_level(self, value):
+        """Set proportional gain level."""
+        self.command_sender.kp_level = value
+
+    @property
+    def kd_level(self):
+        """Get derivative gain level."""
+        return getattr(self.command_sender, "kd_level", 1.0)
+
+    @kd_level.setter
+    def kd_level(self, value):
+        """Set derivative gain level."""
+        self.command_sender.kd_level = value

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/__init__.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/__init__.py
@@ -1,0 +1,34 @@
+from holosoma_inference.config.config_types.robot import RobotConfig
+
+from .base import BasicCommandSender
+
+
+def create_command_sender(config: RobotConfig, lcm=None):
+    """
+    Factory function to create the appropriate command sender based on configuration.
+
+    Args:
+        config: Robot configuration dictionary
+        lcm: LCM instance (optional, for LCM-based senders)
+
+    Returns:
+        An instance of the appropriate command sender class
+    """
+    sdk_type = config.sdk_type
+
+    if sdk_type == "booster":
+        from .booster import BoosterCommandSender
+
+        return BoosterCommandSender(config, lcm)
+    raise ValueError(f"Unsupported SDK type: {sdk_type}. Only 'booster' is supported for command_sender.")
+
+
+# For backward compatibility
+CommandSender = create_command_sender
+
+__all__ = [
+    "BasicCommandSender",
+    "BoosterCommandSender",
+    "CommandSender",  # Backward compatibility
+    "create_command_sender",
+]

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/base/__init__.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/base/__init__.py
@@ -1,0 +1,9 @@
+"""
+Base Command Sender module.
+
+This module contains the base classes for command sending functionality.
+"""
+
+from .basic_command_sender import BasicCommandSender
+
+__all__ = ["BasicCommandSender"]

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/base/basic_command_sender.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/base/basic_command_sender.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from holosoma_inference.config.config_types.robot import RobotConfig
+
+
+def _get_config_value(config: RobotConfig | dict, key: str, default=None):
+    """
+    Util function to temporarily support getting valeus from both `RobotConfig` and old dict-based configs.
+
+    TODO: Force dataclasses-based access once `run_sim.py` is moved to `holosoma`.
+    """
+
+    # Try dataclass attribute access first
+    if hasattr(config, key):
+        return getattr(config, key)
+    # Fall back to hydra
+    if isinstance(config, dict):
+        return config.get(key, default)
+    raise RuntimeError(f"Unsupported type {type(config)}")
+
+
+class BasicCommandSender(ABC):
+    """Abstract base class for command sender implementations."""
+
+    def __init__(self, config: RobotConfig | dict, lcm=None):
+        self.lcm = lcm
+        self.config = config
+        self.sdk_type = _get_config_value(config, "sdk_type", "unitree")
+        self.motor_type = _get_config_value(config, "motor_type", "serial")
+
+        # Initialize control gains
+        self.kp_level = 1.0
+        self.kd_level = 1.0
+        self.waist_kp_level = 1.0
+
+        # Initialize weak motor joint index
+        self.weak_motor_joint_index = []
+        weak_motor_cfg = _get_config_value(self.config, "weak_motor_joint_index")
+        if weak_motor_cfg:
+            for value in self.robot.WeakMotorJointIndex.values():
+                self.weak_motor_joint_index.append(value)
+
+        self.no_action = 0
+
+        # Initialize SDK-specific components
+        self._init_sdk_components()
+
+    @abstractmethod
+    def _init_sdk_components(self):
+        """Initialize SDK-specific components. Must be implemented by subclasses."""
+
+    @abstractmethod
+    def send_command(self, cmd_q, cmd_dq, cmd_tau, dof_pos_latest=None, kp_override=None, kd_override=None):
+        """Send command to robot. Must be implemented by subclasses."""
+
+    def is_weak_motor(self, motor_index):
+        """Check if a motor is a weak motor."""
+        return motor_index in self.weak_motor_joint_index
+
+    def _set_motor_command(
+        self,
+        motor_cmd,
+        motor_id,
+        joint_id,
+        cmd_q,
+        cmd_dq,
+        cmd_tau,
+        motor_kp,
+        motor_kd,
+        kp_override=None,
+        kd_override=None,
+    ):
+        """Set motor command for a specific motor."""
+        default_q = _get_config_value(self.config, "default_motor_angles")
+
+        if joint_id == -1 or self.no_action:
+            motor_cmd.q = default_q[motor_id]
+            motor_cmd.dq = 0.0
+            motor_cmd.tau = 0.0
+            motor_cmd.kp = 0.0
+            motor_cmd.kd = 0.0
+        else:
+            motor_cmd.q = cmd_q[joint_id]
+            motor_cmd.dq = cmd_dq[joint_id]
+            motor_cmd.tau = cmd_tau[joint_id]
+
+            kp_value = motor_kp[motor_id]
+            kd_value = motor_kd[motor_id]
+            if kp_override is not None and joint_id != -1:
+                kp_value = kp_override[joint_id]
+            if kd_override is not None and joint_id != -1:
+                kd_value = kd_override[joint_id]
+
+            motor_cmd.kp = kp_value * self.kp_level
+            motor_cmd.kd = kd_value * self.kd_level
+
+    def _fill_motor_commands(self, motor_cmd, cmd_q, cmd_dq, cmd_tau, kp_override=None, kd_override=None):
+        """Fill motor commands for all motors."""
+        motor2joint = _get_config_value(self.config, "motor2joint")
+        num_motors = _get_config_value(self.config, "num_motors")
+        motor_kp = _get_config_value(self.config, "motor_kp")
+        motor_kd = _get_config_value(self.config, "motor_kd")
+
+        for i in range(num_motors):
+            m_id = i
+            j_id = motor2joint[i]
+            cmd = motor_cmd[m_id]
+            self._set_motor_command(
+                cmd,
+                m_id,
+                j_id,
+                cmd_q,
+                cmd_dq,
+                cmd_tau,
+                motor_kp,
+                motor_kd,
+                kp_override=kp_override,
+                kd_override=kd_override,
+            )

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/booster/__init__.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/booster/__init__.py
@@ -1,0 +1,7 @@
+"""
+Booster command sender implementation.
+"""
+
+from .booster_command_sender import BoosterCommandSender
+
+__all__ = ["BoosterCommandSender"]

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/booster/booster_command_sender.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/booster/booster_command_sender.py
@@ -1,0 +1,106 @@
+from booster_robotics_sdk import (
+    B1LocoClient,
+    B1LowCmdPublisher,
+    LowCmd,
+    LowCmdType,
+    MotorCmd,
+    RobotMode,
+)
+
+from holosoma_inference.config.config_types.robot import RobotConfig
+
+from ..base import BasicCommandSender  # noqa: TID252
+
+
+class BoosterCommandSender(BasicCommandSender):
+    """Booster command sender implementation."""
+
+    def _init_sdk_components(self):
+        """Initialize Booster SDK-specific components."""
+
+        robot_type = self.config.robot_type
+
+        if robot_type in ["t1_23dof", "t1_29dof"]:
+            self.LowCmd = LowCmd
+            self.LowCmdType = LowCmdType
+            self.MotorCmd = MotorCmd
+            self.lowcmd_publisher_ = B1LowCmdPublisher()
+            self.client = B1LocoClient()
+            self.lowcmd_publisher_.InitChannel()
+            self.client.Init()
+            self.init_booster_low_cmd()
+            self.create_prepare_cmd(self.low_cmd, self.config)
+            self._send_cmd(self.low_cmd)
+            self.client.ChangeMode(RobotMode.kCustom)
+            self.dof_names = self.config.dof_names
+            self.dof_names_parallel_mech = self.config.dof_names_parallel_mech
+            self.parallel_mech_indexes = [self.dof_names.index(name) for name in self.dof_names_parallel_mech]
+        else:
+            raise NotImplementedError(f"Robot type {robot_type} is not supported yet")
+
+    def init_booster_low_cmd(self):
+        """Initialize Booster low-level command."""
+        self.low_cmd = self.LowCmd()
+        if self.motor_type == "serial":
+            self.low_cmd.cmd_type = self.LowCmdType.SERIAL
+        elif self.motor_type == "parallel":
+            self.low_cmd.cmd_type = self.LowCmdType.PARALLEL
+        self.motor_cmds = [self.MotorCmd() for _ in range(self.config.num_motors)]
+        self.low_cmd.motor_cmd = self.motor_cmds
+
+    def send_command(self, cmd_q, cmd_dq, cmd_tau, dof_pos_latest=None, kp_override=None, kd_override=None):
+        """Send command to Booster robot."""
+        # In booster, we need to fill the motor_cmds first
+        self.low_cmd = self.LowCmd()
+        if self.motor_type == "serial":
+            self.low_cmd.cmd_type = self.LowCmdType.SERIAL
+        elif self.motor_type == "parallel":
+            self.low_cmd.cmd_type = self.LowCmdType.PARALLEL
+        else:
+            raise NotImplementedError(f"Motor type {self.motor_type} is not supported yet")
+        self.low_cmd.motor_cmd = self.motor_cmds
+
+        motor_cmd = self.low_cmd.motor_cmd
+        self._fill_motor_commands(
+            motor_cmd,
+            cmd_q,
+            cmd_dq,
+            cmd_tau,
+            kp_override=kp_override,
+            kd_override=kd_override,
+        )
+
+        # Send command
+        self.lowcmd_publisher_.Write(self.low_cmd)
+
+    def _send_cmd(self, cmd):
+        """Send command to robot."""
+        self.lowcmd_publisher_.Write(cmd)
+
+    def init_cmd_t1(self, low_cmd):
+        """Initialize T1 command."""
+        low_cmd.cmd_type = self.LowCmdType.SERIAL
+        motorCmds = [self.MotorCmd() for _ in range(self.config.num_motors)]
+        low_cmd.motor_cmd = motorCmds
+
+        num_motors = min(len(motorCmds), self.config.num_motors)
+        for i in range(num_motors):
+            low_cmd.motor_cmd[i].q = 0.0
+            low_cmd.motor_cmd[i].dq = 0.0
+            low_cmd.motor_cmd[i].tau = 0.0
+            low_cmd.motor_cmd[i].kp = 0.0
+            low_cmd.motor_cmd[i].kd = 0.0
+            # weight is not effective in custom mode
+            low_cmd.motor_cmd[i].weight = 0.0
+
+    def create_prepare_cmd(self, low_cmd, cfg: RobotConfig):
+        """Create prepare command for T1."""
+        self.init_cmd_t1(low_cmd)
+        # Use motor_kp, motor_kd, and default_motor_angles from RobotConfig
+        # Note: motor_kp and motor_kd may be None during initialization (loaded from ONNX later)
+        num_motors = min(len(low_cmd.motor_cmd), cfg.num_motors)
+        for i in range(num_motors):
+            low_cmd.motor_cmd[i].kp = cfg.motor_kp[i] if cfg.motor_kp is not None else 0.0
+            low_cmd.motor_cmd[i].kd = cfg.motor_kd[i] if cfg.motor_kd is not None else 0.0
+            low_cmd.motor_cmd[i].q = cfg.default_motor_angles[i]
+        return low_cmd

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/booster/joystick_message.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/booster/joystick_message.py
@@ -1,0 +1,25 @@
+class BoosterJoystickMessage:
+    """Simple message class to provide unified interface for booster joystick data."""
+
+    def __init__(self, remote_control_service):
+        self.remote_control_service = remote_control_service
+
+    @property
+    def lx(self):
+        """Left stick X axis (lateral movement)."""
+        return self.remote_control_service.lx
+
+    @property
+    def ly(self):
+        """Left stick Y axis (forward/backward movement)."""
+        return self.remote_control_service.ly
+
+    @property
+    def rx(self):
+        """Right stick X axis (yaw rotation)."""
+        return self.remote_control_service.rx
+
+    @property
+    def keys(self):
+        """Button states as integer bitmask."""
+        return self.remote_control_service.keys

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/booster/remote_control_service.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/command_sender/booster/remote_control_service.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+
+import evdev
+
+
+@dataclass
+class JoystickConfig:
+    max_vx: float = 0.8
+    max_vy: float = 0.5
+    max_vyaw: float = 0.5
+    control_threshold: float = 0.1
+    # logitech - left and right analog sticks
+    left_x_axis: evdev.ecodes = evdev.ecodes.ABS_X  # Left stick X (left/right)
+    left_y_axis: evdev.ecodes = evdev.ecodes.ABS_Y  # Left stick Y (forward/back)
+    right_x_axis: evdev.ecodes = evdev.ecodes.ABS_RX  # Right stick X (yaw rotation)
+    right_y_axis: evdev.ecodes = evdev.ecodes.ABS_RY  # Right stick Y (not used currently)
+
+    # beitong
+    # left_x_axis: evdev.ecodes = evdev.ecodes.ABS_X
+    # left_y_axis: evdev.ecodes = evdev.ecodes.ABS_Y
+    # right_x_axis: evdev.ecodes = evdev.ecodes.ABS_RX
+    # right_y_axis: evdev.ecodes = evdev.ecodes.ABS_RY
+
+
+class BoosterRemoteControlService:
+    """Service for handling joystick remote control input for Booster robots."""
+
+    def __init__(self, config: JoystickConfig | None = None):
+        """Initialize remote control service with optional configuration."""
+        self.config = config or JoystickConfig()
+        self._lock = threading.Lock()
+        self._running = True
+
+        self.vx = 0.0
+        self.vy = 0.0
+        self.vyaw = 0.0
+        self.lx = 0.0
+        self.ly = 0.0
+        self.rx = 0.0
+        self.keys = 0
+
+        try:
+            self._init_joystick()
+            self._start_joystick_thread()
+        except Exception as e:
+            print(f"Failed to initialize joystick: {e}")
+            self.joystick = None
+            self.joystick_runner = None
+
+    def _init_joystick(self) -> None:
+        """Initialize and validate joystick connection using evdev."""
+        devices = [evdev.InputDevice(path) for path in evdev.list_devices()]
+        joystick = None
+
+        for device in devices:
+            caps = device.capabilities()
+            # Check for both absolute axes and keys
+            if evdev.ecodes.EV_ABS in caps and evdev.ecodes.EV_KEY in caps:
+                abs_info = caps.get(evdev.ecodes.EV_ABS, [])
+                # Look for typical gamepad axes
+                axes = [code for (code, info) in abs_info]
+                if all(
+                    code in axes
+                    for code in [self.config.left_x_axis, self.config.left_y_axis, self.config.right_x_axis]
+                ):
+                    absinfo = {code: info for code, info in abs_info}
+                    self.axis_ranges = {
+                        self.config.left_x_axis: absinfo[self.config.left_x_axis],
+                        self.config.left_y_axis: absinfo[self.config.left_y_axis],
+                        self.config.right_x_axis: absinfo[self.config.right_x_axis],
+                        self.config.right_y_axis: absinfo[self.config.right_y_axis],
+                    }
+                    print(f"Found suitable joystick: {device.name}")
+                    joystick = device
+                    break
+
+        if not joystick:
+            raise RuntimeError("No suitable joystick found")
+
+        self.joystick = joystick
+        print(f"Selected joystick: {joystick.name}")
+
+    def _start_joystick_thread(self):
+        """Start joystick polling thread."""
+        self.joystick_runner = threading.Thread(target=self._run_joystick)
+        self.joystick_runner.daemon = True
+        self.joystick_runner.start()
+
+    def _run_joystick(self):
+        """Poll joystick events."""
+        while self._running:
+            if not self._process_events():
+                break
+
+    def _process_events(self):
+        """Process joystick events."""
+        try:
+            for event in self.joystick.read_loop():
+                if event.type == evdev.ecodes.EV_ABS:
+                    # Handle axis events
+                    self._handle_axis(event.code, event.value)
+                elif event.type == evdev.ecodes.EV_KEY:
+                    # Handle button events
+                    self._handle_button(event.code, event.value)
+            return True
+        except BlockingIOError:
+            # No events available
+            time.sleep(0.01)
+            return True
+        except Exception:
+            return False
+
+    def _handle_axis(self, code: int, value: int):
+        """Handle axis events."""
+        try:
+            # Left stick - movement
+            if code == self.config.left_y_axis:  # Left stick Y (forward/back)
+                self.vx = self._scale(value, self.config.max_vx, self.config.control_threshold, code)
+                self.ly = self.vx  # Map for compatibility with unitree interface
+            elif code == self.config.left_x_axis:  # Left stick X (left/right)
+                self.vy = self._scale(value, self.config.max_vy, self.config.control_threshold, code)
+                self.lx = -self.vy  # Map for compatibility with unitree interface (inverted)
+            # Right stick - rotation
+            elif code == self.config.right_x_axis:  # Right stick X (yaw rotation)
+                self.vyaw = self._scale(value, self.config.max_vyaw, self.config.control_threshold, code)
+                self.rx = -self.vyaw  # Map for compatibility with unitree interface (inverted)
+            elif code == self.config.right_y_axis:  # Right stick Y (not used currently)
+                pass  # Could be used for pitch control in the future
+            # D-pad handling via HAT axes (most common for controllers)
+            elif code == evdev.ecodes.ABS_HAT0X:  # D-pad horizontal
+                self._handle_dpad_axis("horizontal", value)
+            elif code == evdev.ecodes.ABS_HAT0Y:  # D-pad vertical
+                self._handle_dpad_axis("vertical", value)
+            # Analog triggers
+            elif code == evdev.ecodes.ABS_RZ:  # Right trigger (R2)
+                self._handle_analog_trigger("R2", value)
+            elif code == evdev.ecodes.ABS_Z:  # Left trigger (L2) - some controllers
+                self._handle_analog_trigger("L2", value)
+            else:
+                pass
+        except Exception:
+            raise
+
+    def _handle_button(self, code: int, value: int):
+        """Handle button events."""
+        # Track individual button states
+        if not hasattr(self, "_button_states"):
+            self._button_states = {}
+
+        if value == 1:  # Button pressed
+            self._button_states[code] = True
+        elif value == 0:  # Button released
+            self._button_states[code] = False
+
+        # Calculate combined keys value based on button combinations
+        self.keys = self._calculate_keys_value()
+
+    def _handle_dpad_axis(self, direction: str, value: int):
+        """Handle D-pad input via HAT axes."""
+        # Track D-pad states
+        if not hasattr(self, "_dpad_states"):
+            self._dpad_states = {}
+
+        if direction == "horizontal":
+            # HAT0X: -1 = left, 0 = center, 1 = right
+            self._dpad_states["left"] = value == -1
+            self._dpad_states["right"] = value == 1
+            if value == 0:  # Released
+                self._dpad_states["left"] = False
+                self._dpad_states["right"] = False
+        elif direction == "vertical":
+            # HAT0Y: -1 = up, 0 = center, 1 = down
+            self._dpad_states["up"] = value == -1
+            self._dpad_states["down"] = value == 1
+            if value == 0:  # Released
+                self._dpad_states["up"] = False
+                self._dpad_states["down"] = False
+
+        # Update keys value
+        self.keys = self._calculate_keys_value()
+
+    def _handle_analog_trigger(self, trigger_name: str, value: int):
+        """Handle analog trigger as button press."""
+        # Track trigger states
+        if not hasattr(self, "_trigger_states"):
+            self._trigger_states = {}
+
+        # Treat trigger as pressed if value is above threshold (usually > 128 for 8-bit triggers)
+        threshold = 128
+        is_pressed = value > threshold
+
+        self._trigger_states[trigger_name] = is_pressed
+
+        # Update keys value
+        self.keys = self._calculate_keys_value()
+
+    def _calculate_keys_value(self):
+        """Calculate keys value based on current button states to match unitree mapping."""
+        keys_value = 0
+
+        # Check button states
+        if hasattr(self, "_button_states"):
+            button_states = self._button_states
+
+            # Map common buttons to unitree equivalents
+            # BTN_A -> A (256), BTN_B -> B (512), BTN_X -> X (1024), BTN_Y -> Y (2048)
+            # BTN_START -> start (4), BTN_SELECT -> select (8)
+            # BTN_TR -> R1 (1), BTN_TL -> L1 (2), BTN_TR2 -> R2 (16), BTN_TL2 -> L2 (32)
+
+            if button_states.get(evdev.ecodes.BTN_A, False):
+                keys_value |= 256  # A
+                print("A pressed")
+            if button_states.get(evdev.ecodes.BTN_B, False):
+                keys_value |= 512  # B
+                print("B pressed")
+            if button_states.get(evdev.ecodes.BTN_X, False):
+                keys_value |= 1024  # X
+                print("X pressed")
+            if button_states.get(evdev.ecodes.BTN_Y, False):
+                keys_value |= 2048  # Y
+                print("Y pressed")
+            if button_states.get(evdev.ecodes.BTN_START, False):
+                keys_value |= 4  # start
+                print("Start pressed")
+            if button_states.get(evdev.ecodes.BTN_SELECT, False):
+                keys_value |= 8  # select
+                print("Select pressed")
+            if button_states.get(evdev.ecodes.BTN_TR, False):
+                keys_value |= 1  # R1
+                print("R1 pressed")
+            if button_states.get(evdev.ecodes.BTN_TL, False):
+                keys_value |= 2  # L1
+                print("L1 pressed")
+            if button_states.get(evdev.ecodes.BTN_TR2, False):
+                keys_value |= 16  # R2
+                print("R2 pressed")
+            if button_states.get(evdev.ecodes.BTN_TL2, False):
+                keys_value |= 32  # L2
+                print("L2 pressed")
+
+            # Add D-pad support
+            if button_states.get(evdev.ecodes.BTN_DPAD_UP, False):
+                keys_value |= 4096  # up
+                print("Up pressed")
+            if button_states.get(evdev.ecodes.BTN_DPAD_DOWN, False):
+                keys_value |= 16384  # down
+                print("Down pressed")
+            if button_states.get(evdev.ecodes.BTN_DPAD_LEFT, False):
+                keys_value |= 32768  # left
+                print("Left pressed")
+            if button_states.get(evdev.ecodes.BTN_DPAD_RIGHT, False):
+                keys_value |= 8192  # right
+                print("Right pressed")
+
+        # Check D-pad states from HAT axes
+        if hasattr(self, "_dpad_states"):
+            dpad_states = self._dpad_states
+            if dpad_states.get("up", False):
+                keys_value |= 4096  # up
+                print("D-pad Up pressed")
+            if dpad_states.get("down", False):
+                keys_value |= 16384  # down
+                print("D-pad Down pressed")
+            if dpad_states.get("left", False):
+                keys_value |= 32768  # left
+                print("D-pad Left pressed")
+            if dpad_states.get("right", False):
+                keys_value |= 8192  # right
+                print("D-pad Right pressed")
+
+        # Check analog trigger states
+        if hasattr(self, "_trigger_states"):
+            trigger_states = self._trigger_states
+            if trigger_states.get("R2", False):
+                keys_value |= 16  # R2
+                print("R2 pressed")
+            if trigger_states.get("L2", False):
+                keys_value |= 32  # L2
+                print("L2 pressed")
+
+        return keys_value
+
+    def _scale(self, value: float, max_val: float, threshold: float, axis_code: int) -> float:
+        """Scale joystick input to velocity command using actual axis ranges."""
+        absinfo = self.axis_ranges[axis_code]
+        min_in = absinfo.min
+        max_in = absinfo.max
+
+        mapped_value = ((value - min_in) / (max_in - min_in) * 2 - 1) * max_val
+
+        if abs(mapped_value) < threshold:
+            return 0.0
+        return -mapped_value
+
+    def close(self):
+        """Clean up resources."""
+        self._running = False
+        if hasattr(self, "joystick") and self.joystick is not None:
+            self.joystick.close()
+        if hasattr(self, "joystick_runner") and self.joystick_runner is not None:
+            self.joystick_runner.join(timeout=1.0)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/__init__.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/__init__.py
@@ -1,0 +1,36 @@
+from holosoma_inference.config.config_types.robot import RobotConfig
+
+from .base import BasicStateProcessor
+
+
+def create_state_processor(config: RobotConfig, lcm=None):
+    """
+    Factory function to create the appropriate state processor based on configuration.
+
+    Args:
+        config: Robot configuration dictionary
+        lcm: LCM instance (optional, for LCM-based processors)
+
+    Returns:
+        An instance of the appropriate state processor class
+    """
+    sdk_type = config.sdk_type
+
+    if sdk_type == "booster":
+        from .booster import BoosterStateProcessor
+
+        return BoosterStateProcessor(config, lcm)
+    if sdk_type in ["lcm_unitree", "lcm_booster"]:
+        raise ValueError(f"LCM SDK types are no longer supported. Please use 'booster' instead of '{sdk_type}'")
+    raise ValueError(f"Unsupported SDK type: {sdk_type}. Only 'booster' is supported for state_processor.")
+
+
+# For backward compatibility
+StateProcessor = create_state_processor
+
+__all__ = [
+    "BasicStateProcessor",
+    "BoosterStateProcessor",
+    "StateProcessor",  # Backward compatibility
+    "create_state_processor",
+]

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/base/__init__.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/base/__init__.py
@@ -1,0 +1,9 @@
+"""
+Base State Processor module.
+
+This module contains the base classes for state processing functionality.
+"""
+
+from .basic_state_processor import BasicStateProcessor
+
+__all__ = ["BasicStateProcessor"]

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/base/basic_state_processor.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/base/basic_state_processor.py
@@ -1,0 +1,57 @@
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from holosoma_inference.config.config_types.robot import RobotConfig
+
+
+class BasicStateProcessor(ABC):
+    """Abstract base class for state processor implementations."""
+
+    def __init__(self, config: RobotConfig, lcm=None):
+        self.lcm = lcm
+        self.config = config
+        self.num_motor = self.config.num_motors
+        self.sdk_type = self.config.sdk_type
+        self.motor_type = self.config.motor_type
+
+        # Initialize state arrays
+        self.num_dof = self.config.num_joints
+        # 3 + 4 + num_dof (base_pos + base_quat + joint_pos)
+        self._init_q = np.zeros(3 + 4 + self.num_dof)
+        self.q = self._init_q
+        self.dq = np.zeros(3 + 3 + self.num_dof)  # base_lin_vel + base_ang_vel + joint_vel
+        self.ddq = np.zeros(3 + 3 + self.num_dof)  # base_lin_acc + base_ang_acc + joint_acc
+        self.tau_est = np.zeros(3 + 3 + self.num_dof)  # base_lin_force + base_ang_torque + joint_torque
+        self.temp_first = np.zeros(self.num_dof)
+        self.temp_second = np.zeros(self.num_dof)
+        self.robot_state_data = None
+
+        # Initialize SDK-specific components
+        self._init_sdk_components()
+
+    @abstractmethod
+    def _init_sdk_components(self):
+        """Initialize SDK-specific components. Must be implemented by subclasses."""
+
+    @abstractmethod
+    def prepare_low_state(self, msg):
+        """Prepare low-level state data from message. Must be implemented by subclasses."""
+
+    def get_robot_state_data(self):
+        """Get the current robot state data."""
+        return self.robot_state_data
+
+    @abstractmethod
+    def _extract_imu_data(self, imu_state):
+        """Extract IMU data from state message. Must be implemented by subclasses."""
+
+    @abstractmethod
+    def _extract_joint_data(self, robot_joint_state):
+        """Extract joint data from state message. Must be implemented by subclasses."""
+
+    def _create_robot_state_data(self):
+        """Create the final robot state data array."""
+        return np.array(
+            self.q.tolist() + self.dq.tolist() + self.tau_est.tolist() + self.ddq.tolist(), dtype=np.float64
+        ).reshape(1, -1)

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/booster/__init__.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/booster/__init__.py
@@ -1,0 +1,7 @@
+"""
+Booster state processor implementation.
+"""
+
+from .booster_state_processor import BoosterStateProcessor
+
+__all__ = ["BoosterStateProcessor"]

--- a/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/booster/booster_state_processor.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/booster/state_processor/booster/booster_state_processor.py
@@ -1,0 +1,64 @@
+from booster_robotics_sdk import B1LowStateSubscriber
+
+from holosoma_inference.utils.math.quat import rpy_to_quat
+
+from ..base import BasicStateProcessor  # noqa: TID252
+
+
+class BoosterStateProcessor(BasicStateProcessor):
+    """Booster state processor implementation."""
+
+    def _init_sdk_components(self):
+        """Initialize Booster SDK-specific components."""
+
+        robot_type = self.config.robot_type
+
+        if robot_type in {"t1_23dof", "t1_29dof"}:
+            self.robot_lowstate_subscriber = B1LowStateSubscriber(self.low_state_handler_b1)
+            self.robot_lowstate_subscriber.InitChannel()
+        else:
+            raise NotImplementedError(f"Robot type {robot_type} is not supported")
+
+    def prepare_low_state(self, msg):
+        """Prepare Booster low-level state data from message."""
+        if not msg:
+            print("robot_low_state is None")
+            return None
+
+        imu_state = msg.imu_state
+        self._extract_imu_data(imu_state)
+
+        # Choose the appropriate motor state based on motor type
+        if self.motor_type == "serial":
+            robot_joint_state = msg.motor_state_serial
+        elif self.motor_type == "parallel":
+            robot_joint_state = msg.motor_state_parallel
+        else:
+            raise ValueError(f"Invalid motor type '{self.motor_type}'. Expected 'serial' or 'parallel'.")
+
+        self._extract_joint_data(robot_joint_state)
+
+        self.robot_state_data = self._create_robot_state_data()
+        return self.robot_state_data
+
+    def _extract_imu_data(self, imu_state):
+        """Extract IMU data from Booster state message."""
+
+        # base quaternion
+        self.q[0:3] = 0.0  # base position (assumed to be at origin)
+        rpy = imu_state.rpy
+        self.q[3:7] = rpy_to_quat(rpy)
+        self.dq[3:6] = imu_state.gyro
+        self.ddq[0:3] = imu_state.acc
+
+    def _extract_joint_data(self, robot_joint_state):
+        """Extract joint data from Booster state message."""
+        for i in range(self.num_dof):
+            motor_idx = self.config.joint2motor[i]
+            self.q[7 + i] = robot_joint_state[motor_idx].q
+            self.dq[6 + i] = robot_joint_state[motor_idx].dq
+            self.tau_est[6 + i] = robot_joint_state[motor_idx].tau_est
+
+    def low_state_handler_b1(self, msg):
+        """Handle Booster B1 low-level state messages."""
+        self.robot_state_data = self.prepare_low_state(msg)

--- a/src/holosoma_inference/holosoma_inference/sdk/unitree/unitree_interface.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/unitree/unitree_interface.py
@@ -1,0 +1,135 @@
+"""Unitree robot interface using C++/pybind11 binding."""
+
+import numpy as np
+
+from holosoma_inference.config.config_types import RobotConfig
+from holosoma_inference.sdk.base.base_interface import BaseInterface
+
+
+class UnitreeInterface(BaseInterface):
+    """Interface for Unitree robots using C++/pybind11 binding."""
+
+    def __init__(self, robot_config: RobotConfig, domain_id=0, interface_str=None, use_joystick=True):
+        super().__init__(robot_config, domain_id, interface_str, use_joystick)
+        self._unitree_motor_order = None
+        self._kp_level = 1.0
+        self._kd_level = 1.0
+        self._init_binding()
+
+    def _init_binding(self):
+        """Initialize C++/pybind11 binding."""
+        try:
+            import unitree_interface
+        except ImportError as e:
+            raise ImportError("unitree_interface python binding not found.") from e
+
+        robot_type_map = {
+            "G1": unitree_interface.RobotType.G1,
+            "H1": unitree_interface.RobotType.H1,
+            "H1_2": unitree_interface.RobotType.H1_2,
+            "GO2": unitree_interface.RobotType.GO2,
+        }
+        message_type_map = {"HG": unitree_interface.MessageType.HG, "GO2": unitree_interface.MessageType.GO2}
+
+        self.unitree_interface = unitree_interface.create_robot(
+            self.interface_str,
+            robot_type_map[self.robot_config.robot.upper()],
+            message_type_map[self.robot_config.message_type.upper()],
+        )
+        self.unitree_interface.set_control_mode(unitree_interface.ControlMode.PR)
+
+        # GO2 SDK motor order differs from joint order
+        if self.robot_config.robot.lower() == "go2":
+            self._unitree_motor_order = (3, 4, 5, 0, 1, 2, 9, 10, 11, 6, 7, 8)
+
+    def get_low_state(self) -> np.ndarray:
+        """Get robot state as numpy array."""
+        state = self.unitree_interface.read_low_state()
+        base_pos = np.zeros(3)
+        quat = np.array(state.imu.quat)
+        motor_pos = np.array(state.motor.q)
+        base_lin_vel = np.zeros(3)
+        base_ang_vel = np.array(state.imu.omega)
+        motor_vel = np.array(state.motor.dq)
+
+        joint_pos = np.zeros(self.robot_config.num_joints)
+        joint_vel = np.zeros(self.robot_config.num_joints)
+        motor_order = self._unitree_motor_order or self.robot_config.joint2motor
+
+        for j_id in range(self.robot_config.num_joints):
+            m_id = motor_order[j_id]
+            joint_pos[j_id] = float(motor_pos[m_id])
+            joint_vel[j_id] = float(motor_vel[m_id])
+
+        return np.concatenate([base_pos, quat, joint_pos, base_lin_vel, base_ang_vel, joint_vel]).reshape(1, -1)
+
+    def send_low_command(
+        self,
+        cmd_q: np.ndarray,
+        cmd_dq: np.ndarray,
+        cmd_tau: np.ndarray,
+        dof_pos_latest: np.ndarray = None,
+        kp_override: np.ndarray = None,
+        kd_override: np.ndarray = None,
+    ):
+        """Send low-level command to robot."""
+        cmd_q_target = np.zeros(self.robot_config.num_motors)
+        cmd_dq_target = np.zeros(self.robot_config.num_motors)
+        cmd_tau_target = np.zeros(self.robot_config.num_motors)
+        cmd_kp = np.zeros(self.robot_config.num_motors) if kp_override is not None else None
+        cmd_kd = np.zeros(self.robot_config.num_motors) if kd_override is not None else None
+
+        motor_order = self._unitree_motor_order or self.robot_config.joint2motor
+        for j_id in range(self.robot_config.num_joints):
+            m_id = motor_order[j_id]
+            cmd_q_target[m_id] = float(cmd_q[j_id])
+            cmd_dq_target[m_id] = float(cmd_dq[j_id])
+            cmd_tau_target[m_id] = float(cmd_tau[j_id])
+            if cmd_kp is not None:
+                cmd_kp[m_id] = float(kp_override[j_id])
+            if cmd_kd is not None:
+                cmd_kd[m_id] = float(kd_override[j_id])
+
+        cmd = self.unitree_interface.create_zero_command()
+        cmd.q_target = list(cmd_q_target)
+        cmd.dq_target = list(cmd_dq_target)
+        cmd.tau_ff = list(cmd_tau_target)
+
+        motor_kp = np.array(cmd_kp if cmd_kp is not None else self.robot_config.motor_kp)
+        motor_kd = np.array(cmd_kd if cmd_kd is not None else self.robot_config.motor_kd)
+        cmd.kp = list(motor_kp * self._kp_level)
+        cmd.kd = list(motor_kd * self._kd_level)
+
+        self.unitree_interface.write_low_command(cmd)
+
+    def get_joystick_msg(self):
+        """Get wireless controller message."""
+        return self.unitree_interface.read_wireless_controller()
+
+    def get_joystick_key(self, wc_msg=None):
+        """Get current key from joystick message."""
+        if wc_msg is None:
+            wc_msg = self.get_joystick_msg()
+        if wc_msg is None:
+            return None
+        return self._wc_key_map.get(getattr(wc_msg, "keys", 0), None)
+
+    @property
+    def kp_level(self):
+        """Get proportional gain level."""
+        return self._kp_level
+
+    @kp_level.setter
+    def kp_level(self, value):
+        """Set proportional gain level."""
+        self._kp_level = value
+
+    @property
+    def kd_level(self):
+        """Get derivative gain level."""
+        return self._kd_level
+
+    @kd_level.setter
+    def kd_level(self, value):
+        """Set derivative gain level."""
+        self._kd_level = value

--- a/src/holosoma_inference/setup.py
+++ b/src/holosoma_inference/setup.py
@@ -1,38 +1,23 @@
 import platform
-import sys
 
 from setuptools import find_packages, setup
 
-UNITREE_VERSION = "0.1.2"
+UNITREE_VERSION = "0.1.1"
 UNITREE_REPO = "https://github.com/amazon-far/unitree_sdk2"
 BOOSTER_VERSION = "0.1.0"
 BOOSTER_REPO = "https://github.com/amazon-far/booster_robotics_sdk"
 
+PLATFORM_MAP = {
+    "x86_64": "linux_x86_64",
+    "aarch64": "linux_aarch64",
+}
 
-def get_platform_tag():
-    """Get the correct platform tag for wheel installation."""
-    machine = platform.machine()
-    system = platform.system()
+platform_tag = PLATFORM_MAP.get(platform.machine(), "linux_x86_64")
 
-    if system == "Linux":
-        if machine == "x86_64":
-            return "linux_x86_64"
-        if machine in ("aarch64", "arm64"):
-            return "linux_aarch64"
-    elif system == "Darwin":
-        # Get macOS version for proper wheel tag
-        mac_ver = platform.mac_ver()[0]  # Returns version like "14.1.0"
-        major_version = mac_ver.split(".")[0] if mac_ver else "11"
-        assert major_version == "26"
-        return f"macosx_{major_version}_0_{machine}"
-    # Fallback
-    return "linux_x86_64"
-
-
-platform_tag = get_platform_tag()
-pyvers = f"cp{sys.version_info.major}{sys.version_info.minor}"
 unitree_extras = []
-unitree_url = f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/unitree_sdk2-{UNITREE_VERSION}-{pyvers}-{pyvers}-{platform_tag}.whl"  # noqa: E501
+unitree_url = (
+    f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/unitree_sdk2-{UNITREE_VERSION}-cp310-cp310-{platform_tag}.whl"
+)
 unitree_extras.append(f"unitree_sdk2 @ {unitree_url}")
 
 booster_extras = []
@@ -72,6 +57,12 @@ setup(
         ],
         "unitree": unitree_extras,
         "booster": booster_extras,
+    },
+    entry_points={
+        "holosoma.sdk": [
+            "unitree = holosoma_inference.sdk.unitree.unitree_interface:UnitreeInterface",
+            "booster = holosoma_inference.sdk.booster.booster_interface:BoosterInterface",
+        ],
     },
     keywords="humanoid robotics inference policy onnx",
     include_package_data=True,


### PR DESCRIPTION
Make our codebase more extensible to new robot types, as well as get rid of this anti-pattern:

```
if sdk_type == "unitree":
    # some logic
if sdk_type == "booster":
    # some other logic
```

This commit restructures the robot SDK layer API by introducing a unified interface with robot-specific implementations.

Specifically:
1. Created a `BaseInterface` abstract class to standardize robot control APIs
2. Implemented interfaces `BoosterInterface`, `UnitreeInterface` for specific robot implementations.
3. Removed support for the legacy python unitree API: Removed unitree_command_sender.py and unitree_state_processor.py.
