### PR TITLE
[fix] keyboard commands crashing with 3-column command tensor

### DIFF
--- a/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
+++ b/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
@@ -814,13 +814,15 @@ class IsaacGym(BaseSimulator):
                 self.commands[:, 1] += 0.1
                 logger.info(f"Current Command: {self.commands[:,]}")
             elif evt.action == "heading_left_command" and evt.value > 0:
-                self.commands[:, 3] -= 0.1
+                idx = 3 if self.commands.shape[1] > 3 else 2
+                self.commands[:, idx] -= 0.1
                 logger.info(f"Current Command: {self.commands[:,]}")
             elif evt.action == "heading_right_command" and evt.value > 0:
-                self.commands[:, 3] += 0.1
+                idx = 3 if self.commands.shape[1] > 3 else 2
+                self.commands[:, idx] += 0.1
                 logger.info(f"Current Command: {self.commands[:,]}")
             elif evt.action == "zero_command" and evt.value > 0:
-                self.commands[:, :4] = 0
+                self.commands[:] = 0
                 logger.info(f"Current Command: {self.commands[:,]}")
             elif evt.action == "toggle_camera_tracking" and evt.value > 0:
                 was_enabled = self.simulator_config.viewer.enable_tracking


### PR DESCRIPTION
## Issue
- Heading left/right keys (Q/E) hardcode `commands[:, 3]` which crashes with `IndexError` for locomotion configs that have as command (vx, vy, vyaw).
- Fix: fall back to `commands[:, 2]` (angular velocity) when no 4th column exists.
- Also `zero_command` (Z key) which hardcoded `commands[:, :4]` is now zeros on all columns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
