### PR TITLE
fix FastSAC evaluate_policy missing set_is_evaluating call

### DIFF
--- a/src/holosoma/holosoma/agents/fast_sac/fast_sac_agent.py
+++ b/src/holosoma/holosoma/agents/fast_sac/fast_sac_agent.py
@@ -1000,6 +1000,7 @@ class FastSACAgent(BaseAlgo):
 
     @torch.no_grad()
     def evaluate_policy(self, max_eval_steps: int | None = None):
+        self.env.set_is_evaluating()
         obs = self.env.reset()
 
         for _ in itertools.islice(itertools.count(), max_eval_steps):


### PR DESCRIPTION
**Description of changes:**

FastSAC's `evaluate_policy()` was missing a `set_is_evaluating()` call, unlike PPO which  has it in `_pre_evaluate_policy()`. Without this the environment during evaluation:
  - Keeps resampling random velocity commands (command manager doesn't zero them)
  - Keeps applying push perturbations (randomization doesn't skip them)

This makes the robot appear to receive random actions and get pushed around during eval, rather than standing still awaiting keyboard/joystick input.

--
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
