### PR TITLE
Add Integration Tests for the holosoma service API

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -102,3 +102,20 @@ jobs:
           source scripts/source_isaacsim_setup.sh
           pip install -e src/holosoma_inference
           pytest -s src/holosoma_inference/
+
+  service-integration-tests:
+    # The service's contract is its ROS2 topic API, so these run in a real ROS2
+    # Jazzy workspace (the inference-tests env above has no rclpy/colcon and
+    # would only skip them). Builds the minimal test image and runs it.
+    name: Run Service Integration Tests (ROS2)
+    runs-on: codebuild-holosoma-cpu-build-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Build service test image
+        run: |
+          docker build \
+            -f src/holosoma_inference/holosoma_inference_service/docker/Dockerfile.test \
+            -t holosoma-service-test .
+      - name: Run service integration tests
+        run: docker run --rm holosoma-service-test

--- a/src/holosoma_inference/holosoma_inference_service/docker/Dockerfile.test
+++ b/src/holosoma_inference/holosoma_inference_service/docker/Dockerfile.test
@@ -1,0 +1,95 @@
+# syntax=docker/dockerfile:1.7
+#
+# Minimal image to run the holosoma_service ROS2-native integration tests.
+#
+# It builds the two service packages into a colcon workspace and runs pytest
+# against the topic-API contract (see retargetting/test_retargeter_service_api.py).
+# Kept deliberately small: ROS 2 Jazzy base + only the Python deps the retargeter
+# pulls in (mink/mujoco/scipy/numpy) + editable holosoma_inference. No unitree
+# SDK, no ONNX policy, no CUDA — the retargeter test needs none of them.
+#
+# Build (context = repo root):
+#   docker build -f src/holosoma_inference/holosoma_inference_service/docker/Dockerfile.test \
+#     -t holosoma-service-test .
+#
+# Run the tests:
+#   docker run --rm holosoma-service-test
+#
+# ros:jazzy is Ubuntu 24.04 (Noble) native, Python 3.12 — matches the
+# hsmujoco_py312 dev env the tests are validated against.
+FROM ros:jazzy-ros-base
+
+ENV LANG=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+# rclpy on FastDDS; keeps this image free of the CycloneDDS ABI dance the
+# unitree SDK needs (the retargeter test doesn't load the unitree SDK).
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+
+# colcon + venv support for the ament_python service package.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-colcon-common-extensions \
+    python3-pip \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY src/holosoma_inference /ws/src/holosoma_inference
+# holosoma_retargeting ships the g1_29dof.xml MJCF the retargeter IK loads (the
+# test's fixture). Copied for the model assets only; not built as a package.
+COPY src/holosoma_retargeting /ws/src/holosoma_retargeting
+
+# Build the two packages the test needs with the SYSTEM python (before the venv
+# is on PATH): holosoma_msgs (the CmdSMPLH/CmdDense IDL) and holosoma_service
+# (the node + retargeter entry point). The rosidl C++ typesupport generator
+# segfaults if a newer venv numpy shadows the ROS image's numpy during msg
+# codegen, so message generation must run against the stock system interpreter.
+WORKDIR /ws/service
+RUN . /opt/ros/jazzy/setup.sh \
+    && colcon build --paths \
+        /ws/src/holosoma_inference/holosoma_inference_service/holosoma_msgs \
+        /ws/src/holosoma_inference/holosoma_inference_service/holosoma_service
+
+# Now a venv (with --system-site-packages so the ROS Python stack + the built
+# overlay stay visible) for the test runtime deps. pip manages its own numpy
+# here without disturbing the already-built messages.
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv --system-site-packages $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Python deps. holosoma_inference is installed --no-deps (we only need the
+# retargeter's transitive imports, not the full policy/onnx/unitree stack), so
+# list exactly what smpl_retargeter + the node import at runtime.
+#   mink+mujoco  -> IK solve; scipy -> rotations; numpy -> arrays;
+#   pyyaml/loguru/pydantic/tyro -> imported on the holosoma_inference path.
+RUN pip install --no-cache-dir \
+    "mink" \
+    "mujoco>=3.8.1" \
+    "scipy" \
+    "numpy" \
+    "pyyaml" \
+    "loguru" \
+    "pydantic" \
+    "tyro>=0.10.0a4" \
+    "pytest"
+
+# holosoma_inference (editable, no deps) — provides holosoma_inference.compat
+# (entry_points shim) + the retargeter implementation package that setup.py
+# registers under the holosoma.retargeter group.
+RUN pip install --no-cache-dir --no-deps -e /ws/src/holosoma_inference
+
+# Entrypoint sources ROS + the freshly built overlay, then runs the service
+# integration tests. `ros2 launch`/rclpy and the built holosoma_msgs come from
+# the overlay; the g1-smpl retargeter entry point comes from the installed
+# holosoma_service package.
+RUN printf '%s\n' \
+    '#!/bin/bash' \
+    'set -e' \
+    'source /opt/ros/jazzy/setup.bash' \
+    'source /ws/service/install/setup.bash' \
+    'exec python3 -m pytest -v --import-mode=importlib \
+        /ws/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/retargetting/test_retargeter_service_api.py "$@"' \
+    > /usr/local/bin/run_service_tests \
+    && chmod +x /usr/local/bin/run_service_tests
+
+ENTRYPOINT ["/usr/local/bin/run_service_tests"]

--- a/src/holosoma_inference/holosoma_inference_service/docker/Dockerfile.test
+++ b/src/holosoma_inference/holosoma_inference_service/docker/Dockerfile.test
@@ -62,11 +62,15 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # list exactly what smpl_retargeter + the node import at runtime.
 #   mink+mujoco  -> IK solve; scipy -> rotations; numpy -> arrays;
 #   pyyaml/loguru/pydantic/tyro -> imported on the holosoma_inference path.
+# Pin numpy to the Jazzy system version: holosoma_msgs / rclpy C-extensions were
+# compiled against 1.26.4 at colcon-build time above, so an unpinned resolve to
+# numpy 2.x would swap the ABI out from under them at test runtime. Pinning also
+# keeps the image reproducible against future numpy releases.
 RUN pip install --no-cache-dir \
     "mink" \
     "mujoco>=3.8.1" \
     "scipy" \
-    "numpy" \
+    "numpy==1.26.4" \
     "pyyaml" \
     "loguru" \
     "pydantic" \

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/retargetting/test_retargeter_service_api.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/retargetting/test_retargeter_service_api.py
@@ -66,11 +66,16 @@ pytestmark = [
 def _make_smplh(valid: bool = True) -> CmdSMPLH:
     """A non-degenerate SMPL-H frame: identity orientations, joints spread along
     the vertical axis so pelvis->ankle separation (the height-ratio basis) is
-    nonzero and the IK gets a well-posed target."""
+    nonzero and the IK gets a well-posed target.
+
+    ``joint_poses`` is populated even when ``valid=False`` so the invalid frame
+    differs from the valid one *only* in the ``valid`` flag. The node guard is
+    ``if not msg.valid or not msg.joint_poses`` — leaving poses empty would let
+    the empty-poses branch suppress output on its own, so the negative test
+    could not distinguish the ``valid`` contract from a degenerate payload.
+    """
     msg = CmdSMPLH()
     msg.valid = valid
-    if not valid:
-        return msg
     msg.joint_names = list(JOINT_NAMES)
     poses = []
     n = len(JOINT_NAMES)

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/retargetting/test_retargeter_service_api.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/retargetting/test_retargeter_service_api.py
@@ -1,0 +1,151 @@
+"""ROS2-native integration test for the retargeter service API.
+
+Exercises the *contract* FAR-pi (and any external consumer) depends on, rather
+than co-running the two services: spin the real ``RetargeterNode`` and drive it
+over actual ROS2 topics, asserting the ``CmdSMPLH -> CmdDense`` surface. This is
+the one service node that is a pure topic-in/topic-out transform (no ONNX, no
+robot SDK), so the whole pub/sub + serialization + callback path is real.
+
+Two salient cases:
+
+1. Valid ``CmdSMPLH`` in -> one ``CmdDense`` out with the documented shape
+   (29-DoF q/dq, finite, normalized root quat).
+2. ``valid=False`` in -> no ``CmdDense`` out (the "no usable tracking this
+   frame; consumers skip" contract), verified only after the pipeline has been
+   shown to work so the negative assertion is meaningful.
+
+Skips cleanly when the ROS2 / IK stack isn't importable (host env); a built
+colcon workspace (or a ROS2 CI job) has rclpy + holosoma_msgs + mink and the
+``g1-smpl`` retargeter entry point registered.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("rclpy")
+pytest.importorskip("geometry_msgs")
+pytest.importorskip("holosoma_msgs")
+pytest.importorskip("mink")
+
+import rclpy
+from geometry_msgs.msg import Pose
+from holosoma_msgs.msg import CmdDense, CmdSMPLH
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+
+from holosoma_service.retargetting import available_retargeters
+from holosoma_service.retargetting.retargeter_node import IN_TOPIC, OUT_TOPIC, RetargeterNode
+from holosoma_service.retargetting.smpl_retargeter import JOINT_NAMES
+
+# Shipped G1 MJCF the retargeter IK loads, relative to the holosoma repo root.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([os.pardir] * 6)))
+_G1_XML = os.path.join(
+    _REPO_ROOT, "src", "holosoma_retargeting", "holosoma_retargeting", "models", "g1", "g1_29dof.xml"
+)
+
+_EXPECTED_DOF = 29
+# Match the node's QoS exactly (BEST_EFFORT, depth 1) or the endpoints won't pair.
+_QOS = QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT)
+
+pytestmark = [
+    pytest.mark.skipif(not Path(_G1_XML).exists(), reason="shipped g1_29dof.xml not present"),
+    pytest.mark.skipif(
+        "g1-smpl" not in available_retargeters(),
+        reason="g1-smpl retargeter entry point not registered (package not installed)",
+    ),
+]
+
+
+def _make_smplh(valid: bool = True) -> CmdSMPLH:
+    """A non-degenerate SMPL-H frame: identity orientations, joints spread along
+    the vertical axis so pelvis->ankle separation (the height-ratio basis) is
+    nonzero and the IK gets a well-posed target."""
+    msg = CmdSMPLH()
+    msg.valid = valid
+    if not valid:
+        return msg
+    msg.joint_names = list(JOINT_NAMES)
+    poses = []
+    n = len(JOINT_NAMES)
+    for i in range(n):
+        p = Pose()
+        p.orientation.w = 1.0  # identity quaternion (xyzw)
+        p.position.y = 1.0 - i / n  # descend 1.0 -> ~0 so positions are distinct
+        poses.append(p)
+    msg.joint_poses = poses
+    return msg
+
+
+class _Harness(Node):
+    """External peer: publishes CmdSMPLH, records CmdDense — stands in for FAR-pi."""
+
+    def __init__(self) -> None:
+        super().__init__("retargeter_api_test_harness")
+        self.pub = self.create_publisher(CmdSMPLH, IN_TOPIC, _QOS)
+        self.received: list[CmdDense] = []
+        self.create_subscription(CmdDense, OUT_TOPIC, self.received.append, _QOS)
+
+
+@pytest.fixture
+def pipeline():
+    """Real RetargeterNode + harness on one executor. Publishing is best-effort,
+    so callers republish each spin until an output arrives (or timeout)."""
+    rclpy.init()
+    node = RetargeterNode(urdf_path=_G1_XML, rl_rate_hz=50.0, joint_names=[], retargeter="g1-smpl")
+    harness = _Harness()
+    executor = SingleThreadedExecutor()
+    executor.add_node(node)
+    executor.add_node(harness)
+
+    def pump(msg: CmdSMPLH, *, until_received: bool, timeout_s: float = 5.0) -> None:
+        """Publish `msg` each spin. If until_received, stop once output arrives;
+        otherwise pump for the full timeout (used to assert no output)."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            harness.pub.publish(msg)
+            executor.spin_once(timeout_sec=0.05)
+            if until_received and harness.received:
+                return
+
+    try:
+        yield harness, pump
+    finally:
+        executor.shutdown()
+        node.destroy_node()
+        harness.destroy_node()
+        rclpy.shutdown()
+
+
+def test_valid_smplh_yields_wellformed_dense(pipeline):
+    harness, pump = pipeline
+    pump(_make_smplh(valid=True), until_received=True)
+
+    assert harness.received, "no CmdDense published for a valid CmdSMPLH within timeout"
+    out = harness.received[0]
+
+    assert len(out.q) == _EXPECTED_DOF
+    assert len(out.dq) == _EXPECTED_DOF
+    assert np.all(np.isfinite(out.q)), "q contains non-finite values"
+    assert np.all(np.isfinite(out.dq)), "dq contains non-finite values"
+
+    quat = np.array([out.root_quat.x, out.root_quat.y, out.root_quat.z, out.root_quat.w])
+    assert np.isclose(np.linalg.norm(quat), 1.0, atol=1e-3), f"root_quat not normalized: {quat}"
+
+
+def test_invalid_smplh_publishes_nothing(pipeline):
+    harness, pump = pipeline
+    # First prove the pipeline is live (discovery complete), else the negative
+    # assertion below would pass trivially.
+    pump(_make_smplh(valid=True), until_received=True)
+    assert harness.received, "pipeline never produced output; cannot trust the negative case"
+
+    harness.received.clear()
+    pump(_make_smplh(valid=False), until_received=False, timeout_s=1.5)
+    assert not harness.received, "CmdDense published for an invalid (valid=False) frame"

--- a/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/retargetting/test_retargeter_service_api.py
+++ b/src/holosoma_inference/holosoma_inference_service/holosoma_service/holosoma_service/retargetting/test_retargeter_service_api.py
@@ -1,7 +1,7 @@
 """ROS2-native integration test for the retargeter service API.
 
-Exercises the *contract* FAR-pi (and any external consumer) depends on, rather
-than co-running the two services: spin the real ``RetargeterNode`` and drive it
+Exercises the *contract* external consumers depend on, rather than co-running
+two services: spin the real ``RetargeterNode`` and drive it
 over actual ROS2 topics, asserting the ``CmdSMPLH -> CmdDense`` surface. This is
 the one service node that is a pure topic-in/topic-out transform (no ONNX, no
 robot SDK), so the whole pub/sub + serialization + callback path is real.
@@ -84,7 +84,7 @@ def _make_smplh(valid: bool = True) -> CmdSMPLH:
 
 
 class _Harness(Node):
-    """External peer: publishes CmdSMPLH, records CmdDense — stands in for FAR-pi."""
+    """External peer: publishes CmdSMPLH, records CmdDense — stands in for a downstream consumer."""
 
     def __init__(self) -> None:
         super().__init__("retargeter_api_test_harness")


### PR DESCRIPTION
Adds a ROS2-native contract test for the service merged in #124. 

The PR tests the service's public surface ROS2 topic API.