### PR TITLE
Add legend to nightly summary

### DIFF
--- a/tests/nightly/run_summary.py
+++ b/tests/nightly/run_summary.py
@@ -214,6 +214,9 @@ def post_summary_to_slack():
         summary_message += "\nFailed runs: " + ", ".join(problem_runs)
 
     summary_message += "\nWandB Links:\n```\n" + "\n".join(wandb_summaries) + "\n```"
+    summary_message += "\n" + " ".join(
+        f"{emoji} = {status.name.replace('_', ' ').title()}" for status, emoji in RunStatus2Emoji.items()
+    )
 
     slack_client.chat_postMessage(channel=SLACK_CHANNEL, markdown_text=summary_message, unfurl_links=False)
 


### PR DESCRIPTION
This appends a single legend line to the to the nightly summary at the end of the Slack message.

🟩 = Succeeded 🟥 = Crashed ⚠️ = Metrics Regression 🚫 = Failed ❓ = Unknown                                                  

