### PR TITLE
Unified policy service node (Variant A: reuse Ros2Input)

### DIFF
--- a/src/holosoma_inference/holosoma_inference/inputs/impl/ros2.py
+++ b/src/holosoma_inference/holosoma_inference/inputs/impl/ros2.py
@@ -23,6 +23,10 @@ ROS2_COMMAND_MAP: dict[str, StateCommand] = {
     "walk": StateCommand.WALK,
     "stand": StateCommand.STAND,
     "switch_mode": StateCommand.SWITCH_MODE,
+    # Emergency exit over ROS2, parity with the joystick L1+R1 kill. Triggers
+    # the policy's KILL handler (sys.exit(0)) so the process stops sending
+    # commands — the in-band kill for ros2/injected state input.
+    "kill": StateCommand.KILL,
 }
 
 

--- a/src/holosoma_inference/holosoma_inference/policies/dual_mode.py
+++ b/src/holosoma_inference/holosoma_inference/policies/dual_mode.py
@@ -81,10 +81,15 @@ class DualModePolicy:
         """
         from holosoma_inference.inputs.api.commands import StateCommand
 
-        # Inject SWITCH_MODE into both command providers' mappings (joystick X, keyboard x)
+        # Inject SWITCH_MODE into both command providers' key mappings (joystick X,
+        # keyboard x). Only keyboard/joystick providers expose ``_mapping``; others
+        # (e.g. Ros2Input, which already maps the "switch_mode" string to
+        # SWITCH_MODE natively) are intercepted purely via the dispatch patch below.
         for policy in (self.primary, self.secondary):
-            policy._command_provider._mapping["X"] = StateCommand.SWITCH_MODE
-            policy._command_provider._mapping["x"] = StateCommand.SWITCH_MODE
+            mapping = getattr(policy._command_provider, "_mapping", None)
+            if mapping is not None:
+                mapping["X"] = StateCommand.SWITCH_MODE
+                mapping["x"] = StateCommand.SWITCH_MODE
 
         # Patch _dispatch_command to intercept SWITCH_MODE
         self._orig_dispatch = {

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/feedback.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/feedback.py
@@ -1,0 +1,96 @@
+"""Policy-agnostic feedback publisher.
+
+Publishes the executed-command + heartbeat feedback for *any* holosoma policy,
+driven by the policy's per-tick ``_on_command_sent`` hook (so it runs in the
+policy control thread, in every state). Mirrors the split-body controller's
+feedback topics:
+
+  - ``/holosoma/holosoma_executed_cmd`` (``JointState``): the full-body joint
+    command actually sent this tick, at the control rate.
+  - ``/holosoma/heartbeat`` (``Heartbeat``): liveness + status at ~5 Hz.
+
+Extracted verbatim (no behavior change) from the feedback half of the original
+WBT-only ``holosoma_node`` so the loco path can reuse it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import rclpy
+from holosoma_msgs.msg import Heartbeat
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+EXECUTED_CMD_TOPIC = "/holosoma/holosoma_executed_cmd"
+HEARTBEAT_TOPIC = "/holosoma/heartbeat"
+HEARTBEAT_EVERY = 10  # control ticks -> 5 Hz at a 50 Hz control loop
+
+
+class PolicyFeedbackPublisher(Node):
+    """Publishes executed-cmd + heartbeat from a policy's ``_on_command_sent`` hook.
+
+    Policy-agnostic: works for locomotion, WBT, or any ``BasePolicy`` subclass.
+    ``dof_names`` is set by the caller after the policy is built (the policy's
+    joint names aren't known until then).
+    """
+
+    def __init__(self, dof_names: list[str] | None = None):
+        super().__init__("holosoma_feedback")
+        self.dof_names: list[str] = list(dof_names or [])
+        self._cmd_pub = self.create_publisher(JointState, EXECUTED_CMD_TOPIC, 10)
+        self._hb_pub = self.create_publisher(Heartbeat, HEARTBEAT_TOPIC, 10)
+        self._tick = 0
+
+    def on_command_sent(self, policy, cmd_q) -> None:
+        """Publish executed command (every tick) and heartbeat (~5 Hz)."""
+        cmd = np.asarray(cmd_q, dtype=np.float64).reshape(-1)
+
+        msg = JointState()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        if len(self.dof_names) == cmd.shape[0]:
+            msg.name = self.dof_names
+        msg.position = cmd.tolist()
+        self._cmd_pub.publish(msg)
+
+        if self._tick % HEARTBEAT_EVERY == 0:
+            hb = Heartbeat()
+            hb.header.stamp = msg.header.stamp
+            hb.robot_connected = getattr(policy, "interface", None) is not None
+            hb.control_mode = 0
+            if getattr(policy, "use_policy_action", False):
+                hb.status = "running"
+            elif getattr(policy, "get_ready_state", False):
+                hb.status = "get_ready"
+            else:
+                hb.status = "stiff_hold"
+            self._hb_pub.publish(hb)
+        self._tick += 1
+
+    def make_hook(self, policy):
+        """Return an ``_on_command_sent``-compatible callable bound to ``policy``.
+
+        The policy calls ``_on_command_sent(cmd_q, robot_state_data)`` each tick;
+        we ignore the state and forward ``(policy, cmd_q)`` to ``on_command_sent``.
+        """
+
+        def _hook(cmd_q, _state, _p=policy):
+            self.on_command_sent(_p, cmd_q)
+
+        return _hook
+
+
+def spin_in_thread(node: Node) -> None:
+    """Spin a node in a daemon thread on its OWN executor.
+
+    ``rclpy.spin()`` uses the process-global executor, so calling it from more
+    than one thread (here: feedback + dense bridge, alongside Ros2Input's own
+    spin) raises "Executor is already spinning". Each node gets a dedicated
+    SingleThreadedExecutor instead, so any number can spin concurrently.
+    """
+    import threading
+
+    from rclpy.executors import SingleThreadedExecutor
+
+    executor = SingleThreadedExecutor()
+    executor.add_node(node)
+    threading.Thread(target=executor.spin, daemon=True).start()

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/service_node.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/service_node.py
@@ -1,0 +1,161 @@
+"""Unified policy service node (Variant A).
+
+Runs *any* holosoma policy (locomotion, WBT, …) as a ROS2 service and supports
+runtime policy swapping — the ``run_policy.py`` experience served over ROS2.
+
+Design (Variant A — reuse ``Ros2Input`` via config):
+
+    /cmd_vel + /…/state_input ─▶ (loco)  Ros2Input ─(pull)─┐
+                                  [owned by the policy]      ├─▶ policy.run() ─▶ robot
+    /…/dense_tracking_command ─▶ (wbt)  DenseTargetBridge ──┘
+                                  swap via SWITCH_MODE ──────┘
+                                  every tick ─▶ executed_cmd + heartbeat (policy-agnostic)
+
+The policy is built exactly the way ``run_policy.py:main`` builds it
+(``_select_policy_class`` / ``DualModePolicy``), so:
+
+  * **Loco input** needs no code here — launch with
+    ``--task.velocity-input ros2 --task.state-input ros2`` and each policy spins
+    up its own ``Ros2Input`` (Twist + state String), including ``switch_mode``.
+  * **WBT input** is injected: a ``DenseTargetBridge`` is attached as the
+    policy's ``_target_source`` (only for policies that expose that attribute).
+  * **Output** is policy-agnostic: a ``PolicyFeedbackPublisher`` is wired into
+    each policy's per-tick ``_on_command_sent`` hook.
+
+Unlike the original WBT-only ``holosoma_node``, this does not depend on the
+extension-only ``config.task.policy_type`` / ``holosoma.policies.by_type`` entry
+points — it uses the same observation/robot-type resolution as the CLI.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+
+import rclpy
+import tyro
+from loguru import logger
+
+from holosoma_inference.config.config_values.inference import get_annotated_inference_config
+from holosoma_inference.config.utils import TYRO_CONFIG
+from holosoma_inference.policies.dual_mode import DualModePolicy, _select_policy_class
+
+from holosoma_service.policy_control.feedback import PolicyFeedbackPublisher, spin_in_thread
+from holosoma_service.policy_control.target_bridge import DenseTargetBridge
+
+# This node loads rclpy in-process, which clashes with the Unitree SDK's bundled
+# CycloneDDS (heap corruption / "free(): invalid pointer" at SDK init). The
+# multiprocess interface ("unitree_mp", added by PR #124) runs the low-level
+# binding in a spawned child so DDS never shares the parent's rclpy address
+# space. Map the in-process SDK -> its isolated variant for any service run.
+_MP_SDK_MAP = {"unitree": "unitree_mp"}
+
+
+def _iter_policies(policy):
+    """Yield the underlying policy instance(s): primary+secondary for dual-mode."""
+    if isinstance(policy, DualModePolicy):
+        yield policy.primary
+        if policy.secondary is not None:
+            yield policy.secondary
+    else:
+        yield policy
+
+
+def _attach_target_source(policy, bridge: DenseTargetBridge) -> bool:
+    """Attach the dense bridge as the target source of every WBT-style policy.
+
+    Only policies that expose ``_target_source`` (WBT family) are touched;
+    locomotion policies are left untouched. Returns True if any policy was
+    attached (so the caller knows whether to spin the bridge).
+    """
+    attached = False
+    for p in _iter_policies(policy):
+        if hasattr(p, "_target_source"):
+            p._target_source = bridge
+            attached = True
+            logger.info(f"Attached DenseTargetBridge to {type(p).__name__}")
+    return attached
+
+
+def _wire_feedback(policy, feedback: PolicyFeedbackPublisher) -> None:
+    """Wire the feedback publisher into each policy's per-tick hook."""
+    for p in _iter_policies(policy):
+        p._on_command_sent = feedback.make_hook(p)
+
+
+def _dof_names(policy) -> list[str]:
+    """Joint names of the (primary) policy, for labeling executed-cmd msgs."""
+    p = next(_iter_policies(policy))
+    return list(getattr(p, "dof_names", []))
+
+
+def _use_mp_sdk(config):
+    """Force the rclpy-safe multiprocess SDK interface (DDS in a child process).
+
+    Rewrites ``robot.sdk_type`` to its isolated variant (e.g. unitree ->
+    unitree_mp) on the config and its secondary. A no-op for SDK types without
+    a known isolated variant (e.g. already _mp, or booster), so an explicit
+    override survives.
+    """
+    new_type = _MP_SDK_MAP.get(config.robot.sdk_type)
+    if new_type is None:
+        return config
+    logger.info(f"Service node: using multiprocess SDK '{new_type}' (rclpy/DDS isolation)")
+    config = replace(config, robot=replace(config.robot, sdk_type=new_type))
+    if config.secondary is not None:
+        config = replace(config, secondary=_use_mp_sdk(config.secondary))
+    return config
+
+
+def _build_policy(config):
+    """Build the policy the same way run_policy.py does (dual-mode aware)."""
+    if config.secondary is not None:
+        return DualModePolicy(primary_config=config, secondary_config=config.secondary)
+    policy_class = _select_policy_class(config)
+    logger.info(f"Using {policy_class.__name__}")
+    return policy_class(config=config)
+
+
+def main() -> None:
+    # Under `ros2 launch` / `ros2 run`, argv carries ROS args (e.g.
+    # "--ros-args -r __node:=..."). tyro would reject those, so strip them
+    # before parsing this node's own CLI; rclpy.init() consumes them separately.
+    from rclpy.utilities import remove_ros_args
+
+    cli_argv = remove_ros_args(args=sys.argv)
+    sys.argv = cli_argv
+
+    config = tyro.cli(get_annotated_inference_config(), config=TYRO_CONFIG)
+    rclpy.init()
+
+    # 0. Route the Unitree SDK through its multiprocess proxy so its CycloneDDS
+    #    never shares this process's rclpy (otherwise SDK init heap-corrupts).
+    config = _use_mp_sdk(config)
+
+    # 1. Build the policy exactly like run_policy.py — swap support for free.
+    policy = _build_policy(config)
+
+    # 2. Loco input: nothing to wire (config velocity_input/state_input=ros2
+    #    makes each policy own its Ros2Input — Twist + state String).
+    # 3. WBT input: inject a CmdDense bridge as the target source, but only for
+    #    policies that have one (WBT family). Spin it only if attached.
+    bridge = DenseTargetBridge(config.robot.num_joints)
+    if _attach_target_source(policy, bridge):
+        spin_in_thread(bridge)
+
+    # 4. Output: policy-agnostic feedback every tick, every state.
+    feedback = PolicyFeedbackPublisher(dof_names=_dof_names(policy))
+    _wire_feedback(policy, feedback)
+    spin_in_thread(feedback)
+
+    logger.info("PolicyServiceNode ready — running policy.")
+    try:
+        policy.run()  # owns its RateLimiter + SDK I/O; blocks in this thread
+    except KeyboardInterrupt:
+        pass
+    finally:
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/target_bridge.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/target_bridge.py
@@ -1,0 +1,44 @@
+"""Dense tracking-target bridge (WBT-only input seam).
+
+Subscribes ``CmdDense`` and serves it as a WBT ``TargetSource`` (newest-wins;
+holds the last frame between policy ticks) via ``get_target()``, which the
+policy pulls each control tick.
+
+Extracted verbatim (no behavior change) from the input half of the original
+WBT-only ``holosoma_node``. Attached to a policy only when that policy exposes a
+``_target_source`` attribute (i.e. a WBT-style policy); locomotion policies have
+no tracking target and are left untouched.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from holosoma_msgs.msg import CmdDense
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+
+DENSE_TOPIC = "/holosoma/dense_tracking_command"
+
+
+class DenseTargetBridge(Node):
+    """ROS subscriber that implements the WBT ``TargetSource`` protocol.
+
+    ``get_target(num_dofs, rl_rate_hz, urdf_path)`` returns the newest
+    ``(motion_command (1, 2*num_dofs), ref_quat_xyzw (4,))`` received on the
+    dense topic, holding the last frame between policy ticks.
+    """
+
+    def __init__(self, num_dofs: int, topic: str = DENSE_TOPIC):
+        super().__init__("holosoma_target_bridge")
+        self._cmd = np.zeros((1, 2 * num_dofs), dtype=np.float32)  # held until first frame
+        self._ref = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)  # xyzw
+        qos = QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT)
+        self.create_subscription(CmdDense, topic, self._cb, qos)
+
+    def _cb(self, msg: CmdDense) -> None:
+        self._cmd = np.concatenate([msg.q, msg.dq]).astype(np.float32).reshape(1, -1)
+        r = msg.root_quat
+        self._ref = np.array([r.x, r.y, r.z, r.w], dtype=np.float32)
+
+    def get_target(self, num_dofs: int, rl_rate_hz: float, urdf_path: str | None):
+        return self._cmd, self._ref

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/launch/teleop_with_loco_policy.launch.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/launch/teleop_with_loco_policy.launch.py
@@ -1,0 +1,101 @@
+"""Live teleop -> locomotion policy, served over ROS2 (Variant A).
+
+    /cmd_vel (Twist) ──────────────▶ policy_service_node ─▶ robot
+    state (joystick or ROS2 String) ─┘  (publishes executed_cmd + heartbeat)
+
+``policy_service_node`` builds the policy the same way ``run_policy.py`` does
+(no extension-only ``policy_type``) and runs it as a ROS2 service. The Unitree
+SDK is run through the ``unitree_mp`` multiprocess proxy automatically (the node
+forces it), so the SDK's CycloneDDS is isolated from this process's rclpy.
+
+Fully parameterized for composition into a larger launch: every knob is a
+``DeclareLaunchArgument`` so a parent launch can override it.
+
+Default config below: velocity over ROS2 ``/cmd_vel`` + state on the native G1
+joystick (so the joystick L1+R1 kill is available). A velocity publisher drives
+motion, e.g. ``demo_scripts/ros2_velocity_publisher.py --pattern shuttle``.
+
+Usage:
+    ros2 launch holosoma_service teleop_with_loco_policy.launch.py \
+        model_path:=/path/model.onnx interface:=eth0
+    # ROS2 state input instead of joystick:
+    ros2 launch holosoma_service teleop_with_loco_policy.launch.py \
+        model_path:=/path/model.onnx state_input:=ros2
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+# Input sources accepted by holosoma_inference's input factory.
+_INPUT_CHOICES = ["ros2", "interface", "joystick", "keyboard", "injected"]
+
+
+def generate_launch_description() -> LaunchDescription:
+    preset = LaunchConfiguration("preset")
+    model = LaunchConfiguration("model_path")
+    interface = LaunchConfiguration("interface")
+    velocity_input = LaunchConfiguration("velocity_input")
+    state_input = LaunchConfiguration("state_input")
+    domain_id = LaunchConfiguration("domain_id")
+    node_name = LaunchConfiguration("node_name")
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "preset",
+                default_value="inference:g1-29dof-loco",
+                description="Inference preset (tyro positional), e.g. inference:g1-29dof-loco.",
+            ),
+            DeclareLaunchArgument("model_path", description="Path to the ONNX policy. Required."),
+            DeclareLaunchArgument(
+                "interface",
+                default_value="eth0",
+                description="Network interface to the robot SDK (e.g. eth0). Use 'auto' to auto-detect.",
+            ),
+            DeclareLaunchArgument(
+                "velocity_input",
+                default_value="ros2",
+                choices=_INPUT_CHOICES,
+                description="Source for velocity commands. Default 'ros2' (/cmd_vel TwistStamped).",
+            ),
+            DeclareLaunchArgument(
+                "state_input",
+                default_value="interface",
+                choices=_INPUT_CHOICES,
+                description="Source for discrete state (start/stop/walk/kill). Default 'interface' "
+                "(native G1 joystick, so L1+R1 kill works). Use 'ros2' for /holosoma/state_input String.",
+            ),
+            DeclareLaunchArgument(
+                "domain_id",
+                default_value="0",
+                description="DDS domain ID for the robot SDK communication.",
+            ),
+            DeclareLaunchArgument(
+                "node_name",
+                default_value="policy_service",
+                description="ROS2 node name (override when composing multiple instances).",
+            ),
+            Node(
+                package="holosoma_service",
+                executable="policy_service_node",
+                name=node_name,
+                # tyro CLI: positional preset + --task.* overrides.
+                arguments=[
+                    preset,
+                    "--task.model-path",
+                    model,
+                    "--task.velocity-input",
+                    velocity_input,
+                    "--task.state-input",
+                    state_input,
+                    "--task.interface",
+                    interface,
+                    "--task.domain-id",
+                    domain_id,
+                ],
+                output="screen",
+            ),
+        ]
+    )

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/setup.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/setup.py
@@ -22,6 +22,7 @@ setup(
     entry_points={
         "console_scripts": [
             "holosoma_node = holosoma_service.policy_control.holosoma_node:main",
+            "policy_service_node = holosoma_service.policy_control.service_node:main",
             "retargeter_node = holosoma_service.retargetting.retargeter_node:main",
             "unitree_split_controller = holosoma_service.unitree_control.unitree_split_controller:_cli",
             "wasd_controller_node = holosoma_service.unitree_control.wasd_controller_node:main",


### PR DESCRIPTION
## Summary

Adds a unified ROS2 **policy service node** that runs *any* holosoma policy (locomotion, WBT, …) and supports runtime policy swapping — the `run_policy.py` experience, served over ROS2. Builds on #124, reusing its `holosoma_service` package, `unitree_mp` multiprocess proxy, `TargetSource`, and `_on_command_sent` feedback hook.

**This is Variant A** (reuse `Ros2Input`): the node touches no shared input code — loco velocity/state ride the existing `Ros2Input`; the node only adds a WBT dense-target bridge and a policy-agnostic feedback publisher. A companion PR proposes Variant B (single node owns all I/O via an `injected` input source) for comparison.

> Base branch is `dev/tomasz/tracker_service` (#124), which this depends on — not `main`.

## What's here

- **`service_node.py`** — builds the policy via `_select_policy_class`/`DualModePolicy` (no extension-only `policy_type`), routes the Unitree SDK through `unitree_mp` (CycloneDDS in a child process, isolated from this process's rclpy), strips ROS args before tyro so `ros2 launch`/`run` work.
- **`feedback.py`** — `PolicyFeedbackPublisher`: policy-agnostic `executed_cmd` + `heartbeat`, driven by the per-tick `_on_command_sent` hook; each node spun on its own `SingleThreadedExecutor`.
- **`target_bridge.py`** — `DenseTargetBridge`: WBT-only `CmdDense` → `TargetSource`, attached only to policies exposing `_target_source` (loco untouched).
- **`teleop_with_loco_policy.launch.py`** — fully parameterized (`velocity_input`/`state_input`/`interface`/`domain_id`/`node_name`) for composition into a parent launch.
- Two small fixes to shared `holosoma_inference`: ROS2 `"kill"` command (parity with joystick L1+R1), and a `hasattr` guard in `dual_mode` so the SWITCH_MODE injection doesn't crash on providers without `_mapping` (ros2/injected).

## Testing

Validated **walking on a real G1** (ROS2 Jazzy) via the `ros2 launch` path: velocity over `/cmd_vel`, state on the native G1 joystick, `executed_cmd` at 50 Hz, `heartbeat` status reflecting the active policy.
