### PR TITLE
feat(sensors): add Ros2DepthConsumerConfig.frame_delay_ms (configurable depth delay)

### DIFF
--- a/src/holosoma_inference/holosoma_inference/config/config_types/task.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_types/task.py
@@ -53,6 +53,17 @@ class Ros2DepthConsumerConfig:
     far_clip: float = 2.0
     """Far clip (m); depth is normalized to [-0.5, 0.5] over [near, far]."""
 
+    frame_delay_ms: float = 0.0
+    """Modeled depth latency to re-introduce, in absolute milliseconds.
+
+    The ROS2 depth transport is effectively instantaneous (sub-1ms), but the
+    policy was trained with the on-robot image_server's inherent capture/serve
+    latency baked in. ``get_latest()`` holds back frames so it returns the
+    freshest frame at least this old, reproducing that delay independent of
+    publish rate (a fixed ms value is robust across fps, unlike a frame count).
+    ``0.0`` (default) keeps freshest-frame behavior. Pin this per-policy from a
+    preset to match the delay the model was trained with (e.g. ``200.0``)."""
+
 
 @dataclass(frozen=True)
 class TaskConfig:

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/sensors.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/sensors.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import deque
 
 import cv2
 import numpy as np
@@ -60,6 +61,13 @@ class Ros2DepthConsumer(Sensor):
     arrived and while the latest set is older than ``timeout`` seconds, so the
     policy can zero the observation rather than feed a stale/partial stack.
 
+    ``frame_delay_ms`` re-introduces the depth latency the policy trained with.
+    The ROS2 transport is effectively instantaneous, so without this the policy
+    would see fresher frames than it did in training. When set, the consumer
+    buffers timestamped frame sets and ``get_latest()`` returns the freshest set
+    at least ``frame_delay_ms`` old — a fixed wall-clock delay that is robust to
+    the publish rate. ``0.0`` (default) returns the freshest set, as before.
+
     The publisher must produce ``32FC1`` images; a wrong encoding is logged and
     that frame set is dropped.
     """
@@ -78,17 +86,24 @@ class Ros2DepthConsumer(Sensor):
         near_clip: float = 0.1,
         far_clip: float = 2.0,
         timeout: float = 0.5,
+        frame_delay_ms: float = 0.0,
     ):
         if not topics:
             raise ValueError("Ros2DepthConsumer requires at least one topic")
+        if frame_delay_ms < 0:
+            raise ValueError(f"frame_delay_ms must be >= 0, got {frame_delay_ms}")
         self._topics = list(topics)
         self._resized_height = resized_height
         self._resized_width = resized_width
         self._near_clip = near_clip
         self._far_clip = far_clip
         self._timeout = timeout
-        self._latest: np.ndarray | None = None  # (N, 1, H, W)
-        self._stamp: float = 0.0
+        self._frame_delay_s = frame_delay_ms / 1000.0
+        # Ring buffer of (monotonic_stamp, (N, 1, H, W)) sets, newest last. A
+        # depth of 1 reproduces the original freshest-frame behavior; otherwise
+        # we keep enough history to look back ``frame_delay_ms``. The publish
+        # rate is unknown here, so size generously and cap by age, not count.
+        self._buffer: deque[tuple[float, np.ndarray]] = deque(maxlen=128)
         self._lock = threading.Lock()
 
         qos = QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT)
@@ -104,7 +119,8 @@ class Ros2DepthConsumer(Sensor):
             f"Ros2DepthConsumer subscribed to {len(self._topics)} camera(s): "
             f"{self._topics} (encoding={self.EXPECTED_ENCODING}, "
             f"resize={self._resized_height}x{self._resized_width}, "
-            f"clip=[{self._near_clip}, {self._far_clip}]"
+            f"clip=[{self._near_clip}, {self._far_clip}], "
+            f"frame_delay={frame_delay_ms}ms"
             f"{'' if len(self._topics) == 1 else f', sync slop={self.SYNC_SLOP_S}s'})"
         )
 
@@ -122,8 +138,7 @@ class Ros2DepthConsumer(Sensor):
         # Each raw (H_raw, W_raw) -> preprocessed (1, H, W) -> stack to (N, 1, H, W).
         stacked = np.stack([self._preprocess(f) for f in frames], axis=0)
         with self._lock:
-            self._latest = stacked
-            self._stamp = time.monotonic()
+            self._buffer.append((time.monotonic(), stacked))
 
     def _single_cb(self, msg: Image) -> None:
         frame = _decode_depth(msg, self._topics[0])
@@ -137,10 +152,25 @@ class Ros2DepthConsumer(Sensor):
         self._store(frames)
 
     def get_latest(self) -> np.ndarray | None:
-        """Return ``(N, 1, H, W)`` float32 array, or ``None`` if absent/stale."""
+        """Return ``(N, 1, H, W)`` float32 array, or ``None`` if absent/stale.
+
+        With ``frame_delay_ms == 0`` this is the freshest set. Otherwise it is
+        the freshest set at least ``frame_delay_ms`` old; ``None`` if not enough
+        history has accumulated yet to honor the delay.
+        """
+        now = time.monotonic()
         with self._lock:
-            if self._latest is None:
+            if not self._buffer:
                 return None
-            if self._timeout > 0 and (time.monotonic() - self._stamp) > self._timeout:
+            # Stream liveness is measured against the newest set: if even that
+            # is older than ``timeout``, the publisher has stopped — zero the
+            # obs. (The delayed set is expected to lag, so don't time it out.)
+            newest_stamp, _ = self._buffer[-1]
+            if self._timeout > 0 and (now - newest_stamp) > self._timeout:
                 return None
-            return self._latest.copy()
+            # Walk newest -> oldest for the first set at least frame_delay old.
+            target = now - self._frame_delay_s
+            for stamp, frame in reversed(self._buffer):
+                if stamp <= target:
+                    return frame.copy()
+            return None

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/service_node.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/service_node.py
@@ -96,6 +96,7 @@ class ServiceIONode(Node):
                 resized_width=depth_cfg.resized_width,
                 near_clip=depth_cfg.near_clip,
                 far_clip=depth_cfg.far_clip,
+                frame_delay_ms=depth_cfg.frame_delay_ms,
             )
 
         # --- Input: dense tracking target (WBT only); attached on demand ---

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/test_depth_consumer_delay.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/test_depth_consumer_delay.py
@@ -1,0 +1,109 @@
+"""Unit tests for ``Ros2DepthConsumer`` frame-delay buffering.
+
+These exercise the ``frame_delay_ms`` look-back path without ROS traffic by
+driving ``_store`` directly and stubbing the monotonic clock, so they cover the
+selection logic (``get_latest`` returns the freshest set at least the configured
+delay old) independent of any publisher.
+
+``sensors`` imports cv2/message_filters/rclpy/numpy at module load, so skip
+cleanly when those aren't present (host env); the bazel pytest_test target has
+them.
+"""
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("cv2")
+pytest.importorskip("rclpy")
+pytest.importorskip("message_filters")
+
+import numpy as np
+
+from holosoma_service.policy_control import sensors
+from holosoma_service.policy_control.sensors import Ros2DepthConsumer
+
+
+class _FakeNode:
+    """Records subscriptions; ApproximateTimeSynchronizer is never invoked."""
+
+    def create_subscription(self, *args, **kwargs):
+        return object()
+
+
+def _make(monkeypatch, frame_delay_ms, clock):
+    """Build a single-camera consumer with a controllable monotonic clock.
+
+    ``clock`` is a one-element list holding the current fake time; tests mutate
+    ``clock[0]`` to advance it. Patches ``time.monotonic`` in the sensors module.
+    """
+    monkeypatch.setattr(sensors.time, "monotonic", lambda: clock[0])
+    return Ros2DepthConsumer(
+        _FakeNode(),
+        topics=["/depth"],
+        resized_height=4,
+        resized_width=4,
+        timeout=0.0,  # disable staleness gating; isolate the delay logic
+        frame_delay_ms=frame_delay_ms,
+    )
+
+
+def _push(consumer, value):
+    """Store a frame whose pixels are all ``value`` so we can identify it."""
+    consumer._store([np.full((4, 4), float(value), dtype=np.float32)])
+
+
+def test_zero_delay_returns_freshest(monkeypatch):
+    clock = [0.0]
+    c = _make(monkeypatch, frame_delay_ms=0.0, clock=clock)
+    _push(c, 1)
+    clock[0] = 0.1
+    _push(c, 2)
+    out = c.get_latest()
+    assert out is not None
+    # value 2 was the most recent; normalize() shifts values, so compare the
+    # newest stored set rather than raw pixels.
+    assert np.array_equal(out, c._buffer[-1][1])
+
+
+def test_delay_returns_older_frame(monkeypatch):
+    clock = [0.0]
+    c = _make(monkeypatch, frame_delay_ms=200.0, clock=clock)
+    _push(c, 1)  # t=0.0
+    clock[0] = 0.1
+    _push(c, 2)  # t=0.1
+    clock[0] = 0.25
+    _push(c, 3)  # t=0.25
+    # now=0.25, target=0.25-0.2=0.05 -> freshest set at/under 0.05 is the t=0.0 one.
+    out = c.get_latest()
+    assert out is not None
+    assert np.array_equal(out, c._buffer[0][1])
+
+
+def test_delay_none_until_enough_history(monkeypatch):
+    clock = [0.0]
+    c = _make(monkeypatch, frame_delay_ms=200.0, clock=clock)
+    _push(c, 1)  # t=0.0
+    clock[0] = 0.05  # only 50ms elapsed; nothing is 200ms old yet
+    assert c.get_latest() is None
+
+
+def test_empty_buffer_returns_none(monkeypatch):
+    clock = [0.0]
+    c = _make(monkeypatch, frame_delay_ms=0.0, clock=clock)
+    assert c.get_latest() is None
+
+
+def test_timeout_zeros_on_dead_stream(monkeypatch):
+    clock = [0.0]
+    monkeypatch.setattr(sensors.time, "monotonic", lambda: clock[0])
+    c = Ros2DepthConsumer(
+        _FakeNode(), topics=["/depth"], resized_height=4, resized_width=4, timeout=0.5
+    )
+    _push(c, 1)
+    clock[0] = 1.0  # newest set is now 1s old, past the 0.5s timeout
+    assert c.get_latest() is None
+
+
+def test_negative_delay_rejected():
+    with pytest.raises(ValueError):
+        Ros2DepthConsumer(_FakeNode(), topics=["/depth"], frame_delay_ms=-1.0)


### PR DESCRIPTION
Stacks on #124. Adds a configurable depth latency to `Ros2DepthConsumer`

## Why
Requested frame_delay_ms feature

## What
- **`task.py`** — `Ros2DepthConsumerConfig.frame_delay_ms: float = 0.0`. Default `0.0` preserves current freshest-frame behavior, so existing consumers are unaffected.
- **`sensors.py`** — `Ros2DepthConsumer` buffers timestamped frame sets in a ring buffer; `get_latest()` returns the freshest set **at least `frame_delay_ms` old** (`None` until enough history accrues to honor the delay). The stream-liveness `timeout` is measured against the *newest* set, so an intentional delay is never mistaken for a dead publisher.
- **`service_node.py`** — threads `frame_delay_ms` off `task.depth` into the consumer constructor (same path the other depth config fields take).
- **`test_depth_consumer_delay.py`** — unit tests for the look-back selection (stubbed monotonic clock, no ROS traffic; `importorskip` for host envs).