### PR TITLE
Add per-robot joint offset calibration to actions

### DIFF
--- a/src/holosoma_inference/holosoma_inference/config/config_types/robot.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_types/robot.py
@@ -222,3 +222,15 @@ class RobotConfig:
 
     num_upper_body_joints: int = 14
     """Number of upper body degrees of freedom."""
+
+    # =========================================================================
+    # Per-Robot Calibration
+    # =========================================================================
+
+    joint_offsets_deg: tuple[float, ...] | None = None
+    """Per-joint offsets in degrees applied to lowcmd (action-space only).
+
+    These offsets correct for per-robot motor calibration differences without
+    affecting the observation/state space. Converted to radians at init time.
+    Length must equal num_joints when provided.
+    """

--- a/src/holosoma_inference/holosoma_inference/policies/base.py
+++ b/src/holosoma_inference/holosoma_inference/policies/base.py
@@ -73,6 +73,17 @@ class BasePolicy:
         self.num_dofs = self.robot_config.num_joints
         self.default_dof_angles = np.array(self.robot_config.default_dof_angles)
         self.num_upper_dofs = robot_config.num_upper_body_joints
+
+        # Initialize motor limits (only position limits are used)
+        q_max = self.robot_config.joint_pos_max
+        q_min = self.robot_config.joint_pos_min
+        self.q_max_arr: np.array | None = np.array(q_max) if q_max is not None else None
+        self.q_min_arr: np.array | None = np.array(q_min) if q_min is not None else None
+
+        # Per-robot joint offsets (action-space calibration, does not affect observations)
+        offsets_deg = robot_config.joint_offsets_deg
+        self.joint_offsets = np.deg2rad(offsets_deg) if offsets_deg is not None else np.zeros(self.num_dofs)
+
         # Setup dof names and indices
         self._setup_dof_mappings()
 
@@ -690,7 +701,7 @@ class BasePolicy:
                 q_target = scaled_policy_action + self.default_dof_angles
 
             # Prepare command (reuse pre-allocated arrays)
-            self.cmd_q[:] = q_target
+            self.cmd_q[:] = q_target[0] + self.joint_offsets
 
         # Stage 5: Action Pub
         with self.latency_tracker.measure("action_pub"):

--- a/src/holosoma_inference/holosoma_inference/policies/base.py
+++ b/src/holosoma_inference/holosoma_inference/policies/base.py
@@ -74,12 +74,6 @@ class BasePolicy:
         self.default_dof_angles = np.array(self.robot_config.default_dof_angles)
         self.num_upper_dofs = robot_config.num_upper_body_joints
 
-        # Initialize motor limits (only position limits are used)
-        q_max = self.robot_config.joint_pos_max
-        q_min = self.robot_config.joint_pos_min
-        self.q_max_arr: np.array | None = np.array(q_max) if q_max is not None else None
-        self.q_min_arr: np.array | None = np.array(q_min) if q_min is not None else None
-
         # Per-robot joint offsets (action-space calibration, does not affect observations)
         offsets_deg = robot_config.joint_offsets_deg
         self.joint_offsets = np.deg2rad(offsets_deg) if offsets_deg is not None else np.zeros(self.num_dofs)


### PR DESCRIPTION
## Notes

This PR adds `--robot.joint-offsets-deg` parameter for per-robot motor calibration offsets applied to `lowcmd` (action space) without affecting observations, matching the approach done by Unitree with their built-in locomotion policy and the offsets Unitree Explore App. The new option defaults to None (zero offsets), so existing behavior is unchanged.

## Example usage

```
python -m holosoma_inference.run_policy inference:g1-29dof-loco (...) --robot.joint-offsets-deg '[1.5, 0.0, -0.8, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]'
```

