### PR TITLE
feat: add uv-based setup + activation scripts for holosoma_inference

### DIFF
--- a/scripts/setup_inference_via_uv.sh
+++ b/scripts/setup_inference_via_uv.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Exit on error, and print commands
+set -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+
+# Venv configuration
+VENV_DIR=$ROOT_DIR/.venv/hsinference
+
+# Parse command-line arguments
+INSTALL_ROBOT_SDKS=true
+PYTHON_VERSION=""
+REINSTALL=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --no-robot-sdks)
+      INSTALL_ROBOT_SDKS=false
+      echo "Robot SDK installation disabled (unitree, booster)"
+      shift
+      ;;
+    --python)
+      PYTHON_VERSION="$2"
+      shift 2
+      ;;
+    --reinstall)
+      REINSTALL=true
+      echo "Reinstall requested — existing environment will be removed"
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--no-robot-sdks] [--python VERSION] [--reinstall]"
+      echo ""
+      echo "Options:"
+      echo "  --no-robot-sdks    Skip robot SDK installation (unitree, booster)"
+      echo "  --python VERSION   Python version to use (e.g., 3.10, 3.12)"
+      echo "  --reinstall        Remove existing environment and reinstall from scratch"
+      echo "  --help, -h         Show this help message"
+      echo ""
+      echo "Python auto-detection (when --python is not specified):"
+      echo "  Ubuntu 22.04 → Python 3.10 (ROS2 Humble compatible)"
+      echo "  Ubuntu 24.04 → Python 3.12 (ROS2 Jazzy compatible)"
+      echo "  Other         → system default Python"
+      echo ""
+      echo "Note: ROS2 is optional. The environment works standalone."
+      echo "      Use 'source scripts/source_inference_uv_setup.sh' to activate"
+      echo "      (it will source ROS2 automatically if installed)."
+      echo ""
+      echo "Examples:"
+      echo "  # Full setup (default: with robot SDKs)"
+      echo "  $0"
+      echo ""
+      echo "  # Setup with specific Python version, no robot SDKs"
+      echo "  $0 --python 3.12 --no-robot-sdks"
+      echo ""
+      echo "  # Force clean reinstall"
+      echo "  $0 --reinstall"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--no-robot-sdks] [--python VERSION] [--reinstall]"
+      echo "Use --help for more information"
+      exit 1
+      ;;
+  esac
+done
+
+# Sentinel file
+SENTINEL_FILE=${VENV_DIR}/.env_uv_setup_finished_hsinference
+
+# Reinstall: remove existing venv and sentinel so install runs fresh
+if [[ "$REINSTALL" == "true" ]] && [[ -d "$VENV_DIR" ]]; then
+  echo "Removing existing environment at $VENV_DIR..."
+  rm -rf "$VENV_DIR"
+fi
+
+# Install uv if not present
+if ! command -v uv &> /dev/null; then
+  echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # Source the env so uv is available in this session
+  source $HOME/.local/bin/env 2>/dev/null || export PATH="$HOME/.local/bin:$PATH"
+fi
+
+echo "uv version: $(uv --version)"
+
+# Auto-detect Python version from Ubuntu release if not explicitly set.
+# This ensures the venv matches the system Python used by ROS2:
+#   Ubuntu 22.04 (Jammy)  → Python 3.10 → ROS2 Humble
+#   Ubuntu 24.04 (Noble)  → Python 3.12 → ROS2 Jazzy
+if [[ -z "$PYTHON_VERSION" ]]; then
+  OS_NAME_DETECT="$(uname -s)"
+  if [[ "$OS_NAME_DETECT" == "Linux" && -f /etc/os-release ]]; then
+    UBUNTU_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'"' -f2)
+    case "$UBUNTU_VERSION" in
+      22.04)
+        PYTHON_VERSION="3.10"
+        echo "Detected Ubuntu 22.04 → using Python 3.10 (ROS2 Humble compatible)"
+        ;;
+      24.04)
+        PYTHON_VERSION="3.12"
+        echo "Detected Ubuntu 24.04 → using Python 3.12 (ROS2 Jazzy compatible)"
+        ;;
+      *)
+        echo "Ubuntu $UBUNTU_VERSION detected — no default Python version mapped, using system default"
+        ;;
+    esac
+  fi
+fi
+
+# Base installation
+if [[ ! -f $SENTINEL_FILE ]]; then
+  OS_NAME="$(uname -s)"
+  ARCH="$(uname -m)"
+
+  # Create venv
+  echo "Creating virtual environment at $VENV_DIR..."
+  UV_PYTHON_FLAG=""
+  if [[ -n "$PYTHON_VERSION" ]]; then
+    UV_PYTHON_FLAG="--python $PYTHON_VERSION"
+  fi
+  uv venv $UV_PYTHON_FLAG "$VENV_DIR"
+
+  # Activate venv
+  source "$VENV_DIR/bin/activate"
+
+  # Install holosoma_inference
+  # Robot SDK wheels (unitree, booster) are only available on Linux aarch64/x86_64.
+  echo "Installing holosoma_inference..."
+  if [[ "$INSTALL_ROBOT_SDKS" == "true" && "$OS_NAME" == "Linux" ]]; then
+    uv pip install -e "$ROOT_DIR/src/holosoma_inference[unitree,booster]"
+  else
+    if [[ "$INSTALL_ROBOT_SDKS" == "true" && "$OS_NAME" == "Darwin" ]]; then
+      echo "Note: Robot SDK wheels (unitree, booster) are not available for macOS."
+      echo "Installing holosoma_inference without robot SDK extras."
+    fi
+    uv pip install -e "$ROOT_DIR/src/holosoma_inference"
+  fi
+
+  # Pinocchio (rigid-body dynamics) is required by WBT policies.
+  # Installed separately because it's not in setup.py install_requires.
+  echo "Installing pinocchio for WBT policy support..."
+  uv pip install 'pin>=3.8.0'
+
+  # Jetson power mode bump for aarch64 (best-effort, non-fatal)
+  if [[ "$OS_NAME" == "Linux" && "$ARCH" == "aarch64" ]]; then
+    sudo nvpmodel -m 0 2>/dev/null || true
+  fi
+
+  # Validate inference imports
+  echo "Validating holosoma_inference installation..."
+  python -c "import holosoma_inference; print('holosoma_inference imported successfully')"
+  python -c "import pinocchio as pin; print(f'pinocchio version: {pin.__version__}')"
+
+  touch $SENTINEL_FILE
+  echo ""
+  echo "=========================================="
+  echo "holosoma_inference environment setup completed!"
+  echo "=========================================="
+  echo ""
+  echo "Activate with: source scripts/source_inference_uv_setup.sh"
+  echo "=========================================="
+fi
+
+echo ""
+echo "holosoma_inference environment ready."
+echo "Use 'source scripts/source_inference_uv_setup.sh' to activate."

--- a/scripts/setup_inference_via_uv.sh
+++ b/scripts/setup_inference_via_uv.sh
@@ -5,8 +5,8 @@ set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR=$(dirname "$SCRIPT_DIR")
 
-# Venv configuration
-VENV_DIR=$ROOT_DIR/.venv/hsinference
+# Venv configuration (override via HS_INFER_VENV)
+VENV_DIR="${HS_INFER_VENV:-$ROOT_DIR/.venv/hsinference}"
 
 # Parse command-line arguments
 INSTALL_ROBOT_SDKS=true

--- a/scripts/source_inference_uv_setup.sh
+++ b/scripts/source_inference_uv_setup.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Activation script for the uv-based holosoma_inference environment
+# Usage: source scripts/source_inference_uv_setup.sh
+
+# Detect script directory (works in both bash and zsh)
+if [ -n "${BASH_SOURCE[0]}" ]; then
+    SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+elif [ -n "${ZSH_VERSION}" ]; then
+    SCRIPT_DIR=$( cd -- "$( dirname -- "${(%):-%x}" )" &> /dev/null && pwd )
+fi
+
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+VENV_DIR=$ROOT_DIR/.venv/hsinference
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "Error: uv inference environment not found at $VENV_DIR"
+    echo "Run 'bash scripts/setup_inference_via_uv.sh' first."
+    return 1 2>/dev/null || exit 1
+fi
+
+# Source ROS2 if available (before venv activation so venv packages take priority)
+if [[ -f /opt/ros/jazzy/setup.bash ]]; then
+    source /opt/ros/jazzy/setup.bash
+    _ROS_DISTRO="jazzy"
+elif [[ -f /opt/ros/humble/setup.bash ]]; then
+    source /opt/ros/humble/setup.bash
+    _ROS_DISTRO="humble"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+# Ensure venv bin dir is first in PATH (version managers like mise can override it)
+case ":$PATH:" in
+    *":$VENV_DIR/bin:"*) ;;
+    *) export PATH="$VENV_DIR/bin:$PATH" ;;
+esac
+
+# Validate environment
+if python -c "import holosoma_inference" 2>/dev/null; then
+    echo "holosoma_inference uv environment activated successfully"
+
+    if python -c "import pinocchio" 2>/dev/null; then
+        echo "pinocchio version: $(python -c 'import pinocchio; print(pinocchio.__version__)')"
+    fi
+
+    if python -c "import unitree_sdk2" 2>/dev/null; then
+        echo "unitree_sdk2: available"
+    fi
+
+    if [[ -n "${_ROS_DISTRO:-}" ]]; then
+        if python -c "import rclpy" 2>/dev/null; then
+            echo "ROS2 ${_ROS_DISTRO}: rclpy available"
+        else
+            echo "ROS2 ${_ROS_DISTRO}: sourced but rclpy not compatible (Python version mismatch?)"
+        fi
+    fi
+else
+    echo "Warning: holosoma_inference environment activation may have issues"
+    echo "Try running 'bash scripts/setup_inference_via_uv.sh' to reinstall"
+fi
+unset _ROS_DISTRO

--- a/scripts/source_inference_uv_setup.sh
+++ b/scripts/source_inference_uv_setup.sh
@@ -10,7 +10,7 @@ elif [ -n "${ZSH_VERSION}" ]; then
 fi
 
 ROOT_DIR=$(dirname "$SCRIPT_DIR")
-VENV_DIR=$ROOT_DIR/.venv/hsinference
+VENV_DIR="${HS_INFER_VENV:-$ROOT_DIR/.venv/hsinference}"
 
 if [[ ! -d "$VENV_DIR" ]]; then
     echo "Error: uv inference environment not found at $VENV_DIR"


### PR DESCRIPTION
## Summary

Add `scripts/setup_inference_via_uv.sh` + `scripts/source_inference_uv_setup.sh`, mirroring the existing `setup_mujoco_via_uv.sh` pattern but for `holosoma_inference`. Creates an isolated uv-managed venv at `.venv/hsinference` instead of the system Python / conda.

## Why

Two concrete reasons:

1. **Faster installs** — `uv` resolves and installs wheels ~10-100× faster than `pip`, especially on slow networks.
2. **System-Python friendly** — JetPack 7.1 / Ubuntu 24.04 ships Python 3.12 with PEP 668 protections; users need a venv, and conda is overkill for pure-pip workflows.

## Changes

- `scripts/setup_inference_via_uv.sh`: installs `holosoma_inference` (editable), robot SDK extras on Linux, and Pinocchio (`pin>=3.8.0`) for WBT policy support. Auto-detects Python version (3.10 on Ubuntu 22.04, 3.12 on 24.04) or accepts `--python` override.
- `scripts/source_inference_uv_setup.sh`: activation script; sources ROS 2 if `/opt/ros/{jazzy,humble}` is present, then activates the venv.

CLI flags match the mujoco uv script for consistency: `--python VERSION`, `--no-robot-sdks`, `--reinstall`, `--help`.

## Test plan

- [x] Smoke-tested on Ubuntu 22.04 x86_64 (Python 3.10) — `holosoma_inference` imports, pinocchio 3.9.0 installs.
- [x] Smoke-tested on Ubuntu 24.04 aarch64 (Python 3.12, on Jetson AGX Thor) — same validations.
- [x] `source scripts/source_inference_uv_setup.sh` activates the venv.

## Known caveat

Activating the venv *after* sourcing ROS 2 Humble can cause `import pinocchio` to segfault due to Boost/numpy ABI conflicts between ROS Humble's system libs and pinocchio's bundled deps. Not a regression (same issue exists for `setup_mujoco_via_uv.sh`). Mitigation: activate the venv *first* if pinocchio is needed, or use a ROS 2 Jazzy environment where the system numpy matches.