### PR TITLE
ci: publish holosoma-retargeting to PyPI (2/3)

### DIFF
--- a/.github/workflows/publish-holosoma-retargeting.yml
+++ b/.github/workflows/publish-holosoma-retargeting.yml
@@ -1,0 +1,46 @@
+name: Publish holosoma-retargeting to PyPI
+
+# Publishes the `holosoma-retargeting` package (src/holosoma_retargeting) to
+# PyPI using Trusted Publishing (OIDC) — no API tokens stored in the repo.
+#
+# Triggers:
+#   * push a tag like holosoma-retargeting-v0.1.0 -> builds + publishes to PyPI
+#   * manual "Run workflow"                       -> builds only (no publish)
+#
+# The per-package tag prefix disambiguates releases in this monorepo, where
+# three packages (holosoma, holosoma-inference, holosoma-retargeting) share one
+# tag namespace.
+on:
+  push:
+    tags:
+      - "holosoma-retargeting-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_build-python-dist.yml
+    with:
+      package-dir: src/holosoma_retargeting
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    # Only publish on a version tag, never on manual dispatch (build-only smoke).
+    if: startsWith(github.ref, 'refs/tags/holosoma-retargeting-v')
+    runs-on: codebuild-holosoma-cpu-build-${{ github.run_id }}-${{ github.run_attempt }}
+    environment: pypi
+    permissions:
+      id-token: write # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        # uv performs the OIDC token exchange itself (id-token: write above);
+        # --trusted-publishing always fails loudly if OIDC isn't available
+        # rather than silently falling back to an (absent) token.
+        run: uv publish --trusted-publishing always dist/*


### PR DESCRIPTION
**Stacked PR 2 of 3** — publish the holosoma packages to PyPI.

- `.github/workflows/publish-holosoma-retargeting.yml` — triggers on tag `holosoma-retargeting-v*` (or manual dispatch = build-only). Reuses `_build-python-dist.yml` (added in PR 1/3) and publishes `src/holosoma_retargeting` via OIDC Trusted Publishing.

**Stack (merge bottom-up):**
1. `clayros/publish-holosoma-inference` (base of this PR)
2. ← **this PR**
3. `clayros/publish-holosoma`

> Base is the PR-1 branch, so its diff is a single file. Rebase/retarget to `clayros/sdks-from-pypi` if PR 1 merges first (GitHub usually auto-retargets on merge).

**PyPI setup required:** Trusted Publisher on the `holosoma-retargeting` PyPI project → workflow `publish-holosoma-retargeting.yml`, environment `pypi`.