### PR TITLE
fix(test): satisfy ruff in test_depth_consumer_delay

### DIFF
--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/test_depth_consumer_delay.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/policy_control/test_depth_consumer_delay.py
@@ -96,14 +96,12 @@ def test_empty_buffer_returns_none(monkeypatch):
 def test_timeout_zeros_on_dead_stream(monkeypatch):
     clock = [0.0]
     monkeypatch.setattr(sensors.time, "monotonic", lambda: clock[0])
-    c = Ros2DepthConsumer(
-        _FakeNode(), topics=["/depth"], resized_height=4, resized_width=4, timeout=0.5
-    )
+    c = Ros2DepthConsumer(_FakeNode(), topics=["/depth"], resized_height=4, resized_width=4, timeout=0.5)
     _push(c, 1)
     clock[0] = 1.0  # newest set is now 1s old, past the 0.5s timeout
     assert c.get_latest() is None
 
 
 def test_negative_delay_rejected():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="frame_delay_ms must be >= 0"):
         Ros2DepthConsumer(_FakeNode(), topics=["/depth"], frame_delay_ms=-1.0)


### PR DESCRIPTION
Follow-up to #135: the Static Checks job flagged two ruff issues in the new test that the merge didn't block on.

- `pytest.raises(ValueError)` -> added `match=` (PT011)
- collapsed the multiline `Ros2DepthConsumer(...)` call (ruff-format)

Test-only; no behavior change.