### PR TITLE
Fix demo scripts for whole-body tracking

### DIFF
--- a/demo_scripts/demo_lafan_wb_tracking.sh
+++ b/demo_scripts/demo_lafan_wb_tracking.sh
@@ -1,13 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script for running retargeting, data conversion, and whole-body tracking training
 # Requires Ubuntu/Linux OS (IsaacSim is not supported on Mac)
 
 set -e  # Exit on error
 
-# Get script directory
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# figure out where this file is located even if it is being run from another location
+# or as a symlink
+SOURCE="${BASH_SOURCE[0]:-${(%):-%x}}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SCRIPT_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null && pwd )"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 # Detect operating system and check if it's supported
 OS="$(uname -s)"
@@ -34,15 +41,19 @@ esac
 echo "Sourcing retargeting setup..."
 source "$PROJECT_ROOT/scripts/source_retargeting_setup.sh"
 
+# Ensure holosoma_retargeting is installed with correct dependencies (e.g. numpy version)
+pip install -e "$PROJECT_ROOT/src/holosoma_retargeting" --quiet
+
 # Change to retargeting directory
-cd "$PROJECT_ROOT/src/holosoma_retargeting/holosoma_retargeting/"
+RETARGET_DIR="$PROJECT_ROOT/src/holosoma_retargeting/holosoma_retargeting"
+cd "$RETARGET_DIR"
 
 # Step 0: Download and process LAFAN data if needed
 echo "Checking LAFAN data availability..."
-LAFAN_DATA_DIR="demo_data/lafan"
-LAFAN_TEMP_DIR="demo_data/lafan_temp"
-LAFAN_ZIP="demo_data/lafan1.zip"
-DATA_UTILS_DIR="data_utils"
+LAFAN_DATA_DIR="$RETARGET_DIR/demo_data/lafan"
+LAFAN_TEMP_DIR="$RETARGET_DIR/demo_data/lafan_temp"
+LAFAN_ZIP="$RETARGET_DIR/demo_data/lafan1.zip"
+DATA_UTILS_DIR="$RETARGET_DIR/data_utils"
 
 # Check if processed LAFAN data already exists
 if [ -d "$LAFAN_DATA_DIR" ] && [ "$(ls -A $LAFAN_DATA_DIR/*.npy 2>/dev/null)" ]; then
@@ -51,7 +62,7 @@ else
     echo "LAFAN data not found. Downloading and processing..."
 
     # Create demo_data directory if it doesn't exist
-    mkdir -p demo_data
+    mkdir -p "$RETARGET_DIR/demo_data"
 
     # Download lafan1.zip if it doesn't exist
     if [ ! -f "$LAFAN_ZIP" ]; then
@@ -90,7 +101,7 @@ else
         if [ -d "ubisoft-laforge-animation-dataset/lafan1" ] && [ ! -d "lafan1" ]; then
             mv ubisoft-laforge-animation-dataset/lafan1 .
         fi
-        cd ..
+        cd "$RETARGET_DIR"
     else
         echo "lafan1 processing code already available."
     fi
@@ -98,15 +109,15 @@ else
     # Convert BVH files to .npy format
     echo "Converting BVH files to .npy format..."
     cd "$DATA_UTILS_DIR"
-    python extract_global_positions.py --input_dir "../$LAFAN_TEMP_DIR" --output_dir "../$LAFAN_DATA_DIR"
-    cd ..
+    python extract_global_positions.py --input_dir "$LAFAN_TEMP_DIR" --output_dir "$LAFAN_DATA_DIR"
+    cd "$RETARGET_DIR"
 
     echo "LAFAN data processing complete!"
 fi
 
 # Step 1: Run retargeting
 echo "Running retargeting..."
-python examples/robot_retarget.py --data_path demo_data/lafan --task-type robot_only --task-name dance2_subject1 --data_format lafan --task-config.ground-range -10 10 --save_dir demo_results/g1/robot_only/lafan --retargeter.foot-sticking-tolerance 0.02
+python examples/robot_retarget.py --data_path "$LAFAN_DATA_DIR" --task-type robot_only --task-name dance2_subject1 --data_format lafan --task-config.ground-range -10 10 --save_dir demo_results/g1/robot_only/lafan --retargeter.foot-sticking-tolerance 0.02
 
 # Step 2: Run data conversion
 echo "Running data conversion..."
@@ -115,11 +126,24 @@ python data_conversion/convert_data_format_mj.py --input_file ./demo_results/g1/
 # Step 3: Source IsaacSim setup script (for whole-body tracking training)
 echo "Sourcing IsaacSim setup..."
 cd "$PROJECT_ROOT"
+unset CONDA_ENV_NAME
 source "$PROJECT_ROOT/scripts/source_isaacsim_setup.sh"
+
+# Ensure holosoma and isaaclab are installed in the IsaacSim env
+HOLOSOMA_DEPS_DIR="${HOLOSOMA_DEPS_DIR:-$HOME/.holosoma_deps}"
+pip install -e "$PROJECT_ROOT/src/holosoma[unitree,booster]" --quiet
+if ! python -c "import isaaclab" 2>/dev/null; then
+    echo "isaaclab not found, reinstalling..."
+    pip install 'setuptools<81' --quiet
+    echo 'setuptools<81' > /tmp/hs-build-constraints.txt
+    PIP_BUILD_CONSTRAINT=/tmp/hs-build-constraints.txt CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        pip install -e "$HOLOSOMA_DEPS_DIR/IsaacLab/source/isaaclab" --quiet
+    rm /tmp/hs-build-constraints.txt
+fi
 
 # Step 4: Run whole-body tracking training
 echo "Running whole-body tracking training..."
-CONVERTED_FILE="$PROJECT_ROOT/src/holosoma_retargeting/converted_res/robot_only/dance2_subject1_mj_fps50.npz"
+CONVERTED_FILE="$RETARGET_DIR/converted_res/robot_only/dance2_subject1_mj_fps50.npz"
 python src/holosoma/holosoma/train_agent.py \
     exp:g1-29dof-wbt \
     logger:wandb \

--- a/demo_scripts/demo_omomo_wb_tracking.sh
+++ b/demo_scripts/demo_omomo_wb_tracking.sh
@@ -1,13 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script for running retargeting, data conversion, and whole-body tracking training
 # Requires Ubuntu/Linux OS (IsaacSim is not supported on Mac)
 
 set -e  # Exit on error
 
-# Get script directory
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# figure out where this file is located even if it is being run from another location
+# or as a symlink
+SOURCE="${BASH_SOURCE[0]:-${(%):-%x}}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SCRIPT_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null && pwd )"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 # Detect operating system and check if it's supported
 OS="$(uname -s)"
@@ -34,8 +41,12 @@ esac
 echo "Sourcing retargeting setup..."
 source "$PROJECT_ROOT/scripts/source_retargeting_setup.sh"
 
+# Ensure holosoma_retargeting is installed with correct dependencies (e.g. numpy version)
+pip install -e "$PROJECT_ROOT/src/holosoma_retargeting" --quiet
+
 # Change to retargeting directory
-cd "$PROJECT_ROOT/src/holosoma_retargeting/holosoma_retargeting/"
+RETARGET_DIR="$PROJECT_ROOT/src/holosoma_retargeting/holosoma_retargeting"
+cd "$RETARGET_DIR"
 
 # Step 1: Run retargeting
 echo "Running retargeting..."
@@ -48,11 +59,24 @@ python data_conversion/convert_data_format_mj.py --input_file ./demo_results/g1/
 # Step 3: Source IsaacSim setup script (for whole-body tracking training)
 echo "Sourcing IsaacSim setup..."
 cd "$PROJECT_ROOT"
+unset CONDA_ENV_NAME
 source "$PROJECT_ROOT/scripts/source_isaacsim_setup.sh"
+
+# Ensure holosoma and isaaclab are installed in the IsaacSim env
+HOLOSOMA_DEPS_DIR="${HOLOSOMA_DEPS_DIR:-$HOME/.holosoma_deps}"
+pip install -e "$PROJECT_ROOT/src/holosoma[unitree,booster]" --quiet
+if ! python -c "import isaaclab" 2>/dev/null; then
+    echo "isaaclab not found, reinstalling..."
+    pip install 'setuptools<81' --quiet
+    echo 'setuptools<81' > /tmp/hs-build-constraints.txt
+    PIP_BUILD_CONSTRAINT=/tmp/hs-build-constraints.txt CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        pip install -e "$HOLOSOMA_DEPS_DIR/IsaacLab/source/isaaclab" --quiet
+    rm /tmp/hs-build-constraints.txt
+fi
 
 # Step 4: Run whole-body tracking training
 echo "Running whole-body tracking training..."
-CONVERTED_FILE="$PROJECT_ROOT/src/holosoma_retargeting/converted_res/robot_only/sub3_largebox_003_mj_fps50.npz"
+CONVERTED_FILE="$RETARGET_DIR/converted_res/robot_only/sub3_largebox_003_mj_fps50.npz"
 python src/holosoma/holosoma/train_agent.py \
     exp:g1-29dof-wbt \
     logger:wandb \


### PR DESCRIPTION
## Summary

- Fix path resolution in `demo_lafan_wb_tracking.sh` and `demo_omomo_wb_tracking.sh` to work correctly when run from any directory or via symlinks (replaces naive dirname with symlink-resolving loop)
- Use absolute paths throughout both scripts instead of relative paths that break when `cd` changes the working directory
- Ensure correct `conda` environments and dependencies are installed at each stage (retargeting env gets holosoma_retargeting reinstalled, IsaacSim env gets holosoma and isaaclab installed if missing)
- Make both demo scripts consistent in structure and setup logic

## Testing

- [x] Run `demo_scripts/demo_lafan_wb_tracking.sh` end-to-end from the project root
- [x] Run demo_scripts/demo_omomo_wb_tracking.sh end-to-end from the project root
- [x] Verify retargeting, data conversion, and WBT training steps all complete successfully


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
