### PR TITLE
ci: publish holosoma-inference to PyPI (1/3)

### DIFF
--- a/.github/workflows/_build-python-dist.yml
+++ b/.github/workflows/_build-python-dist.yml
@@ -1,0 +1,48 @@
+name: Build Python distribution (reusable)
+
+# Reusable build for the pure-Python packages in this monorepo. Builds an sdist
+# + a py3-none-any wheel for the package at `package-dir` and uploads them as
+# the `dist` artifact for a downstream publish job.
+#
+# This is called by the per-package publish-*.yml workflows. The actual PyPI
+# upload (OIDC Trusted Publishing) lives in those callers, not here, so each
+# PyPI project's Trusted Publisher can match its own caller workflow filename.
+#
+# NOTE: we build with `uv build` (uv is preinstalled on these runners, as the
+# docker workflows already rely on) rather than actions/setup-python + `python -m
+# build`. setup-python bootstraps a toolcache Python that isn't present on these
+# self-hosted AWS CodeBuild runners (same reason the SDK release.yml avoids it),
+# and uv provisions its own interpreter. Any host interpreter builds these
+# pure-Python purelib wheels fine. The downstream publish job uploads with
+# `uv publish` (OIDC trusted publishing) — no twine anywhere in the pipeline.
+
+on:
+  workflow_call:
+    inputs:
+      package-dir:
+        description: Path to the package directory (holds pyproject.toml/setup.py).
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: codebuild-holosoma-cpu-build-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build sdist + wheel
+        working-directory: ${{ inputs.package-dir }}
+        run: |
+          set -euo pipefail
+          echo "Building ${{ inputs.package-dir }} with uv $(uv --version)"
+          uv build --out-dir dist
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dist
+          path: ${{ inputs.package-dir }}/dist/*
+          if-no-files-found: error

--- a/.github/workflows/publish-holosoma-inference.yml
+++ b/.github/workflows/publish-holosoma-inference.yml
@@ -1,0 +1,46 @@
+name: Publish holosoma-inference to PyPI
+
+# Publishes the `holosoma-inference` package (src/holosoma_inference) to PyPI
+# using Trusted Publishing (OIDC) — no API tokens stored in the repo.
+#
+# Triggers:
+#   * push a tag like holosoma-inference-v0.1.0 -> builds + publishes to PyPI
+#   * manual "Run workflow"                     -> builds only (no publish)
+#
+# The per-package tag prefix disambiguates releases in this monorepo, where
+# three packages (holosoma, holosoma-inference, holosoma-retargeting) share one
+# tag namespace.
+on:
+  push:
+    tags:
+      - "holosoma-inference-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/_build-python-dist.yml
+    with:
+      package-dir: src/holosoma_inference
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    # Only publish on a version tag, never on manual dispatch (build-only smoke).
+    if: startsWith(github.ref, 'refs/tags/holosoma-inference-v')
+    runs-on: codebuild-holosoma-cpu-build-${{ github.run_id }}-${{ github.run_attempt }}
+    environment: pypi
+    permissions:
+      id-token: write # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        # uv performs the OIDC token exchange itself (id-token: write above);
+        # --trusted-publishing always fails loudly if OIDC isn't available
+        # rather than silently falling back to an (absent) token.
+        run: uv publish --trusted-publishing always dist/*


### PR DESCRIPTION
**Stacked PR 1 of 3** — publish the holosoma packages to PyPI.

Adds the shared reusable build workflow + the first per-package publisher.

- `.github/workflows/_build-python-dist.yml` — reusable (`workflow_call`) build: `python -m build` (sdist + `py3-none-any` wheel) → `twine check` → upload `dist` artifact. Driven by the runner's own `python3` in a venv (no `actions/setup-python`, same as the SDK `release.yml`).
- `.github/workflows/publish-holosoma-inference.yml` — triggers on tag `holosoma-inference-v*` (or manual dispatch = build-only). Publishes via **OIDC Trusted Publishing** (`environment: pypi`, `id-token: write`, no stored tokens).

**Stack (merge bottom-up):**
1. ← **this PR** (base: `main`; original base PR #139 already merged)
2. `clayros/publish-holosoma-retargeting` (#140)
3. `clayros/publish-holosoma` (#141)

**PyPI setup required (owner does this side):** register a Trusted Publisher on the `holosoma-inference` PyPI project → repo `amazon-far/holosoma`, workflow `publish-holosoma-inference.yml`, environment `pypi`.