### PR TITLE
fix: parse Python cp tag for unitree/booster wheel URLs; bump unitree to 0.1.3

### DIFF
--- a/src/holosoma_inference/setup.py
+++ b/src/holosoma_inference/setup.py
@@ -1,8 +1,9 @@
 import platform
+import sys
 
 from setuptools import find_packages, setup
 
-UNITREE_VERSION = "0.1.1"
+UNITREE_VERSION = "0.1.3"
 UNITREE_REPO = "https://github.com/amazon-far/unitree_sdk2"
 BOOSTER_VERSION = "0.1.0"
 BOOSTER_REPO = "https://github.com/amazon-far/booster_robotics_sdk"
@@ -12,16 +13,31 @@ PLATFORM_MAP = {
     "aarch64": "linux_aarch64",
 }
 
+# Supported Python cp tags — the SDK wheel build matrix publishes these tags.
+# Keep this list in sync with the wheel asset matrix on the amazon-far release.
+_SUPPORTED_PY_TAGS = {(3, 8), (3, 10), (3, 11), (3, 12)}
+_py = (sys.version_info.major, sys.version_info.minor)
+if _py in _SUPPORTED_PY_TAGS:
+    cp_tag = f"cp{_py[0]}{_py[1]}"
+else:
+    # Fall back to cp310 for unsupported interpreters; install will likely
+    # fail, but the URL stays deterministic for error reporting.
+    cp_tag = "cp310"
+
 platform_tag = PLATFORM_MAP.get(platform.machine(), "linux_x86_64")
 
 unitree_extras = []
 unitree_url = (
-    f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/unitree_sdk2-{UNITREE_VERSION}-cp310-cp310-{platform_tag}.whl"
+    f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/"
+    f"unitree_sdk2-{UNITREE_VERSION}-{cp_tag}-{cp_tag}-{platform_tag}.whl"
 )
 unitree_extras.append(f"unitree_sdk2 @ {unitree_url}")
 
 booster_extras = []
-booster_url = f"{BOOSTER_REPO}/releases/download/{BOOSTER_VERSION}/booster_robotics_sdk-{BOOSTER_VERSION}-cp310-cp310-{platform_tag}.whl"  # noqa: E501
+booster_url = (
+    f"{BOOSTER_REPO}/releases/download/{BOOSTER_VERSION}/"
+    f"booster_robotics_sdk-{BOOSTER_VERSION}-{cp_tag}-{cp_tag}-{platform_tag}.whl"
+)
 booster_extras.append(f"booster_robotics_sdk @ {booster_url}")
 
 

--- a/src/holosoma_inference/setup.py
+++ b/src/holosoma_inference/setup.py
@@ -17,12 +17,13 @@ PLATFORM_MAP = {
 # Keep this list in sync with the wheel asset matrix on the amazon-far release.
 _SUPPORTED_PY_TAGS = {(3, 8), (3, 10), (3, 11), (3, 12)}
 _py = (sys.version_info.major, sys.version_info.minor)
-if _py in _SUPPORTED_PY_TAGS:
-    cp_tag = f"cp{_py[0]}{_py[1]}"
-else:
-    # Fall back to cp310 for unsupported interpreters; install will likely
-    # fail, but the URL stays deterministic for error reporting.
-    cp_tag = "cp310"
+if _py not in _SUPPORTED_PY_TAGS:
+    _supported = ", ".join(f"{maj}.{min}" for maj, min in sorted(_SUPPORTED_PY_TAGS))
+    raise RuntimeError(
+        f"holosoma_inference[unitree,booster] has no prebuilt SDK wheel for "
+        f"Python {_py[0]}.{_py[1]}. Supported versions: {_supported}."
+    )
+cp_tag = f"cp{_py[0]}{_py[1]}"
 
 platform_tag = PLATFORM_MAP.get(platform.machine(), "linux_x86_64")
 


### PR DESCRIPTION
## Summary

Fix the `unitree_sdk2` and `booster_robotics_sdk` wheel URL construction in `src/holosoma_inference/setup.py` so `pip install -e .[unitree,booster]` works on Python ≥ 3.11.

Previously:
- `UNITREE_VERSION = "0.1.1"` hardcoded.
- Wheel URL template hardcoded `cp310-cp310` in both SDKs' URL patterns.

On Python 3.11 or 3.12 the install would fetch a `cp310` wheel URL and fail (at best) or silently install the wrong ABI (at worst).

## Changes

- Bump `UNITREE_VERSION` to `0.1.3` (latest release; ships `cp38/cp310/cp311/cp312 × aarch64/x86_64` wheels).
- Parse `sys.version_info` to pick the matching `cp{X}{Y}` tag from a supported set `{(3,8), (3,10), (3,11), (3,12)}`.
- Raise `RuntimeError` on unsupported Python versions (listing the supported set) so the install failure is explicit rather than silently mis-tagged.

## Why now

JetPack 7.1 / Ubuntu 24.04 (Noble) native Python is 3.12, and that's the target for the upcoming Thor Docker image. Without this fix, the `inference` Docker layer can't install the `[unitree]` extra.

## Test plan

- [x] URL construction verified across Python 3.8 / 3.10 / 3.11 / 3.12 — all render the matching `cp{X}{Y}` tag.
- [x] `pip install -e src/holosoma_inference[unitree,booster]` on Python 3.10, `linux/amd64` → fetches `cp310` wheels; `unitree_interface` and `booster_robotics_sdk` import successfully.
- [x] `pip install -e src/holosoma_inference[unitree,booster]` on Python 3.12, `linux/amd64` → fetches `cp312` wheels; imports successfully (depends on amazon-far/unitree_sdk2#10 — merged).
- [x] Unsupported Python (3.9, 3.13) raises `RuntimeError` listing supported versions.
- [x] HEAD-checked all 12 wheel URL combos (unitree + booster × cp310/cp311/cp312 × x86_64/aarch64) — all return HTTP 200.