### PR TITLE
Fix: avoid cloning LFS files

### DIFF
--- a/demo_scripts/demo_lafan_wb_tracking.sh
+++ b/demo_scripts/demo_lafan_wb_tracking.sh
@@ -85,7 +85,7 @@ else
         echo "Cloning ubisoft-laforge-animation-dataset for processing code..."
         cd "$DATA_UTILS_DIR"
         if [ ! -d "ubisoft-laforge-animation-dataset" ]; then
-            git clone -q https://github.com/ubisoft/ubisoft-laforge-animation-dataset.git
+            GIT_LFS_SKIP_SMUDGE=1 git clone -q https://github.com/ubisoft/ubisoft-laforge-animation-dataset.git
         fi
         if [ -d "ubisoft-laforge-animation-dataset/lafan1" ] && [ ! -d "lafan1" ]; then
             mv ubisoft-laforge-animation-dataset/lafan1 .


### PR DESCRIPTION
This PR fixes the second error in https://github.com/amazon-far/holosoma/issues/60.

_Description of changes:_


The upstream repository (ubisoft/ubisoft-laforge-animation-dataset) has exceeded its GitHub LFS bandwidth budget.

Since we only need the script from the repo to perform dataset conversion, we don't actually need to clone the large dataset files. Therefore, we use `GIT_LFS_SKIP_SMUDGE=1` to skip downloading the large binary files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
