### PR TITLE
Fix: holosama retargeting path in demo script

### DIFF
--- a/demo_scripts/demo_lafan_wb_tracking.sh
+++ b/demo_scripts/demo_lafan_wb_tracking.sh
@@ -35,7 +35,7 @@ echo "Sourcing retargeting setup..."
 source "$PROJECT_ROOT/scripts/source_retargeting_setup.sh"
 
 # Change to retargeting directory
-cd "$PROJECT_ROOT/src/holosoma_retargeting/"
+cd "$PROJECT_ROOT/src/holosoma_retargeting/holosoma_retargeting/"
 
 # Step 0: Download and process LAFAN data if needed
 echo "Checking LAFAN data availability..."

--- a/demo_scripts/demo_omomo_wb_tracking.sh
+++ b/demo_scripts/demo_omomo_wb_tracking.sh
@@ -35,7 +35,7 @@ echo "Sourcing retargeting setup..."
 source "$PROJECT_ROOT/scripts/source_retargeting_setup.sh"
 
 # Change to retargeting directory
-cd "$PROJECT_ROOT/src/holosoma_retargeting/"
+cd "$PROJECT_ROOT/src/holosoma_retargeting/holosoma_retargeting/"
 
 # Step 1: Run retargeting
 echo "Running retargeting..."


### PR DESCRIPTION
This PR fixes the first error in #60.

*Description of changes:*

The path of the `cd` command is updated to switch to the correct location to check and download motion data.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
