### PR TITLE
Update path to retargeting readme in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ src/
 
 - **[Training Guide](src/holosoma/README.md)** - Train locomotion and whole-body tracking policies in IsaacGym/IsaacSim
 - **[Inference & Deployment Guide](src/holosoma_inference/README.md)** - Deploy policies to real robots or evaluate in MuJoCo simulation
-- **[Retargeting Guide](src/holosoma_retargeting/README.md)** - Convert human motion capture data to robot motions
+- **[Retargeting Guide](src/holosoma_retargeting/holosoma_retargeting/README.md)** - Convert human motion capture data to robot motions
 
 ## Quick Start
 


### PR DESCRIPTION
*Description of changes:* The link to the retargeting readme in the root readme is broken. This fixes it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
