### PR TITLE
Fix setup_mujoco.sh script

### DIFF
--- a/scripts/setup_mujoco.sh
+++ b/scripts/setup_mujoco.sh
@@ -61,13 +61,13 @@ WARP_SENTINEL_FILE=${WORKSPACE_DIR}/.env_setup_finished_$CONDA_ENV_NAME_warp
 mkdir -p $WORKSPACE_DIR
 
 if [[ ! -f $SENTINEL_FILE ]]; then
+  # Detect OS and architecture
+  OS_NAME="$(uname -s)"
+  ARCH_NAME="$(uname -m)"
+
   # Install miniconda (reuse existing logic)
   if [[ ! -d $CONDA_ROOT ]]; then
     mkdir -p $CONDA_ROOT
-
-    # Detect OS and architecture
-    OS_NAME="$(uname -s)"
-    ARCH_NAME="$(uname -m)"
 
     # Decide installer name based on OS/arch
     if [[ "$OS_NAME" == "Linux" ]]; then
@@ -132,10 +132,10 @@ if [[ ! -f $SENTINEL_FILE ]]; then
   echo "Installing Holosoma packages"
   pip install -U pip
   if [[ "$OS_NAME" == "Linux" ]]; then
-    pip install -e $ROOT_DIR/src/holosoma[unitree, booster]
+    pip install -e "$ROOT_DIR/src/holosoma[unitree, booster]"
   elif [[ "$OS_NAME" == "Darwin" ]]; then
     echo "Warning: only unitree support for osx"
-    pip install -e $ROOT_DIR/src/holosoma[unitree]
+    pip install -e "$ROOT_DIR/src/holosoma[unitree]"
   else
     echo "Unsupported OS: $OS_NAME"
     exit 1


### PR DESCRIPTION
Minor fixes to the `setup_mujoco.sh` script:

1. The requirement was not quoted, and bash was interpreting `]` as glob pattern:
```bash
Requirement already satisfied: pip in /home/ANT.AMAZON.COM/jtomasle/.holosoma_deps/miniconda3/envs/hsmujoco/lib/python3.10/site-packages (26.0.1)
ERROR: Invalid requirement: 'booster]': Expected semicolon (after name with no version specifier) or end
    booster]
           ^
```
2. `OS_NAME` was only defined while bootstrapping the conda, so it failed when conda was already setup: 
```bash
Installing Holosoma packages
Requirement already satisfied: pip in /home/ANT.AMAZON.COM/jtomasle/.holosoma_deps/miniconda3/envs/hsmujoco/lib/python3.10/site-packages (26.0.1)
Unsupported OS:
```
