### PR TITLE
switching to using pypi sdks

### DIFF
--- a/docker/thor/Dockerfile
+++ b/docker/thor/Dockerfile
@@ -119,18 +119,14 @@ RUN uv pip install \
 
 
 # ─── Stage: app-deps ──────────────────────────────────────────────────────────
-# Install amazon-far unitree_sdk2 wheel + copy holosoma_inference source.
+# Install far-unitree-sdk (PyPI) + copy holosoma_inference source.
 # This is the only layer that changes on every commit.
 FROM common-deps AS app-deps
 
-# unitree_sdk2 Python 3.12 aarch64 wheel from amazon-far's GitHub release.
-# Bump UNITREE_SDK2_VERSION in one place when a new release is published.
-ARG UNITREE_SDK2_VERSION=0.1.3
-ARG UNITREE_SDK2_WHL=unitree_sdk2-${UNITREE_SDK2_VERSION}-cp312-cp312-linux_aarch64.whl
-RUN wget -q -O "/tmp/${UNITREE_SDK2_WHL}" \
-    "https://github.com/amazon-far/unitree_sdk2/releases/download/${UNITREE_SDK2_VERSION}/${UNITREE_SDK2_WHL}" \
-    && uv pip install "/tmp/${UNITREE_SDK2_WHL}" \
-    && rm "/tmp/${UNITREE_SDK2_WHL}"
+# far-unitree-sdk from PyPI. pip resolves the correct wheel for the
+# interpreter/platform. Bump UNITREE_SDK2_VERSION in one place on a new release.
+ARG UNITREE_SDK2_VERSION=0.1.4
+RUN uv pip install "far-unitree-sdk==${UNITREE_SDK2_VERSION}"
 
 # holosoma_inference source (editable install, --no-deps since common-deps
 # handled the runtime deps above).
@@ -239,12 +235,8 @@ RUN uv pip install \
 # ─── Stage: app-deps-ros ──────────────────────────────────────────────────────
 FROM common-deps-ros AS app-deps-ros
 
-ARG UNITREE_SDK2_VERSION=0.1.3
-ARG UNITREE_SDK2_WHL=unitree_sdk2-${UNITREE_SDK2_VERSION}-cp312-cp312-linux_aarch64.whl
-RUN wget -q -O "/tmp/${UNITREE_SDK2_WHL}" \
-    "https://github.com/amazon-far/unitree_sdk2/releases/download/${UNITREE_SDK2_VERSION}/${UNITREE_SDK2_WHL}" \
-    && uv pip install "/tmp/${UNITREE_SDK2_WHL}" \
-    && rm "/tmp/${UNITREE_SDK2_WHL}"
+ARG UNITREE_SDK2_VERSION=0.1.4
+RUN uv pip install "far-unitree-sdk==${UNITREE_SDK2_VERSION}"
 
 COPY src/holosoma_inference /opt/holosoma-src/src/holosoma_inference
 # demo_scripts/ros2_velocity_publisher.py is used by the run_shuttle_publisher.sh

--- a/docker/thor/README.md
+++ b/docker/thor/README.md
@@ -134,17 +134,18 @@ installed on top of ROS's system packages to avoid ABI surprises.
 - **CUDA**: `nvcr.io/nvidia/cuda:13.0.2-devel-ubuntu24.04` (matches JetPack 7.1
   + CUDA 13 on Thor).
 - **ROS 2**: Jazzy (Noble native; compatible with common ROS nav stacks).
-- **`unitree_sdk2`**: `0.1.3` (set via `--build-arg UNITREE_SDK2_VERSION=...`).
-  Bump when a new amazon-far release is published with a cp312 aarch64 wheel.
+- **`far-unitree-sdk`**: `0.1.4` (set via `--build-arg UNITREE_SDK2_VERSION=...`).
+  Installed from PyPI; bump when a new release is published.
 - **Python deps**: unpinned by design — let `uv` resolve. Source of truth
   for the dep list is `src/holosoma_inference/setup.py`.
 
 ## Troubleshooting
 
-**Build fails at `wget ... unitree_sdk2-0.1.3-cp312-cp312-linux_aarch64.whl`**
+**Build fails at `uv pip install far-unitree-sdk==...` (no matching distribution)**
 
-The wheel asset may not yet be uploaded to the release. Check
-https://github.com/amazon-far/unitree_sdk2/releases and ping the maintainer.
+The version may not yet be published to PyPI, or no wheel exists for this
+image's Python/platform. Check https://pypi.org/project/far-unitree-sdk/#files
+and ping the maintainer.
 
 **`libcudss.so.0: cannot open shared object file`**
 

--- a/scripts/source_inference_uv_setup.sh
+++ b/scripts/source_inference_uv_setup.sh
@@ -43,8 +43,9 @@ if python -c "import holosoma_inference" 2>/dev/null; then
         echo "pinocchio version: $(python -c 'import pinocchio; print(pinocchio.__version__)')"
     fi
 
-    if python -c "import unitree_sdk2" 2>/dev/null; then
-        echo "unitree_sdk2: available"
+    # far-unitree-sdk (PyPI dist) imports as `unitree_interface`.
+    if python -c "import unitree_interface" 2>/dev/null; then
+        echo "far-unitree-sdk (unitree_interface): available"
     fi
 
     if [[ -n "${_ROS_DISTRO:-}" ]]; then

--- a/src/holosoma/setup.py
+++ b/src/holosoma/setup.py
@@ -1,28 +1,15 @@
-import platform
-import sys
-
 from setuptools import setup
 
-UNITREE_VERSION = "0.1.2"
-UNITREE_REPO = "https://github.com/amazon-far/unitree_sdk2"
+# Robot SDKs are published to PyPI (FAR forks). The import names are unchanged
+# (`unitree_interface`, `booster_robotics_sdk`) — only the distribution names
+# differ from the historical GitHub-release wheels.
+UNITREE_VERSION = "0.1.4"
 BOOSTER_VERSION = "0.1.0"
-BOOSTER_REPO = "https://github.com/amazon-far/booster_robotics_sdk"
-
-PLATFORM_MAP = {
-    "x86_64": "linux_x86_64",
-    "aarch64": "linux_aarch64",
-}
-
-pyvers = f"cp{sys.version_info.major}{sys.version_info.minor}"
-platform_str = PLATFORM_MAP.get(platform.machine(), "linux_x86_64")
-
-unitree_url = f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/unitree_sdk2-{UNITREE_VERSION}-{pyvers}-{pyvers}-{platform_str}.whl"  # noqa: E501
-booster_url = f"{BOOSTER_REPO}/releases/download/{BOOSTER_VERSION}/booster_robotics_sdk-{BOOSTER_VERSION}-{pyvers}-{pyvers}-{platform_str}.whl"  # noqa: E501
 
 setup(
     extras_require={
-        "unitree": [f"unitree_sdk2 @ {unitree_url}"],
-        "booster": [f"booster_robotics_sdk @ {booster_url}"],
+        "unitree": [f"far-unitree-sdk=={UNITREE_VERSION}"],
+        "booster": [f"far-booster-sdk=={BOOSTER_VERSION}"],
     },
     # Entry points are declared in pyproject.toml [project.entry-points.*]
 )

--- a/src/holosoma_inference/docker/service/Dockerfile.x86
+++ b/src/holosoma_inference/docker/service/Dockerfile.x86
@@ -107,18 +107,14 @@ RUN uv pip install \
 
 
 # ─── Stage: app-deps ──────────────────────────────────────────────────────────
-# Install amazon-far unitree_sdk2 wheel + copy holosoma_inference source.
+# Install far-unitree-sdk (PyPI) + copy holosoma_inference source.
 # This is the only layer that changes on every commit.
 FROM common-deps AS app-deps
 
-# unitree_sdk2 Python 3.12 x86_64 wheel from amazon-far's GitHub release.
-# Bump UNITREE_SDK2_VERSION in one place when a new release is published.
-ARG UNITREE_SDK2_VERSION=0.1.3
-ARG UNITREE_SDK2_WHL=unitree_sdk2-${UNITREE_SDK2_VERSION}-cp312-cp312-linux_x86_64.whl
-RUN wget -q -O "/tmp/${UNITREE_SDK2_WHL}" \
-    "https://github.com/amazon-far/unitree_sdk2/releases/download/${UNITREE_SDK2_VERSION}/${UNITREE_SDK2_WHL}" \
-    && uv pip install "/tmp/${UNITREE_SDK2_WHL}" \
-    && rm "/tmp/${UNITREE_SDK2_WHL}"
+# far-unitree-sdk from PyPI. pip resolves the correct wheel for the
+# interpreter/platform. Bump UNITREE_SDK2_VERSION in one place on a new release.
+ARG UNITREE_SDK2_VERSION=0.1.4
+RUN uv pip install "far-unitree-sdk==${UNITREE_SDK2_VERSION}"
 
 # holosoma_inference source (editable install, --no-deps since common-deps
 # handled the runtime deps above).
@@ -206,12 +202,8 @@ RUN uv pip install \
 # ─── Stage: app-deps-ros ──────────────────────────────────────────────────────
 FROM common-deps-ros AS app-deps-ros
 
-ARG UNITREE_SDK2_VERSION=0.1.3
-ARG UNITREE_SDK2_WHL=unitree_sdk2-${UNITREE_SDK2_VERSION}-cp312-cp312-linux_x86_64.whl
-RUN wget -q -O "/tmp/${UNITREE_SDK2_WHL}" \
-    "https://github.com/amazon-far/unitree_sdk2/releases/download/${UNITREE_SDK2_VERSION}/${UNITREE_SDK2_WHL}" \
-    && uv pip install "/tmp/${UNITREE_SDK2_WHL}" \
-    && rm "/tmp/${UNITREE_SDK2_WHL}"
+ARG UNITREE_SDK2_VERSION=0.1.4
+RUN uv pip install "far-unitree-sdk==${UNITREE_SDK2_VERSION}"
 
 COPY src/holosoma_inference /opt/holosoma-src/src/holosoma_inference
 # demo_scripts/ros2_velocity_publisher.py is used by the run_shuttle_publisher.sh

--- a/src/holosoma_inference/setup.py
+++ b/src/holosoma_inference/setup.py
@@ -1,45 +1,14 @@
-import platform
-import sys
-
 from setuptools import find_packages, setup
 
-UNITREE_VERSION = "0.1.3"
-UNITREE_REPO = "https://github.com/amazon-far/unitree_sdk2"
+# Robot SDKs are published to PyPI (FAR forks). The import names are unchanged
+# (`unitree_interface`, `booster_robotics_sdk`) — only the distribution names
+# differ from the historical GitHub-release wheels. pip resolves the correct
+# wheel for the running interpreter/platform from the PyPI index.
+UNITREE_VERSION = "0.1.4"
 BOOSTER_VERSION = "0.1.0"
-BOOSTER_REPO = "https://github.com/amazon-far/booster_robotics_sdk"
 
-PLATFORM_MAP = {
-    "x86_64": "linux_x86_64",
-    "aarch64": "linux_aarch64",
-}
-
-# Supported Python cp tags — the SDK wheel build matrix publishes these tags.
-# Keep this list in sync with the wheel asset matrix on the amazon-far release.
-_SUPPORTED_PY_TAGS = {(3, 8), (3, 10), (3, 11), (3, 12)}
-_py = (sys.version_info.major, sys.version_info.minor)
-if _py not in _SUPPORTED_PY_TAGS:
-    _supported = ", ".join(f"{maj}.{min}" for maj, min in sorted(_SUPPORTED_PY_TAGS))
-    raise RuntimeError(
-        f"holosoma_inference[unitree,booster] has no prebuilt SDK wheel for "
-        f"Python {_py[0]}.{_py[1]}. Supported versions: {_supported}."
-    )
-cp_tag = f"cp{_py[0]}{_py[1]}"
-
-platform_tag = PLATFORM_MAP.get(platform.machine(), "linux_x86_64")
-
-unitree_extras = []
-unitree_url = (
-    f"{UNITREE_REPO}/releases/download/{UNITREE_VERSION}/"
-    f"unitree_sdk2-{UNITREE_VERSION}-{cp_tag}-{cp_tag}-{platform_tag}.whl"
-)
-unitree_extras.append(f"unitree_sdk2 @ {unitree_url}")
-
-booster_extras = []
-booster_url = (
-    f"{BOOSTER_REPO}/releases/download/{BOOSTER_VERSION}/"
-    f"booster_robotics_sdk-{BOOSTER_VERSION}-{cp_tag}-{cp_tag}-{platform_tag}.whl"
-)
-booster_extras.append(f"booster_robotics_sdk @ {booster_url}")
+unitree_extras = [f"far-unitree-sdk=={UNITREE_VERSION}"]
+booster_extras = [f"far-booster-sdk=={BOOSTER_VERSION}"]
 
 
 setup(


### PR DESCRIPTION
*Description of changes:*

switching all references to [unitree](https://github.com/amazon-far/unitree_sdk2) and [booster](https://github.com/amazon-far/booster_robotics_sdk) sdks to use newly published pypi packages: [far-unitree-sdk](https://pypi.org/project/far-unitree-sdk/) and [far-booster-sdk](https://pypi.org/project/far-booster-sdk/)