### PR TITLE
Make nightly continue on error

### DIFF
--- a/.github/workflows/nightly-training.yaml
+++ b/.github/workflows/nightly-training.yaml
@@ -16,7 +16,9 @@ permissions:
 jobs:
   training:
     runs-on: codebuild-holosoma-gpu-build-${{ github.run_id }}-${{ github.run_attempt }}
+    continue-on-error: true
     strategy:
+      fail-fast: false # continue on one experiment failing
       matrix:
         experiment:
         - g1-29dof


### PR DESCRIPTION
*Description of changes:*

Changing nightly workflow to run all tests even if one fails early (like [last night](https://github.com/amazon-far/holosoma/actions/runs/22173712091))

Tested that job still starts with [quick run](https://github.com/amazon-far/holosoma/actions/runs/22204150821)
