### PR TITLE
Unified policy service node (Variant B: single node owns all I/O)

### DIFF
--- a/src/holosoma_inference/holosoma_inference/config/config_types/task.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_types/task.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic.dataclasses import dataclass
 
-InputSource = Literal["keyboard", "interface", "joystick", "ros2"]
+InputSource = Literal["keyboard", "interface", "joystick", "ros2", "injected"]
 
 DEFAULT_VELOCITY_INPUT: InputSource = "keyboard"
 DEFAULT_STATE_INPUT: InputSource = "keyboard"

--- a/src/holosoma_inference/holosoma_inference/inputs/__init__.py
+++ b/src/holosoma_inference/holosoma_inference/inputs/__init__.py
@@ -14,6 +14,20 @@ if TYPE_CHECKING:
 
 def create_input(policy: BasePolicy, source: InputSource, role: str) -> VelCmdProvider | StateCommandProvider:
     """Create an input provider for the given source and role ("velocity" or "command")."""
+    if source == "injected":
+        # The provider is supplied by an external owner (e.g. a ROS2 service
+        # node that owns all I/O) and attached to the policy before init as
+        # ``_injected_velocity_input`` / ``_injected_command_provider``. The
+        # policy does not construct its own provider in this mode.
+        attr = "_injected_velocity_input" if role == "velocity" else "_injected_command_provider"
+        provider = getattr(policy, attr, None)
+        if provider is None:
+            raise ValueError(
+                f"input source 'injected' requires the owner to set policy.{attr} before init "
+                f"(role={role!r})."
+            )
+        return provider
+
     if not policy.use_joystick and source in ("interface", "joystick"):
         source = "keyboard"
 

--- a/src/holosoma_inference/holosoma_inference/inputs/impl/ros2.py
+++ b/src/holosoma_inference/holosoma_inference/inputs/impl/ros2.py
@@ -23,6 +23,10 @@ ROS2_COMMAND_MAP: dict[str, StateCommand] = {
     "walk": StateCommand.WALK,
     "stand": StateCommand.STAND,
     "switch_mode": StateCommand.SWITCH_MODE,
+    # Emergency exit over ROS2, parity with the joystick L1+R1 kill. Triggers
+    # the policy's KILL handler (sys.exit(0)) so the process stops sending
+    # commands — the in-band kill for ros2/injected state input.
+    "kill": StateCommand.KILL,
 }
 
 

--- a/src/holosoma_inference/holosoma_inference/policies/dual_mode.py
+++ b/src/holosoma_inference/holosoma_inference/policies/dual_mode.py
@@ -81,10 +81,15 @@ class DualModePolicy:
         """
         from holosoma_inference.inputs.api.commands import StateCommand
 
-        # Inject SWITCH_MODE into both command providers' mappings (joystick X, keyboard x)
+        # Inject SWITCH_MODE into both command providers' key mappings (joystick X,
+        # keyboard x). Only keyboard/joystick providers expose ``_mapping``; others
+        # (e.g. injected ROS2 providers, which map the "switch_mode" string to
+        # SWITCH_MODE natively) are intercepted purely via the dispatch patch below.
         for policy in (self.primary, self.secondary):
-            policy._command_provider._mapping["X"] = StateCommand.SWITCH_MODE
-            policy._command_provider._mapping["x"] = StateCommand.SWITCH_MODE
+            mapping = getattr(policy._command_provider, "_mapping", None)
+            if mapping is not None:
+                mapping["X"] = StateCommand.SWITCH_MODE
+                mapping["x"] = StateCommand.SWITCH_MODE
 
         # Patch _dispatch_command to intercept SWITCH_MODE
         self._orig_dispatch = {

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/injected_inputs.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/injected_inputs.py
@@ -1,0 +1,114 @@
+"""Node-owned input provider for Variant B (single rclpy owner).
+
+In Variant B the service node owns *all* ROS2 I/O. Instead of the policy
+constructing its own ``Ros2Input`` (Variant A), the node creates this provider,
+subscribing on a node it owns, and injects it via the ``"injected"`` input
+source (see ``holosoma_inference.inputs.create_input``).
+
+Like ``Ros2Input``, this is a *single* object implementing both
+``VelCmdProvider`` and ``StateCommandProvider`` — so when ``velocity_input`` and
+``state_input`` are both ``injected`` the base policy shares one provider for
+both roles (it reuses the velocity provider as the command provider, which then
+must also expose ``poll_commands``). It does not own a node or spin thread —
+subscriptions are created on the caller-supplied node, which the service node
+spins once. ``start()`` is therefore a no-op.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+import numpy as np
+from loguru import logger
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+
+from holosoma_inference.inputs.api.commands import StateCommand, VelCmd
+from holosoma_inference.inputs.impl.ros2 import ROS2_COMMAND_MAP
+
+CMD_VEL_TOPIC = "cmd_vel"
+STATE_INPUT_TOPIC = "holosoma/state_input"
+
+
+class InjectedRos2Input:
+    """Combined vel + state provider backed by subscriptions on a shared node.
+
+    Subscribes a TwistStamped topic for velocity and a String topic for discrete
+    state commands, both on the caller-supplied node (the service node owns the
+    single spin thread). Mirrors ``Ros2Input``'s semantics: velocity clamped to
+    [-1, 1] with timeout-zeroing; state strings mapped via ``ROS2_COMMAND_MAP``
+    (including ``"switch_mode"`` -> ``SWITCH_MODE`` for the dual-mode swap).
+    """
+
+    def __init__(
+        self,
+        node: Node,
+        vel_topic: str = CMD_VEL_TOPIC,
+        cmd_topic: str = STATE_INPUT_TOPIC,
+        vel_timeout: float = 1.0,
+    ):
+        from geometry_msgs.msg import TwistStamped
+        from std_msgs.msg import String
+
+        self._vel_timeout = vel_timeout
+        self._lin_vel = np.zeros((1, 2))
+        self._ang_vel = np.zeros((1, 1))
+        self._last_vel_time: float = 0.0
+        self._lock = threading.Lock()
+        self._queue: deque[StateCommand] = deque()
+
+        # Newest-wins velocity (depth=1, BEST_EFFORT) suits a 50 Hz teleop loop;
+        # state commands are reliable + queued so none are dropped.
+        vel_qos = QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT)
+        node.create_subscription(TwistStamped, vel_topic, self._vel_callback, vel_qos)
+        node.create_subscription(String, cmd_topic, self._cmd_callback, 10)
+        logger.info(f"Injected ROS2 input subscribed to velocity: {vel_topic}, commands: {cmd_topic}")
+
+    def start(self) -> None:
+        """No-op: the service node owns the subscriptions + spin thread."""
+
+    # --- velocity ---
+    def _vel_callback(self, msg):
+        with self._lock:
+            self._lin_vel[0, 0] = max(-1.0, min(1.0, msg.twist.linear.x))
+            self._lin_vel[0, 1] = max(-1.0, min(1.0, msg.twist.linear.y))
+            self._ang_vel[0, 0] = max(-1.0, min(1.0, msg.twist.angular.z))
+            self._last_vel_time = time.monotonic()
+
+    def zero(self) -> None:
+        with self._lock:
+            self._lin_vel[:] = 0.0
+            self._ang_vel[:] = 0.0
+
+    def poll_velocity(self) -> VelCmd:
+        with self._lock:
+            if (
+                self._vel_timeout > 0
+                and self._last_vel_time > 0
+                and (time.monotonic() - self._last_vel_time) > self._vel_timeout
+            ):
+                self._lin_vel[:] = 0.0
+                self._ang_vel[:] = 0.0
+                self._last_vel_time = 0.0
+                logger.warning("Velocity timeout — zeroing commands")
+            return VelCmd(
+                (float(self._lin_vel[0, 0]), float(self._lin_vel[0, 1])),
+                float(self._ang_vel[0, 0]),
+            )
+
+    # --- state commands ---
+    def _cmd_callback(self, msg):
+        cmd_str = msg.data.strip().lower()
+        cmd = ROS2_COMMAND_MAP.get(cmd_str)
+        if cmd is not None:
+            self._queue.append(cmd)
+        else:
+            logger.warning(f"ROS2 command: unknown command '{cmd_str}'")
+
+    def poll_commands(self) -> list[StateCommand]:
+        commands: list[StateCommand] = []
+        while self._queue:
+            commands.append(self._queue.popleft())
+        return commands

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/service_node.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/service_node.py
@@ -1,0 +1,260 @@
+"""Unified policy service node (Variant B — single rclpy owner).
+
+Runs *any* holosoma policy (locomotion, WBT, …) as a ROS2 service and supports
+runtime policy swapping — the ``run_policy.py`` experience served over ROS2.
+
+Variant B differs from Variant A in *who owns the ROS2 I/O*: here the service
+node owns a single ``ServiceIONode`` that carries every subscription and
+publisher — velocity Twist, state String, dense tracking target, and the
+executed-cmd/heartbeat feedback — and is spun once. The locomotion policy does
+not construct its own ``Ros2Input``; instead the node builds the velocity +
+state providers and injects them via the ``"injected"`` input source.
+
+    /cmd_vel + /…/state_input ─▶ (injected vel/state providers) ─┐
+    /…/dense_tracking_command ─▶ (dense target, WBT only)        ├─▶ policy.run() ─▶ robot
+                                  swap via SWITCH_MODE ───────────┘
+                                  every tick ─▶ executed_cmd + heartbeat
+                              ── all on ONE node, ONE spin thread ──
+
+The policy is built like ``run_policy.py`` (``_select_policy_class`` /
+``DualModePolicy``); injected providers are attached *before* ``__init__`` runs
+(the base policy creates its providers during construction). In dual-mode only
+the primary needs injection — the secondary reuses the primary's providers via
+``_shared_hardware_source``.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from dataclasses import replace
+
+import numpy as np
+import rclpy
+import tyro
+from holosoma_msgs.msg import CmdDense, Heartbeat
+from loguru import logger
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import JointState
+
+from holosoma_inference.config.config_values.inference import get_annotated_inference_config
+from holosoma_inference.config.utils import TYRO_CONFIG
+from holosoma_inference.policies.dual_mode import DualModePolicy, _select_policy_class
+
+from holosoma_service.policy_control.injected_inputs import (
+    CMD_VEL_TOPIC,
+    STATE_INPUT_TOPIC,
+    InjectedRos2Input,
+)
+
+DENSE_TOPIC = "/holosoma/dense_tracking_command"
+EXECUTED_CMD_TOPIC = "/holosoma/holosoma_executed_cmd"
+HEARTBEAT_TOPIC = "/holosoma/heartbeat"
+HEARTBEAT_EVERY = 10  # control ticks -> 5 Hz at a 50 Hz control loop
+
+# This node loads rclpy in-process, which clashes with the Unitree SDK's bundled
+# CycloneDDS (heap corruption / "free(): invalid pointer" at SDK init). The
+# multiprocess interface ("unitree_mp", added by PR #124) runs the low-level
+# binding in a spawned child so DDS never shares the parent's rclpy address
+# space. Map the in-process SDK -> its isolated variant for any service run.
+_MP_SDK_MAP = {"unitree": "unitree_mp"}
+
+
+class ServiceIONode(Node):
+    """Single node owning all ROS2 I/O for the policy service (Variant B).
+
+    Holds the injected velocity/state providers, an optional dense target
+    source (WBT only), and the executed-cmd/heartbeat feedback publishers — all
+    on one node, spun once.
+    """
+
+    def __init__(self, num_dofs: int, vel_timeout: float = 1.0):
+        super().__init__("policy_service")
+        # --- Input: one combined vel+state provider (subscribes on THIS node) ---
+        # A single object implements both protocols, mirroring Ros2Input, so the
+        # base policy can share it for both roles when velocity_input ==
+        # state_input == "injected".
+        self.input = InjectedRos2Input(self, CMD_VEL_TOPIC, STATE_INPUT_TOPIC, vel_timeout=vel_timeout)
+
+        # --- Input: dense tracking target (WBT only); attached on demand ---
+        self._cmd = np.zeros((1, 2 * num_dofs), dtype=np.float32)  # held until first frame
+        self._ref = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)  # xyzw
+        qos = QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT)
+        self.create_subscription(CmdDense, DENSE_TOPIC, self._dense_cb, qos)
+
+        # --- Output: feedback publishers ---
+        self.dof_names: list[str] = []
+        self._cmd_pub = self.create_publisher(JointState, EXECUTED_CMD_TOPIC, 10)
+        self._hb_pub = self.create_publisher(Heartbeat, HEARTBEAT_TOPIC, 10)
+        self._tick = 0
+
+    # --- dense TargetSource protocol (WBT) ---
+    def _dense_cb(self, msg: CmdDense) -> None:
+        self._cmd = np.concatenate([msg.q, msg.dq]).astype(np.float32).reshape(1, -1)
+        r = msg.root_quat
+        self._ref = np.array([r.x, r.y, r.z, r.w], dtype=np.float32)
+
+    def get_target(self, num_dofs: int, rl_rate_hz: float, urdf_path: str | None):
+        return self._cmd, self._ref
+
+    # --- feedback, driven by the policy's per-tick hook ---
+    def on_command_sent(self, policy, cmd_q) -> None:
+        cmd = np.asarray(cmd_q, dtype=np.float64).reshape(-1)
+        msg = JointState()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        if len(self.dof_names) == cmd.shape[0]:
+            msg.name = self.dof_names
+        msg.position = cmd.tolist()
+        self._cmd_pub.publish(msg)
+
+        if self._tick % HEARTBEAT_EVERY == 0:
+            hb = Heartbeat()
+            hb.header.stamp = msg.header.stamp
+            hb.robot_connected = getattr(policy, "interface", None) is not None
+            hb.control_mode = 0
+            if getattr(policy, "use_policy_action", False):
+                hb.status = "running"
+            elif getattr(policy, "get_ready_state", False):
+                hb.status = "get_ready"
+            else:
+                hb.status = "stiff_hold"
+            self._hb_pub.publish(hb)
+        self._tick += 1
+
+    def make_hook(self, policy):
+        def _hook(cmd_q, _state, _p=policy):
+            self.on_command_sent(_p, cmd_q)
+
+        return _hook
+
+
+def _iter_policies(policy):
+    """Yield the underlying policy instance(s): primary+secondary for dual-mode."""
+    if isinstance(policy, DualModePolicy):
+        yield policy.primary
+        if policy.secondary is not None:
+            yield policy.secondary
+    else:
+        yield policy
+
+
+def _new_with_injected(cls, config, io: ServiceIONode):
+    """Construct ``cls`` with injected providers attached before ``__init__``.
+
+    The base policy builds its input providers during construction, so the
+    ``_injected_*`` attributes must exist beforehand (see
+    ``holosoma_inference.inputs.create_input`` 'injected' branch).
+    """
+    p = object.__new__(cls)
+    p._injected_velocity_input = io.input
+    p._injected_command_provider = io.input
+    p.__init__(config=config)
+    return p
+
+
+def _build_policy(config, io: ServiceIONode):
+    """Build the policy like run_policy.py, but with node-owned injected inputs.
+
+    For dual-mode, only the primary takes injected providers; the secondary
+    reuses them via ``_shared_hardware_source`` (matching DualModePolicy).
+    """
+    if config.secondary is not None:
+        # Replicate DualModePolicy's construction with injection into primary.
+        dm = object.__new__(DualModePolicy)
+        primary_cls = _select_policy_class(config)
+        secondary_cls = _select_policy_class(config.secondary)
+        logger.info(f"Dual-mode: primary={primary_cls.__name__}, secondary={secondary_cls.__name__}")
+        dm.primary = _new_with_injected(primary_cls, config, io)
+        secondary = object.__new__(secondary_cls)
+        secondary._shared_hardware_source = dm.primary
+        secondary.__init__(config=config.secondary)
+        dm.secondary = secondary
+        dm.active = dm.primary
+        dm.active_label = "primary"
+        dm._setup_command_intercept()
+        logger.info("Dual-mode ready. Publish 'switch_mode' to swap policies.")
+        return dm
+
+    policy_class = _select_policy_class(config)
+    logger.info(f"Using {policy_class.__name__}")
+    return _new_with_injected(policy_class, config, io)
+
+
+def _attach_target_source(policy, io: ServiceIONode) -> None:
+    """Attach the node as the target source of every WBT-style policy."""
+    for p in _iter_policies(policy):
+        if hasattr(p, "_target_source"):
+            p._target_source = io
+            logger.info(f"Attached dense target source to {type(p).__name__}")
+
+
+def _wire_feedback(policy, io: ServiceIONode) -> None:
+    """Wire the feedback publisher into each policy's per-tick hook."""
+    for p in _iter_policies(policy):
+        p._on_command_sent = io.make_hook(p)
+
+
+def _dof_names(policy) -> list[str]:
+    p = next(_iter_policies(policy))
+    return list(getattr(p, "dof_names", []))
+
+
+def _use_mp_sdk(config):
+    """Force the rclpy-safe multiprocess SDK interface (DDS in a child process).
+
+    Rewrites ``robot.sdk_type`` to its isolated variant (e.g. unitree ->
+    unitree_mp) on the config and its secondary. A no-op for SDK types without
+    a known isolated variant (e.g. already _mp, or booster), so an explicit
+    override survives.
+    """
+    new_type = _MP_SDK_MAP.get(config.robot.sdk_type)
+    if new_type is None:
+        return config
+    logger.info(f"Service node: using multiprocess SDK '{new_type}' (rclpy/DDS isolation)")
+    config = replace(config, robot=replace(config.robot, sdk_type=new_type))
+    if config.secondary is not None:
+        config = replace(config, secondary=_use_mp_sdk(config.secondary))
+    return config
+
+
+def main() -> None:
+    # Under `ros2 launch` / `ros2 run`, argv carries ROS args (e.g.
+    # "--ros-args -r __node:=..."). tyro would reject those, so strip them
+    # before parsing this node's own CLI; rclpy.init() consumes them separately.
+    from rclpy.utilities import remove_ros_args
+
+    sys.argv = remove_ros_args(args=sys.argv)
+
+    config = tyro.cli(get_annotated_inference_config(), config=TYRO_CONFIG)
+    rclpy.init()
+
+    # Route the Unitree SDK through its multiprocess proxy so its CycloneDDS
+    # never shares this process's rclpy (otherwise SDK init heap-corrupts).
+    config = _use_mp_sdk(config)
+
+    # One node owns every subscription + publisher.
+    io = ServiceIONode(config.robot.num_joints, vel_timeout=config.task.ros_vel_timeout)
+
+    # Build the policy with node-owned injected vel/state providers.
+    policy = _build_policy(config, io)
+
+    # WBT target source (no-op for loco) + policy-agnostic feedback.
+    _attach_target_source(policy, io)
+    io.dof_names = _dof_names(policy)
+    _wire_feedback(policy, io)
+
+    # Single spin thread for the one node.
+    threading.Thread(target=rclpy.spin, args=(io,), daemon=True).start()
+
+    logger.info("PolicyServiceNode (Variant B) ready — running policy.")
+    try:
+        policy.run()  # owns its RateLimiter + SDK I/O; blocks in this thread
+    except KeyboardInterrupt:
+        pass
+    finally:
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/launch/teleop_with_loco_policy.launch.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/launch/teleop_with_loco_policy.launch.py
@@ -1,0 +1,104 @@
+"""Live teleop -> locomotion policy, served over ROS2 (Variant B).
+
+    /cmd_vel (Twist) ──────────────▶ ServiceIONode ─▶ policy ─▶ robot
+    /holosoma/state_input (String) ──┘  (one node owns ALL ROS2 I/O;
+                                         publishes executed_cmd + heartbeat)
+
+``policy_service_node`` builds the policy the same way ``run_policy.py`` does
+and runs it as a ROS2 service. Unlike Variant A, a single ``ServiceIONode`` owns
+every subscription/publisher and injects the velocity+state providers into the
+policy (input source ``injected``). The Unitree SDK runs through the
+``unitree_mp`` multiprocess proxy automatically (the node forces it), isolating
+its CycloneDDS from this process's rclpy.
+
+Fully parameterized for composition into a larger launch: every knob is a
+``DeclareLaunchArgument`` so a parent launch can override it.
+
+State commands (start/stop/walk/kill) arrive on ``/holosoma/state_input`` as
+Strings; the in-band emergency kill is
+``ros2 topic pub /holosoma/state_input std_msgs/String "{data: kill}"``. Velocity
+is driven by e.g. ``demo_scripts/ros2_velocity_publisher.py --pattern shuttle``.
+
+Usage:
+    ros2 launch holosoma_service teleop_with_loco_policy.launch.py \
+        model_path:=/path/model.onnx interface:=eth0
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+# Input sources accepted by holosoma_inference's input factory.
+_INPUT_CHOICES = ["ros2", "interface", "joystick", "keyboard", "injected"]
+
+
+def generate_launch_description() -> LaunchDescription:
+    preset = LaunchConfiguration("preset")
+    model = LaunchConfiguration("model_path")
+    interface = LaunchConfiguration("interface")
+    velocity_input = LaunchConfiguration("velocity_input")
+    state_input = LaunchConfiguration("state_input")
+    domain_id = LaunchConfiguration("domain_id")
+    node_name = LaunchConfiguration("node_name")
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "preset",
+                default_value="inference:g1-29dof-loco",
+                description="Inference preset (tyro positional), e.g. inference:g1-29dof-loco.",
+            ),
+            DeclareLaunchArgument("model_path", description="Path to the ONNX policy. Required."),
+            DeclareLaunchArgument(
+                "interface",
+                default_value="eth0",
+                description="Network interface to the robot SDK (e.g. eth0). Use 'auto' to auto-detect.",
+            ),
+            DeclareLaunchArgument(
+                "velocity_input",
+                default_value="injected",
+                choices=_INPUT_CHOICES,
+                description="Source for velocity commands. Variant B default 'injected' "
+                "(node-owned /cmd_vel subscription).",
+            ),
+            DeclareLaunchArgument(
+                "state_input",
+                default_value="injected",
+                choices=_INPUT_CHOICES,
+                description="Source for discrete state (start/stop/walk/kill). Variant B default "
+                "'injected' (node-owned /holosoma/state_input String; 'kill' triggers exit). "
+                "Use 'interface' for the native G1 joystick (L1+R1 kill).",
+            ),
+            DeclareLaunchArgument(
+                "domain_id",
+                default_value="0",
+                description="DDS domain ID for the robot SDK communication.",
+            ),
+            DeclareLaunchArgument(
+                "node_name",
+                default_value="policy_service",
+                description="ROS2 node name (override when composing multiple instances).",
+            ),
+            Node(
+                package="holosoma_service",
+                executable="policy_service_node",
+                name=node_name,
+                # tyro CLI: positional preset + --task.* overrides.
+                arguments=[
+                    preset,
+                    "--task.model-path",
+                    model,
+                    "--task.velocity-input",
+                    velocity_input,
+                    "--task.state-input",
+                    state_input,
+                    "--task.interface",
+                    interface,
+                    "--task.domain-id",
+                    domain_id,
+                ],
+                output="screen",
+            ),
+        ]
+    )

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/setup.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/setup.py
@@ -22,6 +22,7 @@ setup(
     entry_points={
         "console_scripts": [
             "holosoma_node = holosoma_service.policy_control.holosoma_node:main",
+            "policy_service_node = holosoma_service.policy_control.service_node:main",
             "retargeter_node = holosoma_service.retargetting.retargeter_node:main",
             "unitree_split_controller = holosoma_service.unitree_control.unitree_split_controller:_cli",
             "wasd_controller_node = holosoma_service.unitree_control.wasd_controller_node:main",


### PR DESCRIPTION
## Summary

Adds a unified ROS2 **policy service node** that runs *any* holosoma policy (locomotion, WBT, …) and supports runtime policy swapping — the `run_policy.py` experience, served over ROS2. Builds on #124, reusing its `holosoma_service` package, `unitree_mp` multiprocess proxy, `TargetSource`, and `_on_command_sent` feedback hook.

**This is Variant B** (single node owns all I/O): a single `ServiceIONode` owns *every* subscription/publisher — velocity, state, dense target, and feedback — and injects the input providers into the policy via a new `injected` input source. A companion PR proposes Variant A (reuse `Ros2Input`, no shared-input changes); pick one.

> Base branch is `dev/tomasz/tracker_service` (#124), which this depends on — not `main`.

## What's here

- **`injected` input source** (shared `holosoma_inference`): `create_input` returns a provider pre-attached by an external owner (`policy._injected_*`) instead of constructing one; `InputSource` enum gains `"injected"`.
- **`injected_inputs.py`** — `InjectedRos2Input`: one object implementing both `VelCmdProvider` and `StateCommandProvider` (like `Ros2Input`), subscribing on the node the service owns. Single object is required because the base policy shares one provider for both roles when `velocity_input == state_input`.
- **`service_node.py`** — `ServiceIONode` carries all I/O on one node spun once; builds the policy via `_select_policy_class`/`DualModePolicy` injecting providers before `__init__` (dual-mode injects primary; secondary shares via `_shared_hardware_source`). Routes the Unitree SDK through `unitree_mp`; strips ROS args before tyro.
- **`teleop_with_loco_policy.launch.py`** — fully parameterized for composition into a parent launch.
- Same two shared fixes as the companion PR: ROS2 `"kill"` command + `dual_mode` `hasattr` guard.

## Variant A vs B

- **A** touches no shared input code (smaller blast radius); reuses `Ros2Input`. Two rclpy nodes coexist.
- **B** (this PR) is more unified — one node owns all topics, easiest to extend — at the cost of a new `injected` source in shared `inputs/`.

## Testing

Validated **walking on a real G1** (ROS2 Jazzy) via the `ros2 launch` path: velocity over `/cmd_vel`, state on the native G1 joystick, `executed_cmd` at 50 Hz, `heartbeat` status reflecting the active policy.
