### PR TITLE
Add pin (pinocchio) to holosoma_inference install_requires

### DIFF
--- a/src/holosoma_inference/setup.py
+++ b/src/holosoma_inference/setup.py
@@ -66,6 +66,7 @@ setup(
         "zmq",
         "defusedxml",
         "evdev",
+        "pin>=3.8.0",
         "importlib_metadata>=4.6; python_version<'3.12'",
         "eval_type_backport; python_version<'3.10'",
     ],


### PR DESCRIPTION
## Summary

`holosoma_inference.policies.wbt_utils` imports `pinocchio as pin`, making it a runtime dependency for the WBT policy code path. It's not currently declared in `src/holosoma_inference/setup.py::install_requires`, so any environment that relies on pip's dependency resolution to install `holosoma_inference` (rather than layering pinocchio in manually) hits an ImportError on the first WBT call.

Pinned to `>=3.8.0` to match the API surface used in `wbt_utils.py`.

## Why now

Came up in code review on a downstream Dockerfile that explicitly installs `pin>=3.8.0` as a workaround. Adding it here removes the need for that workaround in every consumer.

## Test plan

- [x] `pip install -e src/holosoma_inference[unitree]` in a clean Python 3.12 venv now resolves and installs `pin` automatically.
- [x] `python -c "from holosoma_inference.policies.wbt_utils import *"` no longer raises `ModuleNotFoundError: No module named 'pinocchio'` in a fresh install.