### PR TITLE
reproducible keyed domain-randomization sampling

### DIFF
--- a/src/holosoma/holosoma/config_types/distribution.py
+++ b/src/holosoma/holosoma/config_types/distribution.py
@@ -1,0 +1,193 @@
+"""The validated meaning of one randomized scalar: :class:`DistributionSpec` and the config range
+values (:data:`DistributionLike`) it is parsed from.
+
+Import-light (no torch/numpy), so a config schema can depend on this without pulling the sampler.
+The keyed sampler that DRAWS from a spec lives in :mod:`holosoma.utils.sampler`.
+
+Distribution conventions (bounds-first, with optional explicit parameters)
+--------------------------------------------------------------------------
+- ``uniform``     — ``U[low, high]``.
+- ``log_uniform`` — ``exp(U[log low, log high])``; requires ``low > 0`` and ``high > 0``.
+- ``gaussian``    — a normal sampled from ``(mean, std)``. ``mean``/``std`` are taken explicitly when
+  given, else derived from BOTH bounds as ``mean = (low + high) / 2`` and ``std = (high - low) / 6``
+  (so ``[low, high]`` spans ±3 std). Truncation follows whichever bounds are present (TRUE truncated
+  normal via inverse-CDF, no endpoint point-mass): both bounds -> ``[low, high]``; ONE-SIDED (only
+  ``low`` or only ``high``, which requires explicit ``(mean, std)`` since one number can't derive
+  them) -> a half-open truncation ``[low, +inf)`` / ``(-inf, high]``; no bounds (explicit ``(mean,
+  std)`` only) -> an un-truncated normal. Truncation keeps a physical quantity (mass, damping, CoM
+  offset) inside the configured band.
+
+Examples
+--------
+>>> DistributionSpec.parse([0.5, 1.5])                              # bare pair -> uniform bounds
+DistributionSpec(kind='uniform', low=0.5, high=1.5, mean=None, std=None)
+>>> DistributionSpec.parse({"kind": "log_uniform", "low": 0.8, "high": 1.2})  # explicit kind
+DistributionSpec(kind='log_uniform', low=0.8, high=1.2, mean=None, std=None)
+>>> DistributionSpec.parse({"kind": "gaussian", "low": -1.0, "high": 1.0})  # truncated normal
+DistributionSpec(kind='gaussian', low=-1.0, high=1.0, mean=None, std=None)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal, Sequence, Union, get_args
+
+Distribution = Literal["uniform", "log_uniform", "gaussian"]
+"""Sampling distributions a randomization term may request."""
+
+# Derived from the Literal above so the two can't drift (one source of truth for the allowed kinds).
+_SUPPORTED_DISTRIBUTIONS: tuple[str, ...] = get_args(Distribution)
+
+# One randomized scalar's range, as written in a config: anything DistributionSpec.parse accepts.
+# This is the type a term takes from config and forwards to the sampler — three equivalent forms:
+#   - a [lo, hi] pair        -> uniform bounds (the common case)
+#   - a {kind, low, high, mean, std} dict -> a non-uniform distribution (gaussian/log_uniform), or one
+#                               with explicit params; also the form a DistributionSpec round-trips to
+#                               through a JSON config save (so a loaded config arrives as this dict)
+#   - a DistributionSpec     -> already-parsed (programmatic) passthrough
+# All three are accepted (rather than requiring DistributionSpec) because configs are written and
+# serialized as pairs/dicts, and a bare pair is the most common term input.
+DistributionLike = Union["DistributionSpec", Sequence[float], dict]
+
+
+@dataclass(frozen=True)
+class DistributionSpec:
+    """The validated meaning of one randomized scalar.
+
+    Built once (typically via :meth:`parse` at a term boundary) and drawn through a bound
+    ``TermSampler``. ``low``/``high`` are the configured bounds (``[lo, hi]``). For ``gaussian``
+    only, ``mean`` and ``std`` may be supplied explicitly; otherwise they are derived from the bounds.
+    Validation runs in :meth:`__post_init__`, so an invalid combination (unknown kind, non-positive
+    ``log_uniform`` bound, missing parameters, ``high < low``) raises AT CONSTRUCTION — a config typo
+    fails loudly at the term boundary, never as a silent NaN deep in the physics write.
+
+    Frozen + validated-once means a spec is a safe, hashable value you can build, stash, and reuse.
+
+    Fields
+    ------
+    kind : "uniform" | "log_uniform" | "gaussian"
+    low, high : the configured bounds. Required for uniform/log_uniform; for gaussian they are the
+        truncation band (and, absent explicit params, the source of the derived mean/std).
+    mean, std : gaussian ONLY, and only when you want to set them explicitly (e.g. a tight std inside a
+        wide band). Supply both or neither.
+
+    Examples
+    --------
+    >>> DistributionSpec(low=0.5, high=1.5)                       # uniform is the default kind
+    DistributionSpec(kind='uniform', low=0.5, high=1.5, mean=None, std=None)
+    >>> DistributionSpec(kind="gaussian", low=-1.0, high=1.0)     # truncated normal, mean/std derived
+    DistributionSpec(kind='gaussian', low=-1.0, high=1.0, mean=None, std=None)
+    >>> DistributionSpec(kind="gaussian", mean=2.5, std=0.1)      # explicit params, un-truncated
+    DistributionSpec(kind='gaussian', low=None, high=None, mean=2.5, std=0.1)
+    >>> DistributionSpec(kind="log_uniform", low=-1.0, high=1.0)  # invalid: bounds must be positive
+    Traceback (most recent call last):
+        ...
+    ValueError: log_uniform requires strictly positive bounds, got [-1.0, 1.0].
+    """
+
+    kind: Distribution = "uniform"
+    low: float | None = None
+    high: float | None = None
+    mean: float | None = None
+    std: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in _SUPPORTED_DISTRIBUTIONS:
+            raise ValueError(f"unknown distribution '{self.kind}'. Expected one of {_SUPPORTED_DISTRIBUTIONS}.")
+
+        # NaN/inf slip past the ordering checks below (NaN compares False) and would surface as
+        # silent NaN deep in a physics write; reject them here.
+        for name in ("low", "high", "mean", "std"):
+            v = getattr(self, name)
+            if v is not None and not math.isfinite(v):
+                raise ValueError(f"distribution '{self.kind}': '{name}' must be finite, got {v!r}.")
+
+        if self.kind in ("uniform", "log_uniform"):
+            if self.low is None or self.high is None:
+                raise ValueError(f"distribution '{self.kind}' requires both 'low' and 'high' bounds.")
+            if self.high < self.low:
+                raise ValueError(f"distribution '{self.kind}': high ({self.high}) must be >= low ({self.low}).")
+            if self.kind == "log_uniform" and (self.low <= 0.0 or self.high <= 0.0):
+                raise ValueError(f"log_uniform requires strictly positive bounds, got [{self.low}, {self.high}].")
+            if self.mean is not None or self.std is not None:
+                raise ValueError(f"distribution '{self.kind}' does not accept 'mean'/'std' (bounds only).")
+
+        else:  # gaussian
+            if (self.mean is None) != (self.std is None):
+                raise ValueError("gaussian: supply 'mean' and 'std' together, or neither.")
+            has_explicit = self.mean is not None and self.std is not None
+            has_both_bounds = self.low is not None and self.high is not None
+            one_sided = (self.low is None) != (self.high is None)  # exactly one bound set
+            # (mean, std) can be given explicitly, OR derived from BOTH bounds. A ONE-SIDED bound
+            # (only low or only high) truncates on that side but cannot derive (mean, std) from a
+            # single number, so it requires explicit params.
+            if not has_explicit:
+                if one_sided:
+                    raise ValueError(
+                        "gaussian with a single bound (only 'low' or only 'high') needs explicit "
+                        "('mean', 'std'); a lone bound cannot derive them. Give both bounds or mean/std."
+                    )
+                if not has_both_bounds:
+                    raise ValueError(
+                        "gaussian requires either explicit ('mean', 'std') or ('low', 'high') bounds to derive them."
+                    )
+            if self.std is not None and self.std < 0.0:
+                raise ValueError(f"gaussian: std must be >= 0, got {self.std}.")
+            if self.low is not None and self.high is not None and self.high < self.low:
+                raise ValueError(f"gaussian: high ({self.high}) must be >= low ({self.low}).")
+
+    def resolved_mean_std(self) -> tuple[float, float]:
+        """``(mean, std)`` for a gaussian: explicit when given, else derived from the bounds."""
+        if self.mean is not None and self.std is not None:
+            return float(self.mean), float(self.std)
+        # low and high are guaranteed by __post_init__ when explicit params are absent.
+        lo, hi = float(self.low), float(self.high)  # type: ignore[arg-type]
+        return 0.5 * (lo + hi), (hi - lo) / 6.0
+
+    @classmethod
+    def parse(cls, value: DistributionLike) -> DistributionSpec:
+        """Parse one config range value (:data:`DistributionLike`) into a validated spec.
+
+        This is the boundary between loose config input and the validated :class:`DistributionSpec`
+        the sampler draws from — ``TermSampler.draw`` calls it for you, so a term hands its config
+        value straight through. A bare ``[lo, hi]`` pair is ALWAYS uniform; a non-uniform distribution
+        must say so explicitly via the dict ``"kind"`` (or a ready :class:`DistributionSpec`). Accepts:
+        - an existing :class:`DistributionSpec` (returned as-is);
+        - a ``[lo, hi]`` / ``(lo, hi)`` pair → uniform bounds;
+        - a dict ``{"kind"?, "low"?, "high"?, "mean"?, "std"?}`` (``kind`` defaults to ``"uniform"``;
+          ``low``/``high`` may instead be given as a ``"range": [lo, hi]`` convenience key).
+
+        Examples
+        --------
+        >>> DistributionSpec.parse([0.5, 1.5])                          # bare pair -> uniform
+        DistributionSpec(kind='uniform', low=0.5, high=1.5, mean=None, std=None)
+        >>> DistributionSpec.parse({"kind": "gaussian", "low": -1.0, "high": 1.0})  # explicit kind
+        DistributionSpec(kind='gaussian', low=-1.0, high=1.0, mean=None, std=None)
+        >>> DistributionSpec.parse({"range": [0.5, 1.5], "kind": "log_uniform"})  # 'range' shorthand
+        DistributionSpec(kind='log_uniform', low=0.5, high=1.5, mean=None, std=None)
+        >>> spec = DistributionSpec.parse([0.5, 1.5])
+        >>> DistributionSpec.parse(spec) is spec                        # spec passes through
+        True
+        """
+        if isinstance(value, DistributionSpec):
+            return value
+        if isinstance(value, dict):
+            params = dict(value)
+            if "range" in params:
+                if "low" in params or "high" in params:
+                    raise ValueError("distribution spec: pass either 'range' or 'low'/'high', not both.")
+                rng = list(params.pop("range"))
+                if len(rng) != 2:
+                    raise ValueError(f"distribution spec: 'range' must have exactly 2 elements [lo, hi], got {rng}.")
+                params["low"], params["high"] = rng[0], rng[1]
+            kind = params.pop("kind", "uniform")
+            unknown = set(params) - {"low", "high", "mean", "std"}
+            if unknown:
+                raise ValueError(f"unknown distribution spec keys {sorted(unknown)}; expected low/high/mean/std/kind.")
+            return cls(kind=kind, **params)
+        # Sequence form: [lo, hi] -> uniform.
+        pair = list(value)
+        if len(pair) != 2:
+            raise ValueError(f"range value must have exactly 2 elements [lo, hi], got {pair}.")
+        return cls(kind="uniform", low=float(pair[0]), high=float(pair[1]))

--- a/src/holosoma/holosoma/config_types/randomization.py
+++ b/src/holosoma/holosoma/config_types/randomization.py
@@ -7,6 +7,21 @@ from typing import Any
 
 from pydantic.dataclasses import dataclass
 
+from holosoma.config_types.distribution import DistributionLike
+
+
+@dataclass(frozen=True)
+class BaseComRange:
+    """Per-axis CoM-offset ranges for ``randomize_base_com_startup`` (added to the torso CoM, metres).
+
+    Each axis is a ``[lo, hi]`` pair (uniform), spec dict, or :class:`DistributionSpec`. Offsets
+    are typically signed and small, e.g. ``BaseComRange(x=[-0.025, 0.025], y=[-0.05, 0.05], z=[-0.05, 0.05])``.
+    """
+
+    x: DistributionLike = (0.0, 0.0)
+    y: DistributionLike = (0.0, 0.0)
+    z: DistributionLike = (0.0, 0.0)
+
 
 @dataclass(frozen=True)
 class RandomizationTermCfg:

--- a/src/holosoma/holosoma/config_values/wbt/g1/randomization.py
+++ b/src/holosoma/holosoma/config_values/wbt/g1/randomization.py
@@ -27,6 +27,8 @@ robot_state_dr_at_setup = {
     ),
 }
 
+# IsaacSim-only object physics DR (the robot's RobotConfig.object). Randomizes the spawned object's
+# material, mass, and inertia through the same keyed sampler the robot terms use.
 object_state_dr_at_setup = {
     "randomize_object_rigid_body_material_startup": RandomizationTermCfg(
         func="holosoma.managers.randomization.terms.locomotion:randomize_object_rigid_body_material_startup",
@@ -46,15 +48,10 @@ object_state_dr_at_setup = {
         func="holosoma.managers.randomization.terms.locomotion:randomize_object_rigid_body_inertia_startup",
         params={
             "inertia_distribution_params_dict": {
-                # In beyondmimic, only Ixx is randomized, which is probably a bug instead of a feature.
-                # Here, we want to reproduce their work. User should feel free to randomize all terms.
+                # Only Ixx is randomized, reproducing beyondmimic. Unnamed components default to
+                # the identity scale [1.0, 1.0]; name more to randomize them.
                 "Ixx": [0.5, 1.5],
-                "Iyy": [1.0, 1.0],
-                "Izz": [1.0, 1.0],
-                "Ixy": [1.0, 1.0],
-                "Iyz": [1.0, 1.0],
-                "Ixz": [1.0, 1.0],
-            }
+            },
         },
     ),
 }
@@ -128,16 +125,9 @@ g1_29dof_wbt_randomization = RandomizationManagerCfg(
 )
 
 g1_29dof_wbt_randomization_w_object = RandomizationManagerCfg(
-    setup_terms={
-        **base_setup_terms,
-        **object_state_dr_at_setup,
-    },
-    reset_terms={
-        **base_reset_terms,
-    },
-    step_terms={
-        **base_step_terms,
-    },
+    setup_terms={**base_setup_terms, **object_state_dr_at_setup},
+    reset_terms={**base_reset_terms},
+    step_terms={**base_step_terms},
 )
 
 __all__ = ["g1_29dof_wbt_randomization", "g1_29dof_wbt_randomization_w_object"]

--- a/src/holosoma/holosoma/envs/base_task/base_task.py
+++ b/src/holosoma/holosoma/envs/base_task/base_task.py
@@ -99,6 +99,13 @@ class BaseTask:
         self.dim_actions = robot_config.actions_dim
         self.device = device
 
+        # Domain-randomization keying state (read by the randomization manager to bind TermSamplers).
+        # base_seed makes every DR draw value = f(seed, term, env, episode); the per-env episode
+        # counter (incremented on reset, BEFORE the reset DR runs) keys async per-env resets. Set here
+        # (before any manager is constructed) so setup-stage DR already sees them.
+        self.dr_base_seed = training_config.seed
+        self.dr_episode_count = torch.zeros(self.num_envs, dtype=torch.long, device="cpu")
+
         self.terrain_manager = TerrainManager(terrain_config, self, device)
         self.simulator: BaseSimulator = SimulatorClass(
             tyro_config=full_sim_config, terrain_manager=self.terrain_manager, device=device
@@ -248,6 +255,9 @@ class BaseTask:
 
         # Reset all managers AFTER state changes
         if self.randomization_manager is not None:
+            # Advance the per-env episode counter BEFORE reset DR draws, so each env's k-th reset is
+            # keyed by episode == k (independent of when, or alongside whom, it reset).
+            self.dr_episode_count[env_ids.to("cpu")] += 1
             self.randomization_manager.reset(env_ids)
 
         if self.action_manager is not None:

--- a/src/holosoma/holosoma/managers/randomization/base.py
+++ b/src/holosoma/holosoma/managers/randomization/base.py
@@ -10,10 +10,20 @@ if TYPE_CHECKING:
 
     from holosoma.config_types.randomization import RandomizationTermCfg
     from holosoma.managers.randomization.manager import RandomizationManager
+    from holosoma.utils.sampler import TermSampler
 
 
 class RandomizationTermBase(ABC):
-    """Base class for stateful randomization hooks."""
+    """Base class for stateful randomization hooks.
+
+    Subclass this to apply custom domain randomization during environment setup, reset, or step.
+    Each lifecycle method receives a :class:`~holosoma.utils.sampler.TermSampler` bound by the
+    manager to this term's stable name, lifecycle stage, and the per-env episode counter.
+
+    Draw EVERY random value from the provided ``sampler``. Never use a raw generator (``torch.rand``,
+    ``numpy.random``, the ``random`` module, etc.): only sampler draws are reproducible per
+    (term, env, episode) and independent of the order or set of other active terms.
+    """
 
     def __init__(self, cfg: RandomizationTermCfg, env: Any):
         self.cfg = cfg
@@ -21,13 +31,13 @@ class RandomizationTermBase(ABC):
         self.manager: RandomizationManager | None = None
 
     @abstractmethod
-    def setup(self) -> None:
+    def setup(self, sampler: TermSampler) -> None:
         """Called once during environment setup."""
 
     @abstractmethod
-    def reset(self, env_ids: Tensor | None) -> None:
+    def reset(self, env_ids: Tensor | None, sampler: TermSampler) -> None:
         """Called when specific environments reset."""
 
     @abstractmethod
-    def step(self) -> None:
+    def step(self, sampler: TermSampler) -> None:
         """Called every simulation step (if configured)."""

--- a/src/holosoma/holosoma/managers/randomization/manager.py
+++ b/src/holosoma/holosoma/managers/randomization/manager.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from holosoma.config_types.randomization import RandomizationManagerCfg, RandomizationTermCfg
 from holosoma.managers.randomization.exceptions import RandomizerNotSupportedError
+from holosoma.utils.sampler import STAGE_RESET, STAGE_SETUP, STAGE_STEP, TermSampler
 
 from .base import RandomizationTermBase
 
@@ -124,10 +125,19 @@ class RandomizationManager:
             Lifecycle stage being registered (``"setup"``, ``"reset"``, or ``"step"``).
         """
         for entry in self._class_entries:
-            if entry["name"] == term_name and isinstance(entry["instance"], term_class):
-                entry["stages"].add(stage)
-                self._state_terms.setdefault(term_name, entry["instance"])
-                return
+            if entry["name"] != term_name:
+                continue
+            # Same registry name across stages must be the SAME class — reuse the one instance so a
+            # multi-stage term shares state. A name collision with a DIFFERENT class is a config error
+            # (it would otherwise silently create a duplicate entry while _state_terms kept only one).
+            if type(entry["instance"]) is not term_class:
+                raise ValueError(
+                    f"Randomization term '{term_name}' is registered with conflicting classes "
+                    f"{type(entry['instance']).__name__} and {term_class.__name__}."
+                )
+            entry["stages"].add(stage)
+            self._state_terms.setdefault(term_name, entry["instance"])
+            return
 
         instance = term_class(term_cfg, self.env)
         instance.manager = self
@@ -184,7 +194,9 @@ class RandomizationManager:
         for entry in self._class_entries:
             if "setup" in entry["stages"]:
                 try:
-                    entry["instance"].setup()
+                    entry["instance"].setup(
+                        TermSampler.bind(self.env.dr_base_seed, entry["name"], STAGE_SETUP, self.env.dr_episode_count)
+                    )
                 except RandomizerNotSupportedError:
                     if self.cfg.ignore_unsupported:
                         # Mark as failed to skip in reset() and step()
@@ -197,7 +209,13 @@ class RandomizationManager:
             if term_name in self._setup_funcs:
                 func = self._setup_funcs[term_name]
                 try:
-                    func(self.env, **term_cfg.params)
+                    func(
+                        self.env,
+                        sampler=TermSampler.bind(
+                            self.env.dr_base_seed, term_name, STAGE_SETUP, self.env.dr_episode_count
+                        ),
+                        **term_cfg.params,
+                    )
                 except RandomizerNotSupportedError:
                     if self.cfg.ignore_unsupported:
                         self._failed_randomizers.add(term_name)
@@ -222,21 +240,35 @@ class RandomizationManager:
         """
         for entry in self._class_entries:
             if "reset" in entry["stages"] and entry["name"] not in self._failed_randomizers:
-                entry["instance"].reset(env_ids)
+                entry["instance"].reset(
+                    env_ids,
+                    TermSampler.bind(self.env.dr_base_seed, entry["name"], STAGE_RESET, self.env.dr_episode_count),
+                )
 
         for term_name, term_cfg in zip(self._reset_names, self._reset_cfgs):
             if term_name in self._reset_funcs and term_name not in self._failed_randomizers:
                 func = self._reset_funcs[term_name]
                 # Don't catch unsupported here because setup() has already checked
-                func(self.env, env_ids, **term_cfg.params)
+                func(
+                    self.env,
+                    env_ids,
+                    sampler=TermSampler.bind(self.env.dr_base_seed, term_name, STAGE_RESET, self.env.dr_episode_count),
+                    **term_cfg.params,
+                )
 
     def step(self) -> None:
         """Run per-step hooks (if any are configured)."""
         for entry in self._class_entries:
             if "step" in entry["stages"] and entry["name"] not in self._failed_randomizers:
-                entry["instance"].step()
+                entry["instance"].step(
+                    TermSampler.bind(self.env.dr_base_seed, entry["name"], STAGE_STEP, self.env.dr_episode_count)
+                )
 
         for term_name, term_cfg in zip(self._step_names, self._step_cfgs):
             if term_name in self._step_funcs and term_name not in self._failed_randomizers:
                 func = self._step_funcs[term_name]
-                func(self.env, **term_cfg.params)
+                func(
+                    self.env,
+                    sampler=TermSampler.bind(self.env.dr_base_seed, term_name, STAGE_STEP, self.env.dr_episode_count),
+                    **term_cfg.params,
+                )

--- a/src/holosoma/holosoma/managers/randomization/terms/_shared.py
+++ b/src/holosoma/holosoma/managers/randomization/terms/_shared.py
@@ -1,0 +1,20 @@
+"""Small helpers shared by the randomization term modules (locomotion + objects)."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import torch
+
+# PhysX caps the number of unique materials per scene, so IsaacSim material DR fills a fixed bucket
+# table and assigns each shape a bucket. 64 buckets keep the quantile staircase close to continuous.
+_MATERIAL_NUM_BUCKETS = 64
+
+
+def _ensure_env_ids_tensor(env: Any, env_ids: torch.Tensor | Sequence[int] | None) -> torch.Tensor:
+    """Convert environment indices to a tensor on the correct device."""
+    if env_ids is None:
+        return torch.arange(env.num_envs, device=env.device, dtype=torch.long)
+    if isinstance(env_ids, torch.Tensor):
+        return env_ids.to(device=env.device, dtype=torch.long)
+    return torch.as_tensor(list(env_ids), device=env.device, dtype=torch.long)

--- a/src/holosoma/holosoma/managers/randomization/terms/locomotion.py
+++ b/src/holosoma/holosoma/managers/randomization/terms/locomotion.py
@@ -2,33 +2,23 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import Any, Literal, Sequence
 
-import numpy as np
 import torch
 from loguru import logger
 
-from holosoma.config_types.simulator import MujocoBackend
+from holosoma.config_types.randomization import BaseComRange
 from holosoma.managers.action.terms.joint_control import JointPositionActionTerm
 from holosoma.managers.randomization.base import RandomizationTermBase
 from holosoma.managers.randomization.exceptions import RandomizerNotSupportedError
+from holosoma.managers.randomization.terms._shared import (
+    _MATERIAL_NUM_BUCKETS,
+    _ensure_env_ids_tensor,
+)
 from holosoma.simulator import mujoco_required_field
 from holosoma.simulator.shared.field_decorators import MUJOCO_FIELD_ATTR
-from holosoma.utils.torch_utils import torch_rand_float
-
-if TYPE_CHECKING:
-    from isaaclab.managers import SceneEntityCfg
-
-    from holosoma.simulator.isaacsim.isaacsim import IsaacSim
-
-
-def _ensure_env_ids_tensor(env: Any, env_ids: torch.Tensor | Sequence[int] | None) -> torch.Tensor:
-    """Convert environment indices to a tensor on the correct device."""
-    if env_ids is None:
-        return torch.arange(env.num_envs, device=env.device, dtype=torch.long)
-    if isinstance(env_ids, torch.Tensor):
-        return env_ids.to(device=env.device, dtype=torch.long)
-    return torch.as_tensor(list(env_ids), device=env.device, dtype=torch.long)
+from holosoma.utils.sampler import DistributionLike, DistributionSpec, TermSampler, quantiles
+from holosoma.utils.simulator_config import SimulatorType
 
 
 def _get_joint_action_term(env: Any) -> JointPositionActionTerm | None:
@@ -52,80 +42,6 @@ def _get_joint_action_term(env: Any) -> JointPositionActionTerm | None:
     return None
 
 
-def _isaacsim_randomize_rigid_body_mass(
-    simulator: IsaacSim,
-    env_ids_cpu: torch.Tensor,
-    asset_cfg: SceneEntityCfg,
-    mass_distribution_params: tuple[float, float],
-    operation: str,
-):
-    try:
-        from isaaclab.envs import mdp
-        from isaaclab.managers import EventTermCfg
-    except ImportError as exc:  # pragma: no cover - defensive
-        raise RuntimeError("IsaacSim mass randomization requires isaaclab.") from exc
-    func = mdp.randomize_rigid_body_mass(
-        EventTermCfg(
-            func=mdp.randomize_rigid_body_mass,
-            mode="startup",
-            params={
-                "env_ids": env_ids_cpu,
-                "asset_cfg": asset_cfg,
-                "mass_distribution_params": mass_distribution_params,
-                "operation": operation,
-            },
-        ),
-        env=simulator,
-    )
-    func(
-        simulator,
-        env_ids_cpu,
-        asset_cfg=asset_cfg,
-        mass_distribution_params=mass_distribution_params,
-        operation=operation,
-    )
-
-
-def _isaacsim_randomize_rigid_body_material(
-    simulator: IsaacSim,
-    env_ids_cpu: torch.Tensor,
-    asset_cfg: SceneEntityCfg,
-    static_friction_range: tuple[float, float],
-    dynamic_friction_range: tuple[float, float],
-    restitution_range: tuple[float, float],
-    num_buckets: int,
-):
-    try:
-        from isaaclab.envs import mdp
-        from isaaclab.managers import EventTermCfg
-    except ImportError as exc:  # pragma: no cover - defensive
-        raise RuntimeError("IsaacSim material randomization requires isaaclab.") from exc
-    func = mdp.randomize_rigid_body_material(
-        EventTermCfg(
-            func=mdp.randomize_rigid_body_material,
-            mode="startup",
-            params={
-                "env_ids": env_ids_cpu,
-                "asset_cfg": asset_cfg,
-                "static_friction_range": static_friction_range,
-                "dynamic_friction_range": dynamic_friction_range,
-                "restitution_range": restitution_range,
-                "num_buckets": num_buckets,
-            },
-        ),
-        simulator,
-    )
-    func(
-        simulator,
-        env_ids_cpu,
-        asset_cfg=asset_cfg,
-        static_friction_range=static_friction_range,
-        dynamic_friction_range=dynamic_friction_range,
-        restitution_range=restitution_range,
-        num_buckets=num_buckets,
-    )
-
-
 class PushRandomizerState(RandomizationTermBase):
     """Stateful randomizer that owns push scheduling buffers and counters."""
 
@@ -141,16 +57,16 @@ class PushRandomizerState(RandomizationTermBase):
         self._set_max_push_tensor(vector_max)
         self.enabled: bool = bool(params.get("enabled", True))
         logger.info(
-            f"[Randomization] PushRandomizerState initialized (enabled={self.enabled}, \
-                max_push_vel={self._max_push_vel_tensor.tolist()}, \
-                interval_s={self.push_interval_range})",
+            f"[Randomization] PushRandomizerState initialized (enabled={self.enabled}, "
+            f"max_push_vel={self._max_push_vel_tensor.tolist()}, "
+            f"interval_s={self.push_interval_range})",
         )
 
         self.push_interval_s: torch.Tensor | None = None
         self.push_robot_counter: torch.Tensor | None = None
         self.push_robot_plot_counter: torch.Tensor | None = None
 
-    def setup(self) -> None:
+    def setup(self, sampler: TermSampler) -> None:
         env = self.env
         device = env.device
         num_envs = env.num_envs
@@ -160,18 +76,18 @@ class PushRandomizerState(RandomizationTermBase):
         self.push_robot_plot_counter = torch.zeros(num_envs, dtype=torch.int, device=device)
 
         all_ids = torch.arange(num_envs, device=device, dtype=torch.long)
-        self._resample_intervals(all_ids)
+        self._resample_intervals(all_ids, sampler)
 
-    def reset(self, env_ids: torch.Tensor | None) -> None:
+    def reset(self, env_ids: torch.Tensor | None, sampler: TermSampler) -> None:
         if self.push_robot_counter is None or self.push_robot_plot_counter is None:
             return
-        idx = self._ensure_indices(env_ids)
+        idx = _ensure_env_ids_tensor(self.env, env_ids)
         if idx.numel() == 0:
             return
         self.push_robot_counter[idx] = 0
         self.push_robot_plot_counter[idx] = 0
 
-    def step(self) -> None:
+    def step(self, sampler: TermSampler) -> None:
         if not self.enabled:
             return
         if self.push_robot_counter is None or self.push_robot_plot_counter is None:
@@ -197,11 +113,11 @@ class PushRandomizerState(RandomizationTermBase):
         if max_push_vel is not None:
             self._set_max_push_tensor(max_push_vel)
 
-    def resample(self, env_ids: torch.Tensor | None = None) -> None:
-        idx = self._ensure_indices(env_ids)
+    def resample(self, env_ids: torch.Tensor | None, sampler: TermSampler) -> None:
+        idx = _ensure_env_ids_tensor(self.env, env_ids)
         if idx.numel() == 0:
             return
-        self._resample_intervals(idx)
+        self._resample_intervals(idx, sampler)
 
     def due_envs(self, dt: float) -> torch.Tensor:
         if not self.enabled:
@@ -221,20 +137,14 @@ class PushRandomizerState(RandomizationTermBase):
     def max_push_vel(self) -> torch.Tensor:
         return self._max_push_vel_tensor
 
-    def _ensure_indices(self, env_ids: torch.Tensor | None) -> torch.Tensor:
-        if env_ids is None:
-            return torch.arange(self.env.num_envs, device=self.env.device, dtype=torch.long)
-        if isinstance(env_ids, torch.Tensor):
-            return env_ids.to(device=self.env.device, dtype=torch.long)
-        return torch.as_tensor(env_ids, device=self.env.device, dtype=torch.long)
-
-    def _resample_intervals(self, env_ids: torch.Tensor) -> None:
+    def _resample_intervals(self, env_ids: torch.Tensor, sampler: TermSampler) -> None:
         if self.push_interval_s is None:
             return
         low, high = self.push_interval_range
         low_i = max(1, int(low))
         high_i = max(low_i + 1, int(high))
-        samples = torch_rand_float(low_i, high_i, (env_ids.shape[0], 1), device=self.env.device).squeeze(1)
+        # Keyed via the bound sampler. Drawn on the env device, one value per env -> [n_env].
+        samples = sampler.draw([float(low_i), float(high_i)], env_ids=env_ids, device=self.env.device)
         self.push_interval_s[env_ids] = samples
 
     def _set_max_push_tensor(self, values: Sequence[float]) -> None:
@@ -258,9 +168,11 @@ class ActuatorRandomizerState(RandomizationTermBase):
         self.enable_pd_gain = bool(params.get("enable_pd_gain", True))
         self.enable_rfi_lim = bool(params.get("enable_rfi_lim", False))
 
-        self.kp_range: Sequence[float] = [float(kp_range[0]), float(kp_range[1])]
-        self.kd_range: Sequence[float] = [float(kd_range[0]), float(kd_range[1])]
-        self.rfi_lim_range: Sequence[float] = [float(rfi_lim_range[0]), float(rfi_lim_range[1])]
+        # Ranges are config leaves ([lo, hi] pair, uniform; or a spec dict) kept as-is so an explicit
+        # spec survives to the sampler.
+        self.kp_range: DistributionLike = kp_range
+        self.kd_range: DistributionLike = kd_range
+        self.rfi_lim_range: DistributionLike = rfi_lim_range
 
         self.rfi_lim = float(params.get("rfi_lim", 0.1))
 
@@ -268,7 +180,10 @@ class ActuatorRandomizerState(RandomizationTermBase):
         self.kd_scale: torch.Tensor | None = None
         self.rfi_lim_scale: torch.Tensor | None = None
 
-    def setup(self) -> None:
+    # Per-quantity axis tags so kp / kd / rfi draw from independent keyed streams.
+    _AXIS_KP, _AXIS_KD, _AXIS_RFI = 0, 1, 2
+
+    def setup(self, sampler: TermSampler) -> None:
         env = self.env
         device = env.device
         num_envs = env.num_envs
@@ -287,7 +202,7 @@ class ActuatorRandomizerState(RandomizationTermBase):
                 "the term will attach shared actuator scales once its setup() runs."
             )
 
-    def reset(self, env_ids: torch.Tensor | None) -> None:
+    def reset(self, env_ids: torch.Tensor | None, sampler: TermSampler) -> None:
         if self.kp_scale is None or self.kd_scale is None or self.rfi_lim_scale is None:
             raise RuntimeError("ActuatorRandomizerState.setup() must be called before reset().")
 
@@ -296,26 +211,39 @@ class ActuatorRandomizerState(RandomizationTermBase):
             return
 
         device = self.env.device
+        n_dof = self.env.num_dof
+        # Per-(env, dof) draws: dof indices as a [1, n_dof] coord -> [n_env, n_dof]; the _AXIS_* ints
+        # are the per-quantity STREAM coords keeping kp/kd/rfi mutually independent.
+        dof_ids = torch.arange(n_dof)[None, :]
 
         if self.enable_pd_gain:
-            self.kp_scale[idx] = torch_rand_float(
-                self.kp_range[0], self.kp_range[1], (idx.shape[0], self.env.num_dof), device=device
+            self.kp_scale[idx] = sampler.draw(
+                self.kp_range,
+                env_ids=idx,
+                coords=(self._AXIS_KP, dof_ids),
+                device=device,
             )
-            self.kd_scale[idx] = torch_rand_float(
-                self.kd_range[0], self.kd_range[1], (idx.shape[0], self.env.num_dof), device=device
+            self.kd_scale[idx] = sampler.draw(
+                self.kd_range,
+                env_ids=idx,
+                coords=(self._AXIS_KD, dof_ids),
+                device=device,
             )
         else:
             self.kp_scale[idx] = 1.0
             self.kd_scale[idx] = 1.0
 
         if self.enable_rfi_lim:
-            self.rfi_lim_scale[idx] = torch_rand_float(
-                self.rfi_lim_range[0], self.rfi_lim_range[1], (idx.shape[0], self.env.num_dof), device=device
+            self.rfi_lim_scale[idx] = sampler.draw(
+                self.rfi_lim_range,
+                env_ids=idx,
+                coords=(self._AXIS_RFI, dof_ids),
+                device=device,
             )
         else:
             self.rfi_lim_scale[idx] = 1.0
 
-    def step(self) -> None:
+    def step(self, sampler: TermSampler) -> None:
         """No per-step behaviour required."""
 
     @property
@@ -337,7 +265,9 @@ class ActuatorRandomizerState(RandomizationTermBase):
         return self.rfi_lim_scale
 
 
-def setup_action_delay_buffers(env, *, ctrl_delay_step_range: Sequence[int], enabled: bool = True, **_) -> None:
+def setup_action_delay_buffers(
+    env, sampler: TermSampler, *, ctrl_delay_step_range: Sequence[int], enabled: bool = True, **_
+) -> None:
     """Initialize action delay index buffer during setup.
 
     Note: The action_queue itself is managed by the action manager.
@@ -349,17 +279,15 @@ def setup_action_delay_buffers(env, *, ctrl_delay_step_range: Sequence[int], ena
     if not enabled:
         return
 
-    # Initialize action delay indices (determines which action from the queue to use)
-    env.action_delay_idx = torch.randint(
-        ctrl_delay_step_range[0],
-        ctrl_delay_step_range[1] + 1,
-        (env.num_envs,),
-        device=env.device,
-        requires_grad=False,
-    )
+    # Keyed discrete draw (per-env, reproducible) of the delay index in [lo, hi] inclusive -> [n_env].
+    env.action_delay_idx = sampler.draw_int(
+        int(ctrl_delay_step_range[0]),
+        int(ctrl_delay_step_range[1]),
+        env_ids=torch.arange(env.num_envs, device="cpu"),
+    ).to(env.device)
 
 
-def setup_torque_rfi(env, *, enabled: bool = False, rfi_lim: float = 0.1, **_) -> None:
+def setup_torque_rfi(env, sampler: TermSampler, *, enabled: bool = False, rfi_lim: float = 0.1, **_) -> None:
     """Configure torque RFI at startup."""
     term = _get_joint_action_term(env)
     env._pending_torque_rfi = (bool(enabled), float(rfi_lim))
@@ -368,18 +296,31 @@ def setup_torque_rfi(env, *, enabled: bool = False, rfi_lim: float = 0.1, **_) -
     term.configure_torque_rfi(enabled=env._pending_torque_rfi[0], rfi_lim=env._pending_torque_rfi[1])
 
 
-def setup_dof_pos_bias(env, *, dof_pos_bias_range: Sequence[float], enabled: bool = False, **_) -> None:
-    """Apply startup DOF position bias randomization."""
+def setup_dof_pos_bias(
+    env,
+    sampler: TermSampler,
+    *,
+    dof_pos_bias_range: DistributionLike,
+    enabled: bool = False,
+    **_,
+) -> None:
+    """Apply startup DOF position bias randomization.
+
+    ``dof_pos_bias_range`` is a config range value — a ``[lo, hi]`` pair (uniform) or a spec dict, drawn via
+    the bound sampler. A gaussian bias gives a smoother initial-pose jitter than uniform.
+    """
     env._randomize_dof_pos_bias = bool(enabled)
-    env._dof_pos_bias_range = list(dof_pos_bias_range)
+    env._dof_pos_bias_range = dof_pos_bias_range
 
     if not enabled:
         return
 
-    default_dof_pos_bias = torch_rand_float(
-        dof_pos_bias_range[0],
-        dof_pos_bias_range[1],
-        (env.num_envs, env.num_dof),
+    # Per-(env, dof): dof indices as a [1, n_dof] coord -> [n_env, n_dof].
+    dof_ids = torch.arange(env.num_dof)[None, :]
+    default_dof_pos_bias = sampler.draw(
+        dof_pos_bias_range,
+        env_ids=torch.arange(env.num_envs, device="cpu"),
+        coords=(dof_ids,),
         device=env.device,
     )
     env.default_dof_pos = env.default_dof_pos_base + default_dof_pos_bias
@@ -389,6 +330,7 @@ def randomize_push_schedule(
     env,
     env_ids,
     *,
+    sampler: TermSampler,
     push_interval_s: Sequence[float] | None = None,
     enabled: bool | None = None,
     max_push_vel: Sequence[float] | None = None,
@@ -411,13 +353,25 @@ def randomize_push_schedule(
         return
 
     state.zero_counters(idx)
-    state.resample(idx)
+    state.resample(idx, sampler)
 
 
 def randomize_pd_gains(
-    env, env_ids, *, kp_range: Sequence[float], kd_range: Sequence[float], enabled: bool = True, **_
+    env,
+    env_ids,
+    *,
+    sampler: TermSampler,
+    kp_range: DistributionLike,
+    kd_range: DistributionLike,
+    enabled: bool = True,
+    **_,
 ):
-    """Randomize proportional and derivative gain scales."""
+    """Randomize proportional and derivative gain scales.
+
+    ``kp_range``/``kd_range`` are config leaves ([lo, hi] pair, uniform; or a spec dict), drawn via
+    the bound sampler. When the actuator state is registered this delegates to it (passing the
+    sampler through); otherwise it draws directly.
+    """
     state = env.randomization_manager.get_state("actuator_randomizer_state")
     term = _get_joint_action_term(env)
     if state is None:
@@ -434,26 +388,32 @@ def randomize_pd_gains(
             term.update_pd_scales(idx, torch.ones_like(kp_scale[idx]), torch.ones_like(kd_scale[idx]))
             return
 
-        kp_samples = torch_rand_float(kp_range[0], kp_range[1], (idx.shape[0], env.num_dof), device=env.device)
-        kd_samples = torch_rand_float(kd_range[0], kd_range[1], (idx.shape[0], env.num_dof), device=env.device)
+        dof_ids = torch.arange(env.num_dof)[None, :]  # [1, n_dof] -> [n_env, n_dof]; ints 0/1 = streams
+        kp_samples = sampler.draw(kp_range, env_ids=idx, coords=(0, dof_ids), device=env.device)
+        kd_samples = sampler.draw(kd_range, env_ids=idx, coords=(1, dof_ids), device=env.device)
         term.update_pd_scales(idx, kp_samples, kd_samples)
         return
 
     state.enable_pd_gain = bool(enabled)
-    state.kp_range = [float(kp_range[0]), float(kp_range[1])]
-    state.kd_range = [float(kd_range[0]), float(kd_range[1])]
-    state.reset(env_ids)
+    state.kp_range = kp_range
+    state.kd_range = kd_range
+    state.reset(env_ids, sampler)
 
 
 def randomize_rfi_limits(
     env,
     env_ids,
     *,
-    rfi_lim_range: Sequence[float],
+    sampler: TermSampler,
+    rfi_lim_range: DistributionLike,
     enabled: bool = True,
     **_,
 ) -> None:
-    """Randomize residual force injection limits."""
+    """Randomize residual force injection limits.
+
+    ``rfi_lim_range`` is a config range value — a ``[lo, hi]`` pair (uniform) or a spec dict, drawn via the
+    bound sampler.
+    """
     state = env.randomization_manager.get_state("actuator_randomizer_state")
     term = _get_joint_action_term(env)
     if state is None:
@@ -469,21 +429,21 @@ def randomize_rfi_limits(
             term.update_rfi_scales(idx, torch.ones_like(term.get_rfi_scale_tensor()[idx]))
             return
 
-        rfi_samples = torch_rand_float(
-            rfi_lim_range[0], rfi_lim_range[1], (idx.shape[0], env.num_dof), device=env.device
-        )
+        dof_ids = torch.arange(env.num_dof)[None, :]  # [1, n_dof] -> [n_env, n_dof]; int 2 = stream
+        rfi_samples = sampler.draw(rfi_lim_range, env_ids=idx, coords=(2, dof_ids), device=env.device)
         term.update_rfi_scales(idx, rfi_samples)
         return
 
     state.enable_rfi_lim = bool(enabled)
-    state.rfi_lim_range = [float(rfi_lim_range[0]), float(rfi_lim_range[1])]
-    state.reset(env_ids)
+    state.rfi_lim_range = rfi_lim_range
+    state.reset(env_ids, sampler)
 
 
 def randomize_action_delay(
     env,
     env_ids,
     *,
+    sampler: TermSampler,
     ctrl_delay_step_range: Sequence[int] | None = None,
     enabled: bool | None = None,
     **_,
@@ -504,8 +464,8 @@ def randomize_action_delay(
         env._ctrl_delay_step_range = list(ctrl_delay_step_range)
     elif not hasattr(env, "_ctrl_delay_step_range"):
         raise AttributeError(
-            "randomize_action_delay() requires setup_action_delay_buffers \
-                to run before it can infer ctrl_delay_step_range."
+            "randomize_action_delay() requires setup_action_delay_buffers "
+            "to run before it can infer ctrl_delay_step_range."
         )
 
     if not env._randomize_ctrl_delay:
@@ -521,62 +481,48 @@ def randomize_action_delay(
 
     delay_low = int(env._ctrl_delay_step_range[0])
     delay_high = int(env._ctrl_delay_step_range[1])
-    if delay_high < delay_low:
-        raise ValueError("ctrl_delay_step_range upper bound must be >= lower bound.")
 
-    # Randomize delay indices
-    env.action_delay_idx[idx] = torch.randint(
-        delay_low,
-        delay_high + 1,
-        (idx.shape[0],),
-        device=env.device,
-        requires_grad=False,
-    )
+    # Keyed discrete delay index per env (reproducible per (term, env, episode)) -> [n_env].
+    # Bounds ordering is validated inside draw_int (single source of truth).
+    env.action_delay_idx[idx] = sampler.draw_int(delay_low, delay_high, env_ids=idx).to(env.device)
 
 
 def randomize_dof_state(
     env,
     env_ids,
     *,
-    joint_pos_scale_range: Sequence[float],
-    joint_pos_bias_range: Sequence[float],
-    joint_vel_range: Sequence[float],
+    sampler: TermSampler,
+    joint_pos_scale_range: DistributionLike,
+    joint_pos_bias_range: DistributionLike,
+    joint_vel_range: DistributionLike,
     randomize_dof_pos_bias: bool = False,
     **_,
 ) -> None:
-    """Randomize DOF positions and velocities."""
-    env._joint_pos_scale_range = list(joint_pos_scale_range)
-    env._joint_pos_bias_range = list(joint_pos_bias_range)
-    env._joint_vel_range = list(joint_vel_range)
+    """Randomize DOF positions and velocities.
+
+    Each range is a config range value — a ``[lo, hi]`` pair (uniform) or a spec dict, drawn via the bound
+    sampler. The three quantities (pos scale, pos bias, vel) draw on independent axes so they don't
+    share a stream.
+    """
+    env._joint_pos_scale_range = joint_pos_scale_range
+    env._joint_pos_bias_range = joint_pos_bias_range
+    env._joint_vel_range = joint_vel_range
     env._randomize_dof_pos_bias = bool(randomize_dof_pos_bias)
 
     idx = _ensure_env_ids_tensor(env, env_ids)
     if idx.numel() == 0:
         return
 
-    scale_factor = torch_rand_float(
-        joint_pos_scale_range[0],
-        joint_pos_scale_range[1],
-        (idx.shape[0], env.num_dof),
-        device=env.device,
-    )
+    n_dof = env.num_dof
+    dof_ids = torch.arange(n_dof)[None, :]  # [1, n_dof] -> [n_env, n_dof]; ints 0/1/2 = streams
+    scale_factor = sampler.draw(joint_pos_scale_range, env_ids=idx, coords=(0, dof_ids), device=env.device)
     if randomize_dof_pos_bias:
-        bias_offset = torch_rand_float(
-            joint_pos_bias_range[0],
-            joint_pos_bias_range[1],
-            (idx.shape[0], env.num_dof),
-            device=env.device,
-        )
+        bias_offset = sampler.draw(joint_pos_bias_range, env_ids=idx, coords=(1, dof_ids), device=env.device)
     else:
-        bias_offset = torch.zeros((idx.shape[0], env.num_dof), device=env.device)
+        bias_offset = torch.zeros((idx.shape[0], n_dof), device=env.device)
 
     env.simulator.dof_pos[idx] = env.default_dof_pos[idx] * scale_factor + bias_offset
-    env.simulator.dof_vel[idx] = torch_rand_float(
-        joint_vel_range[0],
-        joint_vel_range[1],
-        (idx.shape[0], env.num_dof),
-        device=env.device,
-    )
+    env.simulator.dof_vel[idx] = sampler.draw(joint_vel_range, env_ids=idx, coords=(2, dof_ids), device=env.device)
 
 
 @mujoco_required_field("body_ipos")
@@ -584,14 +530,24 @@ def randomize_base_com_startup(
     env,
     env_ids: Sequence[int] | torch.Tensor | None = None,
     *,
-    base_com_range: dict[str, Sequence[float]],
+    sampler: TermSampler,
+    base_com_range: BaseComRange | dict[str, DistributionLike],
     enabled: bool = True,
     **_,
 ) -> None:
     """Randomize base (torso) center of mass.
 
     Note: Uses ADDITION operation to offset CoM position (e.g., x: [-0.01, 0.01] m).
+
+    ``base_com_range`` is a :class:`BaseComRange` (or an equivalent ``{x, y, z}`` dict); each axis is a
+    ``[lo, hi]`` pair (uniform) or a ``{kind, low, high, mean, std}`` spec dict —
+    honored identically on ALL backends (IsaacGym per-axis loop, MuJoCo ``randomize_field``, IsaacSim
+    project-owned ``randomize_body_com``), all via the shared keyed
+    :meth:`holosoma.utils.sampler.TermSampler.draw`. A gaussian spec is a truncated normal on
+    ``[lo, hi]``; log_uniform requires positive bounds.
     """
+    if isinstance(base_com_range, BaseComRange):
+        base_com_range = {"x": base_com_range.x, "y": base_com_range.y, "z": base_com_range.z}
     env._randomize_base_com = bool(enabled)
     env._base_com_range = base_com_range
     if not enabled:
@@ -610,7 +566,7 @@ def randomize_base_com_startup(
     if idx.numel() == 0:
         return
 
-    if hasattr(simulator, "gym"):
+    if simulator.get_simulator_type() == SimulatorType.ISAACGYM:
         gym = simulator.gym
         torso_name = env.robot_config.torso_name
         if not hasattr(simulator, "_base_com_bias"):
@@ -618,7 +574,17 @@ def randomize_base_com_startup(
                 env.num_envs, 3, dtype=torch.float, device=env.device, requires_grad=False
             )
 
-        for env_id in idx.tolist():
+        # Per-axis (x/y/z) draw for all envs at once, keyed per env; index per actor in the loop. CoM
+        # offsets are commonly signed (e.g. x: [-0.025, 0.025]); gaussian truncates to the range,
+        # log_uniform (correctly) raises on a non-positive bound at spec construction.
+        # Draw on CPU: the values are consumed per-actor via .item() below (IsaacGym props are CPU),
+        # matching the sibling friction/mass draws and avoiding a pointless GPU round-trip.
+        axis_draws = [
+            sampler.draw(base_com_range[ax], env_ids=idx, coords=(k,), device="cpu")
+            for k, ax in enumerate(("x", "y", "z"))
+        ]  # each [n_env]; stack the three per-axis streams into (n_env, 3)
+        bias_all = torch.stack(axis_draws, dim=-1)  # (n_env, 3)
+        for offset, env_id in enumerate(idx.tolist()):
             env_ptr = simulator.envs[env_id]
             actor = simulator.robot_handles[env_id]
             body_props = gym.get_actor_rigid_body_properties(env_ptr, actor)
@@ -626,25 +592,17 @@ def randomize_base_com_startup(
             if body_index < 0:
                 raise RuntimeError(f"Body '{torso_name}' not found when randomizing base COM.")
 
-            xrange = base_com_range["x"]
-            yrange = base_com_range["y"]
-            zrange = base_com_range["z"]
-
-            bias = torch.tensor(
-                [
-                    torch_rand_float(xrange[0], xrange[1], (1, 1), device=env.device).item(),
-                    torch_rand_float(yrange[0], yrange[1], (1, 1), device=env.device).item(),
-                    torch_rand_float(zrange[0], zrange[1], (1, 1), device=env.device).item(),
-                ],
-                dtype=torch.float,
-                device=env.device,
-            )
+            bias = bias_all[offset]
             simulator._base_com_bias[env_id] = bias
             body_props[body_index].com.x += bias[0].item()
             body_props[body_index].com.y += bias[1].item()
             body_props[body_index].com.z += bias[2].item()
-            gym.set_actor_rigid_body_properties(env_ptr, actor, body_props, recomputeInertia=True)
-    elif simulator.__class__.__name__ == "IsaacSim":
+            # recomputeInertia=False: a CoM shift must NOT rewrite the inertia tensor from geometry —
+            # that would discard the authored inertia and diverge from IsaacSim (randomize_body_com
+            # writes coms only) and MuJoCo (writes body_ipos only), both of which leave body_inertia
+            # (the principal moments about the body CoM) unchanged.
+            gym.set_actor_rigid_body_properties(env_ptr, actor, body_props, recomputeInertia=False)
+    elif simulator.get_simulator_type() == SimulatorType.ISAACSIM:
         try:
             from isaaclab.managers import SceneEntityCfg
         except ImportError as exc:  # pragma: no cover - dependency optional
@@ -653,47 +611,34 @@ def randomize_base_com_startup(
 
         torso_name = env.robot_config.torso_name
         env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
-        if env_ids_cpu.numel() == 0:
-            return
 
-        low = torch.tensor(
-            [base_com_range["x"][0], base_com_range["y"][0], base_com_range["z"][0]],
-            dtype=torch.float,
-            device="cpu",
-        )
-        high = torch.tensor(
-            [base_com_range["x"][1], base_com_range["y"][1], base_com_range["z"][1]],
-            dtype=torch.float,
-            device="cpu",
-        )
+        # One spec per axis (x, y, z).
+        specs = [DistributionSpec.parse(base_com_range[axis]) for axis in ("x", "y", "z")]
         asset_cfg = SceneEntityCfg("robot", body_names=[torso_name])
         asset_cfg.resolve(simulator.scene)  # Required to avoid applying randomization to all bodies
         randomize_body_com(
             simulator,
             env_ids_cpu,
             asset_cfg,
-            (low, high),
+            specs,
             operation="add",
-            distribution="uniform",
-            num_envs=simulator.training_config.num_envs,
+            sampler=sampler,
         )
-    elif simulator.simulator_config.mujoco_backend == MujocoBackend.WARP:
-        from holosoma.simulator.mujoco.backends.warp_randomization import randomize_field
+    elif simulator.get_simulator_type() == SimulatorType.MUJOCO:
+        from holosoma.simulator.mujoco.backends.randomization import randomize_field
 
-        # convert xyz to 012
-        base_com_range_remapped = {}
-        for key, value in base_com_range.items():
-            assert len(value) == 2, f"Range for '{key}' must have exactly 2 elements, got {len(value)}"
-            base_com_range_remapped["xyz".index(key)] = (value[0], value[1])
+        # convert xyz -> axis index 0/1/2, passing each range (a [lo, hi] pair or spec dict) through
+        # unchanged so an explicit per-axis spec survives to the sampler.
+        base_com_range_remapped = {"xyz".index(key): value for key, value in base_com_range.items()}
         randomize_field(
             simulator,
             field=getattr(randomize_base_com_startup, MUJOCO_FIELD_ATTR),
             ranges=base_com_range_remapped,
+            sampler=sampler,
             env_ids=idx,
             entity_names=[env.robot_config.torso_name],
             entity_type="body",
             operation="add",
-            distribution="uniform",
         )
 
     else:  # pragma: no cover - defensive
@@ -707,17 +652,32 @@ def randomize_mass_startup(
     env,
     env_ids: Sequence[int] | torch.Tensor | None = None,
     *,
+    sampler: TermSampler,
     enable_link_mass: bool = True,
-    link_mass_range: Sequence[float] = (1.0, 1.0),
+    link_mass_range: DistributionLike = (1.0, 1.0),
     enable_base_mass: bool = True,
-    added_mass_range: Sequence[float] = (0.0, 0.0),
+    added_mass_range: DistributionLike = (0.0, 0.0),
     enabled: bool = True,
+    recompute_inertia: bool = True,
     **_,
 ) -> None:
     """Randomize link and base masses at startup.
 
     Note: link_mass_range uses SCALING (e.g., 0.9-1.2 = 90-120% of original),
           added_mass_range uses ADDITION (e.g., -1.0 to 3.0 kg offset).
+
+    ``recompute_inertia`` (default True): each body's inertia is rescaled by the SAME factor its mass
+    changed by (``m_after / m_before``), identically on all backends (explicit multiplicative ratio —
+    NOT a from-geometry recompute — so it commutes with a separate inertia DR term). This mirrors the
+    object mass term's contract. When False, mass changes and inertia is left untouched.
+
+    Each range is a config range value — a ``[lo, hi]`` pair (uniform) or a ``{kind, low, high, mean, std}``
+    spec dict — honored identically on ALL backends (IsaacGym per-actor loop, MuJoCo
+    ``randomize_field``, IsaacSim via the project-owned ``randomize_rigid_body_mass``), all via the
+    shared keyed :meth:`holosoma.utils.sampler.TermSampler.draw`. A gaussian spec is a truncated normal
+    on ``[lo, hi]``; log_uniform requires positive bounds (so it suits the scale operation,
+    ``link_mass_range``, and by design RAISES on a signed ``added_mass_range`` rather than silently
+    mis-sampling).
     """
     if not enabled:
         return
@@ -736,7 +696,7 @@ def randomize_mass_startup(
     env._randomize_link_mass = bool(enable_link_mass)
     env._randomize_base_mass = bool(enable_base_mass)
 
-    if hasattr(simulator, "gym"):
+    if simulator.get_simulator_type() == SimulatorType.ISAACGYM:
         gym = simulator.gym
         body_names = list(env.robot_config.randomize_link_body_names or [])
         torso_name = env.robot_config.torso_name
@@ -759,87 +719,142 @@ def randomize_mass_startup(
             if enable_base_mass and torso_name in simulator._body_list:
                 base_mass = float(sample_props[simulator._body_list.index(torso_name)].mass)
                 logger.debug(f"[randomize_mass_startup][IsaacGym] default torso mass: {base_mass:.6f}")
-        for env_id in idx.tolist():
+        # Pre-draw keyed tensors for all envs at once, then index per actor in the loop. Link scale is
+        # per (env, body) keyed by the stable body index (stream 0, body ids on the trailing dim ->
+        # [n_env, n_link]); base-mass add is per env (stream 1 -> [n_env]).
+        # Warn on configured link bodies absent from this robot rather than silently dropping them:
+        # MuJoCo (resolve_entity_ids) and IsaacSim (SceneEntityCfg.resolve) both RAISE on an unknown
+        # body name, so silence here would be an inconsistent, backend-specific drop of an explicit request.
+        if enable_link_mass:
+            missing = [n for n in body_names if n not in simulator._body_list]
+            if missing:
+                logger.warning(
+                    f"[randomize_mass_startup][IsaacGym] link body name(s) {missing} not found on the "
+                    f"robot (body list: {simulator._body_list}); link-mass randomization skipped for them."
+                )
+        link_body_ids = [simulator._body_list.index(n) for n in body_names if n in simulator._body_list]
+        link_scales = (
+            sampler.draw(link_mass_range, env_ids=idx, coords=(0, torch.tensor(link_body_ids)[None, :]), device="cpu")
+            if enable_link_mass and link_body_ids
+            else None
+        )
+        base_deltas = (
+            sampler.draw(added_mass_range, env_ids=idx, coords=(1,), device="cpu")
+            if enable_base_mass and torso_name in simulator._body_list
+            else None
+        )
+        for offset, env_id in enumerate(idx.tolist()):
             env_ptr = simulator.envs[env_id]
             actor = simulator.robot_handles[env_id]
             body_props = gym.get_actor_rigid_body_properties(env_ptr, actor)
-            if enable_link_mass and body_names:
-                for body_name in body_names:
-                    if body_name not in simulator._body_list:
-                        continue
-                    body_index = simulator._body_list.index(body_name)
-                    scale = np.random.uniform(link_mass_range[0], link_mass_range[1])
-                    body_props[body_index].mass *= scale  # Scale operation: multiply by factor
-            if enable_base_mass and torso_name in simulator._body_list:
+            # Snapshot mass per touched body so inertia can be scaled by the exact ratio THIS write
+            # produced (explicit m_after/m_before — NOT recomputeInertia=True, which recomputes from
+            # geometry, a different result that would also clobber a prior inertia-DR scale).
+            touched: dict[int, float] = {}
+            if link_scales is not None:
+                for col, body_index in enumerate(link_body_ids):
+                    touched.setdefault(body_index, body_props[body_index].mass)
+                    body_props[body_index].mass *= float(link_scales[offset, col])  # scale by factor
+            if base_deltas is not None:
                 base_index = simulator._body_list.index(torso_name)
-                delta = np.random.uniform(added_mass_range[0], added_mass_range[1])
-                body_props[base_index].mass += delta  # Add operation: offset by delta
-            gym.set_actor_rigid_body_properties(env_ptr, actor, body_props, recomputeInertia=True)
-    elif simulator.__class__.__name__ == "IsaacSim":
+                touched.setdefault(base_index, body_props[base_index].mass)
+                body_props[base_index].mass += float(base_deltas[offset])  # add operation: offset
+            if recompute_inertia:
+                for body_index, m_before in touched.items():
+                    if m_before > 0.0:
+                        r = body_props[body_index].mass / m_before
+                        inertia = body_props[body_index].inertia  # gymapi.Mat33, symmetric
+                        inertia.x.x *= r
+                        inertia.y.y *= r
+                        inertia.z.z *= r
+                        inertia.x.y *= r
+                        inertia.y.x *= r
+                        inertia.y.z *= r
+                        inertia.z.y *= r
+                        inertia.x.z *= r
+                        inertia.z.x *= r
+            # recomputeInertia=False: inertia is set explicitly above (or left untouched).
+            gym.set_actor_rigid_body_properties(env_ptr, actor, body_props, recomputeInertia=False)
+    elif simulator.get_simulator_type() == SimulatorType.ISAACSIM:
         try:
             from isaaclab.managers import SceneEntityCfg
         except ImportError as exc:  # pragma: no cover - defensive
             raise RuntimeError("IsaacSim mass randomization requires isaaclab.") from exc
 
+        from holosoma.simulator.isaacsim.events import randomize_rigid_body_mass
+
         env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
-        if env_ids_cpu.numel() == 0:
-            return
 
         if enable_link_mass:
             asset_cfg = SceneEntityCfg("robot", body_names=env.robot_config.randomize_link_body_names)
             asset_cfg.resolve(simulator.scene)  # Required to avoid applying randomization to all bodies
-            _isaacsim_randomize_rigid_body_mass(
+            randomize_rigid_body_mass(
                 simulator,
                 env_ids_cpu,
                 asset_cfg,
-                (link_mass_range[0], link_mass_range[1]),
+                link_mass_range,
                 operation="scale",
+                sampler=sampler,
+                recompute_inertia=recompute_inertia,
             )
 
         if enable_base_mass:
             asset_cfg = SceneEntityCfg("robot", body_names=[env.robot_config.torso_name])
             asset_cfg.resolve(simulator.scene)  # Required to avoid applying randomization to all bodies
-            _isaacsim_randomize_rigid_body_mass(
+            randomize_rigid_body_mass(
                 simulator,
                 env_ids_cpu,
                 asset_cfg,
-                (added_mass_range[0], added_mass_range[1]),
+                added_mass_range,
                 operation="add",
+                sampler=sampler,
+                axis=1,  # base-add stream, distinct from link-scale (axis 0) so a body in both lists decorrelates
+                recompute_inertia=recompute_inertia,
             )
-    elif simulator.simulator_config.mujoco_backend == MujocoBackend.WARP:
-        from holosoma.simulator.mujoco.backends.warp_randomization import randomize_field
+    elif simulator.get_simulator_type() == SimulatorType.MUJOCO:
+        from holosoma.simulator.mujoco.backends.randomization import (
+            _field_view,
+            randomize_field,
+            resolve_entity_ids,
+            scale_inertia_by_mass_ratio,
+        )
 
-        # randomize over the range (scale and/or shift)
-        if idx.numel() == 0:
-            return
+        mass_field = getattr(randomize_mass_startup, MUJOCO_FIELD_ATTR)
 
+        def _mass_write(
+            names: Sequence[str], ranges, *, operation: Literal["add", "scale", "abs"], axis_base: int
+        ) -> None:
+            # Resolve to body ids ourselves so the inertia rescale (which has no name API) uses the
+            # same bodies, and snapshot mass BEFORE so the ratio matches the exact write this produced
+            # (mirrors the object mass term + the IsaacGym/IsaacSim explicit m_after/m_before scale).
+            body_ids = torch.tensor(
+                resolve_entity_ids(simulator.backend.model, list(names), "body"),
+                device=simulator.sim_device,
+                dtype=torch.long,
+            )
+            mass_before = _field_view(simulator, "body_mass")[:, body_ids].clone() if recompute_inertia else None
+            randomize_field(
+                simulator,
+                field=mass_field,
+                ranges=ranges,
+                sampler=sampler,
+                env_ids=idx,
+                entity_ids=body_ids,
+                operation=operation,
+                axis_base=axis_base,
+            )
+            if recompute_inertia:
+                scale_inertia_by_mass_ratio(simulator, body_ids, mass_before)
+
+        # each range is a pair or spec dict, passed to randomize_field which builds the spec.
         if enable_link_mass:
-            assert len(link_mass_range) == 2, (
-                f"link_mass_range must have exactly 2 elements, got {len(link_mass_range)}"
-            )
-            randomize_field(
-                simulator,
-                field=getattr(randomize_mass_startup, MUJOCO_FIELD_ATTR),
-                ranges=(link_mass_range[0], link_mass_range[1]),
-                env_ids=idx,
-                entity_names=env.robot_config.randomize_link_body_names,
-                entity_type="body",
-                operation="scale",
-            )
-
+            _mass_write(
+                env.robot_config.randomize_link_body_names, link_mass_range, operation="scale", axis_base=0
+            )  # link-scale stream
         if enable_base_mass:
-            assert len(added_mass_range) == 2, (
-                f"added_mass_range must have exactly 2 elements, got {len(added_mass_range)}"
-            )
-            randomize_field(
-                simulator,
-                field=getattr(randomize_mass_startup, MUJOCO_FIELD_ATTR),
-                ranges=(added_mass_range[0], added_mass_range[1]),
-                env_ids=idx,
-                entity_names=[env.robot_config.torso_name],
-                entity_type="body",
-                operation="add",
-            )
+            _mass_write(
+                [env.robot_config.torso_name], added_mass_range, operation="add", axis_base=1
+            )  # base-add stream (distinct from link-scale)
 
     else:  # pragma: no cover - defensive
         raise RandomizerNotSupportedError(
@@ -847,25 +862,62 @@ def randomize_mass_startup(
         )
 
 
+def _draw_bucketed_per_env(
+    sampler: TermSampler,
+    spec: DistributionLike,
+    env_ids: torch.Tensor,
+    num_buckets: int | None,
+) -> torch.Tensor:
+    """Draw one friction value per env, bucketed or continuous, on the PhysX (IsaacGym) path.
+
+    ``num_buckets`` an int: fill that many buckets with the distribution's quantile values (keyed
+    permute so the staircase is reproducible-but-shuffled per seed) and pick one bucket per env via
+    the keyed selection — bounds the unique-material count at ``num_buckets`` regardless of env count.
+    ``None``: one continuous keyed draw per env (~``num_envs`` unique values). Mirrors the IsaacSim
+    material writer's bucket mechanism so both PhysX backends share one quantization policy.
+    """
+    if num_buckets is None:
+        return sampler.draw(spec, env_ids=env_ids)  # [n_env], continuous
+    column = quantiles(DistributionSpec.parse(spec), num_buckets, "cpu")[sampler.permute(num_buckets, (0,))]
+    bucket_ids = sampler.draw_int(0, num_buckets - 1, env_ids=env_ids, coords=(1,))
+    return column[bucket_ids]
+
+
 @mujoco_required_field("geom_friction")
 def randomize_friction_startup(
     env,
     env_ids: Sequence[int] | torch.Tensor | None = None,
     *,
-    friction_range: Sequence[float],
+    sampler: TermSampler,
+    friction_range: DistributionLike,
+    num_buckets: int | None = _MATERIAL_NUM_BUCKETS,
     enabled: bool = True,
     **_,
 ) -> None:
     """Randomize contact friction coefficients for robot rigid shapes.
 
     Note: Uses ABSOLUTE operation to set friction values (e.g., [0.5, 1.5]).
+
+    ``friction_range`` is a config range value — a ``[lo, hi]`` pair (uniform) or a spec dict.
+
+    ``num_buckets`` controls VALUE QUANTIZATION uniformly across all three backends (default 64):
+    friction here draws through the shared keyed sampler, and an int quantizes each draw onto
+    ``num_buckets`` stratified quantile values (an ``n``-atom staircase), while ``None`` draws
+    continuously. Bucketing exists to respect PhysX's per-scene material cap (~64k); the default keeps
+    that guard on the PhysX backends (IsaacGym + IsaacSim) and, for cross-backend value consistency,
+    applies the same staircase on MuJoCo (which has no cap and could otherwise be continuous). Set
+    ``None`` for a continuous marginal where the material count is safely under the cap. ``uniform`` is
+    exact when continuous; ``gaussian``/``log_uniform`` match up to the bucket quantization.
+
+    GRANULARITY still differs per backend here (IsaacGym one value per env, IsaacSim per shape, MuJoCo
+    per geom); ``num_buckets`` unifies the value set, not the granularity.
     """
     env._randomize_friction = bool(enabled)
-    env._friction_range = list(friction_range)
+    env._friction_range = friction_range
     if not enabled:
         return
 
-    logger.info(f"[Randomization] Friction: range={friction_range} (operation=abs)")
+    logger.info(f"[Randomization] Friction: range={friction_range} (operation=abs, num_buckets={num_buckets})")
 
     idx = _ensure_env_ids_tensor(env, env_ids)
     if idx.numel() == 0:
@@ -873,60 +925,59 @@ def randomize_friction_startup(
 
     simulator = env.simulator
 
-    num_buckets = 64
-    buckets = torch_rand_float(
-        friction_range[0],
-        friction_range[1],
-        (num_buckets, 1),
-        device="cpu",
-    )
-
-    idx_cpu = idx.to(device="cpu", dtype=torch.long)
-    bucket_ids = torch.randint(0, num_buckets, (idx_cpu.shape[0],), device="cpu")
-    friction_samples_cpu = buckets[bucket_ids]
-
-    if hasattr(simulator, "gym"):
+    if simulator.get_simulator_type() == SimulatorType.ISAACGYM:
+        # IsaacGym sets prop.friction directly. One friction per env -> ~num_envs unique PhysX
+        # materials, so bucket (default) to bound that count under the cap, or draw continuous per env
+        # when num_buckets is None. Same quantization policy as the IsaacSim branch below.
         gym = simulator.gym
+        idx_cpu = idx.to(device="cpu", dtype=torch.long)
+        friction_samples = _draw_bucketed_per_env(sampler, friction_range, idx_cpu, num_buckets)  # [n_env]
         for offset, env_id in enumerate(idx_cpu.tolist()):
             env_ptr = simulator.envs[env_id]
             actor = simulator.robot_handles[env_id]
             shape_props = gym.get_actor_rigid_shape_properties(env_ptr, actor)
-            friction_value = friction_samples_cpu[offset].item()
+            friction_value = float(friction_samples[offset])
             for prop in shape_props:
                 prop.friction = friction_value
             gym.set_actor_rigid_shape_properties(env_ptr, actor, shape_props)
-    elif simulator.__class__.__name__ == "IsaacSim":
+    elif simulator.get_simulator_type() == SimulatorType.ISAACSIM:
         try:
             from isaaclab.managers import SceneEntityCfg
         except ImportError as exc:  # pragma: no cover - defensive
             raise RuntimeError("IsaacSim friction randomization requires isaaclab.") from exc
         env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
-        if env_ids_cpu.numel() == 0:
-            return
+
+        from holosoma.simulator.isaacsim.events import randomize_rigid_body_material
 
         asset_cfg = SceneEntityCfg("robot", body_names=".*")
         asset_cfg.resolve(simulator.scene)  # Not stricly required, but a good practice
 
-        _isaacsim_randomize_rigid_body_material(
+        randomize_rigid_body_material(
             simulator,
             env_ids_cpu,
             asset_cfg,
-            static_friction_range=(friction_range[0], friction_range[1]),
-            dynamic_friction_range=(friction_range[0], friction_range[1]),
-            restitution_range=(0.0, 0.0),
-            num_buckets=num_buckets,
+            static_friction=friction_range,
+            dynamic_friction=friction_range,
+            restitution=None,  # leave restitution at each shape's spawned value (friction-only term);
+            # matches the IsaacGym/MuJoCo branches, which never touch restitution here.
+            num_buckets=num_buckets,  # same quantization policy as the IsaacGym branch
+            sampler=sampler,
         )
 
-    elif simulator.simulator_config.mujoco_backend == MujocoBackend.WARP:
-        from holosoma.simulator.mujoco.backends.warp_randomization import randomize_field
+    elif simulator.get_simulator_type() == SimulatorType.MUJOCO:
+        # MuJoCo writes geom_friction directly (no material cap), so continuous per-geom is the true
+        # marginal (num_buckets=None). When num_buckets is set, quantize onto the same staircase the
+        # PhysX backends use so a bucketed friction config reads consistently across all three.
+        from holosoma.simulator.mujoco.backends.randomization import randomize_field
 
-        assert len(friction_range) == 2, f"friction_range must have exactly 2 elements, got {len(friction_range)}"
         randomize_field(
             simulator,
             field=getattr(randomize_friction_startup, MUJOCO_FIELD_ATTR),
-            ranges={0: (friction_range[0], friction_range[1])},
+            ranges={0: friction_range},
+            sampler=sampler,
             env_ids=idx,
             operation="abs",
+            num_buckets=num_buckets,
         )
 
     else:  # pragma: no cover - defensive
@@ -939,13 +990,20 @@ def randomize_robot_rigid_body_material_startup(
     env,
     env_ids: Sequence[int] | torch.Tensor | None = None,
     *,
-    static_friction_range: Sequence[float],
-    dynamic_friction_range: Sequence[float],
-    restitution_range: Sequence[float],
+    sampler: TermSampler,
+    static_friction_range: DistributionLike,
+    dynamic_friction_range: DistributionLike,
+    restitution_range: DistributionLike,
     enabled: bool = True,
     **_,
 ) -> None:
-    """Randomize robot rigid body material properties (friction, restitution)."""
+    """Randomize robot rigid body material properties (friction, restitution). IsaacSim-only.
+
+    Each range is a config range value — a ``[lo, hi]`` pair (uniform) or a spec dict — honored via the
+    quantile-bucket scheme: IsaacSim MUST bucket (PhysX caps unique materials per scene), so the
+    per-shape marginal is a 64-atom staircase approximation of the requested distribution. ``uniform``
+    is exact; ``gaussian``/``log_uniform`` are approximate.
+    """
     if not enabled:
         return
 
@@ -954,7 +1012,7 @@ def randomize_robot_rigid_body_material_startup(
         return
 
     simulator = env.simulator
-    if simulator.__class__.__name__ != "IsaacSim":
+    if simulator.get_simulator_type() != SimulatorType.ISAACSIM:
         raise RandomizerNotSupportedError(
             f"randomize_robot_rigid_body_material_startup only supports IsaacSim, got {type(simulator).__name__}"
         )
@@ -963,166 +1021,22 @@ def randomize_robot_rigid_body_material_startup(
         from isaaclab.managers import SceneEntityCfg
     except ImportError as exc:  # pragma: no cover - defensive
         raise RuntimeError("IsaacSim material randomization requires isaaclab.") from exc
+    from holosoma.simulator.isaacsim.events import randomize_rigid_body_material
 
     env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
-    if env_ids_cpu.numel() == 0:
-        return
 
     asset_cfg = SceneEntityCfg("robot", body_names=".*")
     asset_cfg.resolve(simulator.scene)
 
-    num_buckets = 64
-    _isaacsim_randomize_rigid_body_material(
+    randomize_rigid_body_material(
         simulator,
         env_ids_cpu,
         asset_cfg,
-        static_friction_range=(static_friction_range[0], static_friction_range[1]),
-        dynamic_friction_range=(dynamic_friction_range[0], dynamic_friction_range[1]),
-        restitution_range=(restitution_range[0], restitution_range[1]),
-        num_buckets=num_buckets,
-    )
-
-
-def randomize_object_rigid_body_material_startup(
-    env,
-    env_ids: Sequence[int] | torch.Tensor | None = None,
-    *,
-    static_friction_range: Sequence[float],
-    dynamic_friction_range: Sequence[float],
-    restitution_range: Sequence[float],
-    enabled: bool = True,
-    **_,
-) -> None:
-    """Randomize object rigid body material properties (friction, restitution)."""
-    if not enabled:
-        return
-
-    idx = _ensure_env_ids_tensor(env, env_ids)
-    if idx.numel() == 0:
-        return
-
-    simulator = env.simulator
-    if simulator.__class__.__name__ != "IsaacSim":
-        raise RandomizerNotSupportedError(
-            f"randomize_object_rigid_body_material_startup only supports IsaacSim, got {type(simulator).__name__}"
-        )
-
-    try:
-        from isaaclab.managers import SceneEntityCfg
-    except ImportError as exc:  # pragma: no cover - defensive
-        raise RuntimeError("IsaacSim material randomization requires isaaclab.") from exc
-
-    env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
-    if env_ids_cpu.numel() == 0:
-        return
-
-    asset_cfg = SceneEntityCfg("object", body_names=".*")
-    asset_cfg.resolve(simulator.scene)
-
-    num_buckets = 64
-    _isaacsim_randomize_rigid_body_material(
-        simulator,
-        env_ids_cpu,
-        asset_cfg,
-        static_friction_range=(static_friction_range[0], static_friction_range[1]),
-        dynamic_friction_range=(dynamic_friction_range[0], dynamic_friction_range[1]),
-        restitution_range=(restitution_range[0], restitution_range[1]),
-        num_buckets=num_buckets,
-    )
-
-
-def randomize_object_rigid_body_mass_startup(
-    env,
-    env_ids: Sequence[int] | torch.Tensor | None = None,
-    *,
-    mass_distribution_params: Sequence[float],
-    enabled: bool = True,
-    **_,
-) -> None:
-    """Randomize object rigid body mass."""
-    if not enabled:
-        return
-
-    idx = _ensure_env_ids_tensor(env, env_ids)
-    if idx.numel() == 0:
-        return
-
-    simulator = env.simulator
-    if simulator.__class__.__name__ != "IsaacSim":
-        raise RandomizerNotSupportedError(
-            f"randomize_object_rigid_body_mass_startup only supports IsaacSim, got {type(simulator).__name__}"
-        )
-
-    try:
-        from isaaclab.managers import SceneEntityCfg
-
-    except ImportError as exc:  # pragma: no cover - defensive
-        raise RuntimeError("IsaacSim mass randomization requires isaaclab.") from exc
-
-    env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
-    if env_ids_cpu.numel() == 0:
-        return
-
-    asset_cfg = SceneEntityCfg("object", body_names=".*")
-    asset_cfg.resolve(simulator.scene)
-
-    _isaacsim_randomize_rigid_body_mass(
-        simulator,
-        env_ids_cpu,
-        asset_cfg,
-        (mass_distribution_params[0], mass_distribution_params[1]),
-        operation="add",
-    )
-
-
-def randomize_object_rigid_body_inertia_startup(
-    env,
-    env_ids: Sequence[int] | torch.Tensor | None = None,
-    *,
-    inertia_distribution_params_dict: dict[str, tuple[float, float]],
-    enabled: bool = True,
-    **_,
-) -> None:
-    """Randomize object rigid body inertia."""
-    if not enabled:
-        return
-
-    idx = _ensure_env_ids_tensor(env, env_ids)
-    if idx.numel() == 0:
-        return
-
-    simulator = env.simulator
-    if simulator.__class__.__name__ != "IsaacSim":
-        raise RandomizerNotSupportedError(
-            f"randomize_object_rigid_body_inertia_startup only supports IsaacSim, got {type(simulator).__name__}"
-        )
-
-    try:
-        from isaaclab.managers import SceneEntityCfg
-    except ImportError as exc:  # pragma: no cover - defensive
-        raise RuntimeError("IsaacSim inertia randomization requires isaaclab.") from exc
-
-    from holosoma.simulator.isaacsim.events import randomize_rigid_body_inertia
-
-    env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
-    if env_ids_cpu.numel() == 0:
-        return
-
-    asset_cfg = SceneEntityCfg("object", body_names=".*")
-    asset_cfg.resolve(simulator.scene)
-
-    ordering = ["Ixx", "Iyy", "Izz", "Ixy", "Iyz", "Ixz"]
-    lower_bounds = [inertia_distribution_params_dict[key][0] for key in ordering]
-    upper_bounds = [inertia_distribution_params_dict[key][1] for key in ordering]
-    inertia_distribution_params = (torch.tensor(lower_bounds, device="cpu"), torch.tensor(upper_bounds, device="cpu"))
-
-    randomize_rigid_body_inertia(
-        simulator,
-        env_ids_cpu,
-        asset_cfg,
-        inertia_distribution_params,
-        operation="scale",
-        distribution="uniform",
+        static_friction=static_friction_range,
+        dynamic_friction=dynamic_friction_range,
+        restitution=restitution_range,
+        num_buckets=_MATERIAL_NUM_BUCKETS,
+        sampler=sampler,
     )
 
 
@@ -1130,6 +1044,7 @@ def configure_torque_rfi(
     env,
     env_ids,
     *,
+    sampler: TermSampler,
     enabled: bool | None = None,
     rfi_lim: float | None = None,
     **_,
@@ -1151,6 +1066,7 @@ def configure_torque_rfi(
 def apply_pushes(
     env,
     *,
+    sampler: TermSampler,
     enabled: bool | None = None,
     push_interval_s: Sequence[float] | None = None,
     max_push_vel: Sequence[float] | None = None,
@@ -1172,6 +1088,176 @@ def apply_pushes(
         return
 
     state.zero_counters(push_robot_env_ids)
-    state.resample(push_robot_env_ids)
+    state.resample(push_robot_env_ids, sampler)
     env._max_push_vel = state.max_push_vel.clone()
     env._push_robots(push_robot_env_ids)
+
+
+# --- Object physics DR (IsaacSim-only startup terms) ---------------------------------------------
+# The robot's `object` (RobotConfig.object) is spawned under the "object" scene-entity namespace on
+# IsaacSim. These terms randomize its physics through the SAME project-owned, keyed-sampler writers
+# the robot terms use (holosoma.simulator.isaacsim.events), so an object config means exactly what it
+# does for the robot and the draw is reproducible per (term, env, episode). IsaacSim-only: IsaacGym
+# and MuJoCo gain cross-backend object DR in a later branch of this stack (terms/objects.py).
+
+
+def randomize_object_rigid_body_material_startup(
+    env,
+    env_ids: Sequence[int] | torch.Tensor | None = None,
+    *,
+    sampler: TermSampler,
+    static_friction_range: DistributionLike,
+    dynamic_friction_range: DistributionLike,
+    restitution_range: DistributionLike,
+    enabled: bool = True,
+    **_,
+) -> None:
+    """Randomize the object's rigid-body material (friction, restitution) at startup.
+
+    Each range is a config range value — a ``[lo, hi]`` pair (uniform) or a ``{kind, low, high,
+    mean, std}`` spec dict — filled into a per-shape bucket table (PhysX caps unique materials per
+    scene) via the shared keyed sampler, matching the robot material term's contract.
+    """
+    if not enabled:
+        return
+
+    idx = _ensure_env_ids_tensor(env, env_ids)
+    if idx.numel() == 0:
+        return
+
+    simulator = env.simulator
+    if simulator.get_simulator_type() != SimulatorType.ISAACSIM:
+        raise RandomizerNotSupportedError(
+            f"randomize_object_rigid_body_material_startup only supports IsaacSim, got {type(simulator).__name__}"
+        )
+
+    try:
+        from isaaclab.managers import SceneEntityCfg
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise RuntimeError("IsaacSim material randomization requires isaaclab.") from exc
+
+    from holosoma.simulator.isaacsim.events import randomize_rigid_body_material
+
+    env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
+
+    asset_cfg = SceneEntityCfg("object", body_names=".*")
+    asset_cfg.resolve(simulator.scene)
+
+    randomize_rigid_body_material(
+        simulator,
+        env_ids_cpu,
+        asset_cfg,
+        static_friction=static_friction_range,
+        dynamic_friction=dynamic_friction_range,
+        restitution=restitution_range,
+        num_buckets=_MATERIAL_NUM_BUCKETS,
+        sampler=sampler,
+    )
+
+
+def randomize_object_rigid_body_mass_startup(
+    env,
+    env_ids: Sequence[int] | torch.Tensor | None = None,
+    *,
+    sampler: TermSampler,
+    mass_distribution_params: DistributionLike,
+    enabled: bool = True,
+    **_,
+) -> None:
+    """Randomize the object's rigid-body mass at startup (ADD operation).
+
+    ``mass_distribution_params`` is a config range value — a ``[lo, hi]`` pair (uniform) or a
+    ``{kind, low, high, mean, std}`` spec dict — drawn through the shared keyed sampler and ADDED to
+    the object's spawned mass (matching the robot mass term's contract). Inertia is rescaled by the
+    same mass ratio (``recompute_inertia``) so a uniform-density mass change stays consistent.
+    """
+    if not enabled:
+        return
+
+    idx = _ensure_env_ids_tensor(env, env_ids)
+    if idx.numel() == 0:
+        return
+
+    simulator = env.simulator
+    if simulator.get_simulator_type() != SimulatorType.ISAACSIM:
+        raise RandomizerNotSupportedError(
+            f"randomize_object_rigid_body_mass_startup only supports IsaacSim, got {type(simulator).__name__}"
+        )
+
+    try:
+        from isaaclab.managers import SceneEntityCfg
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise RuntimeError("IsaacSim mass randomization requires isaaclab.") from exc
+
+    from holosoma.simulator.isaacsim.events import randomize_rigid_body_mass
+
+    env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
+
+    asset_cfg = SceneEntityCfg("object", body_names=".*")
+    asset_cfg.resolve(simulator.scene)
+
+    randomize_rigid_body_mass(
+        simulator,
+        env_ids_cpu,
+        asset_cfg,
+        mass_distribution_params,
+        operation="add",
+        sampler=sampler,
+    )
+
+
+def randomize_object_rigid_body_inertia_startup(
+    env,
+    env_ids: Sequence[int] | torch.Tensor | None = None,
+    *,
+    sampler: TermSampler,
+    inertia_distribution_params_dict: dict[str, DistributionLike],
+    enabled: bool = True,
+    **_,
+) -> None:
+    """Randomize the object's rigid-body inertia at startup (SCALE operation).
+
+    ``inertia_distribution_params_dict`` is a per-component dict of SCALE ranges keyed
+    ``[Ixx, Iyy, Izz, Ixy, Iyz, Ixz]``; each value is a ``[lo, hi]`` pair (uniform) or a spec dict.
+    Each component is drawn through the shared keyed sampler and multiplies the object's inertia
+    tensor (multiplicative => commutes with the mass term's inertia rescale). An unspecified component
+    defaults to the identity scale ``[1.0, 1.0]``.
+    """
+    if not enabled:
+        return
+
+    idx = _ensure_env_ids_tensor(env, env_ids)
+    if idx.numel() == 0:
+        return
+
+    simulator = env.simulator
+    if simulator.get_simulator_type() != SimulatorType.ISAACSIM:
+        raise RandomizerNotSupportedError(
+            f"randomize_object_rigid_body_inertia_startup only supports IsaacSim, got {type(simulator).__name__}"
+        )
+
+    try:
+        from isaaclab.managers import SceneEntityCfg
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise RuntimeError("IsaacSim inertia randomization requires isaaclab.") from exc
+
+    from holosoma.simulator.isaacsim.events import randomize_rigid_body_inertia
+
+    env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
+
+    asset_cfg = SceneEntityCfg("object", body_names=".*")
+    asset_cfg.resolve(simulator.scene)
+
+    # One spec per inertia component, in the order events.randomize_rigid_body_inertia expects.
+    # An unnamed component keeps the identity scale [1.0, 1.0] (no randomization on that axis).
+    ordering = ["Ixx", "Iyy", "Izz", "Ixy", "Iyz", "Ixz"]
+    specs = [DistributionSpec.parse(inertia_distribution_params_dict.get(key, [1.0, 1.0])) for key in ordering]
+
+    randomize_rigid_body_inertia(
+        simulator,
+        env_ids_cpu,
+        asset_cfg,
+        specs,
+        operation="scale",
+        sampler=sampler,
+    )

--- a/src/holosoma/holosoma/simulator/isaacsim/events.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/events.py
@@ -1,85 +1,182 @@
+"""Project-owned IsaacSim physics randomization writers (mass / CoM / inertia / material).
+
+These deliberately do NOT route through IsaacLab's ``mdp.randomize_rigid_body_*`` events. IsaacLab's
+samplers read a gaussian's two parameters as ``(mean, std)``, which conflicts with the project's
+``[lo, hi]`` BOUNDS convention and silently produces a wrong distribution. By owning the write here
+and sampling through the shared keyed :meth:`holosoma.utils.sampler.TermSampler.draw`, a config means exactly
+the same thing on IsaacSim as on MuJoCo and IsaacGym — including gaussian and log_uniform.
+
+The mass/CoM/inertia writers take a list of per-component :class:`DistributionSpec` (validated at the
+term boundary) and write through ``asset.root_physx_view``; CoM/inertia reset to the asset's captured
+defaults (``asset.data.default_*``) before applying, so repeated calls compose from the original.
+
+The MATERIAL writer (:func:`randomize_rigid_body_material`) is different in kind because PhysX caps
+the number of unique physics materials per scene (~64k). It takes a ``num_buckets`` knob: an int
+fills ``num_buckets`` materials with the distribution's QUANTILE values
+(:func:`~holosoma.utils.sampler.quantiles`) and lets each shape pick a bucket (matching IsaacLab's
+mechanism), bounding unique materials at ``num_buckets`` — an ``n``-atom staircase matching the
+continuous backends' per-shape marginal APPROXIMATELY (raise to tighten). ``num_buckets=None`` draws
+continuously per shape — a true marginal, but safe only when the per-shape material count is under
+the cap.
+"""
+
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Sequence
 
-import isaaclab.utils.math as math_utils
 import torch
 from isaaclab.assets import Articulation, RigidObject
 from isaaclab.envs import ManagerBasedEnv
 from isaaclab.managers import SceneEntityCfg
 
+from holosoma.utils.sampler import DistributionSpec, DistributionLike, TermSampler, quantiles
 
-def resolve_dist_fn(
-    distribution: Literal["uniform", "log_uniform", "gaussian"] = "uniform",
+
+def _resolve_body_ids(asset: RigidObject | Articulation, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Resolve the body indices targeted by ``asset_cfg`` (CPU long tensor)."""
+    if asset_cfg.body_ids == slice(None):
+        if asset_cfg.body_names is not None:
+            body_ids, _ = asset.find_bodies(asset_cfg.body_names)
+            return torch.tensor(body_ids, dtype=torch.int, device="cpu")
+        return torch.arange(asset.num_bodies, dtype=torch.int, device="cpu")
+    return torch.tensor(asset_cfg.body_ids, dtype=torch.int, device="cpu")
+
+
+def _sample_columns(
+    sampler: TermSampler,
+    specs: Sequence[DistributionSpec],
+    env_ids: torch.Tensor,
+    body_ids: torch.Tensor,
+    device: str | torch.device,
+) -> torch.Tensor:
+    """Keyed per-component draw -> ``[n_env, n_body, len(specs)]``.
+
+    Each component (x/y/z for CoM, the 6 inertia components) gets its own int stream coord ``k`` so
+    they stay on independent streams; ``body_ids`` are the stable per-body keys (passed as a ``[1,
+    n_body]`` coord so they form the trailing dimension). Routes through the bound
+    :class:`TermSampler`, so a per-component config (different bounds, or even a different
+    ``kind``/explicit mean,std per component) is honored AND reproducible per (term, env, episode).
+    """
+    cols = [
+        sampler.draw(spec, env_ids=env_ids, coords=(k, body_ids[None, :]), device=device)  # [n_env, n_body]
+        for k, spec in enumerate(specs)
+    ]
+    return torch.stack(cols, dim=-1)  # [n_env, n_body, n_spec]
+
+
+def randomize_rigid_body_mass(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg,
+    mass: DistributionLike,
+    operation: Literal["add", "abs", "scale"],
+    sampler: TermSampler,
+    axis: int = 0,
+    min_mass: float = 1e-6,
+    recompute_inertia: bool = True,
 ):
-    dist_fn = math_utils.sample_uniform
+    """Randomize rigid-body mass, drawing through the bound keyed sampler.
 
-    if distribution == "uniform":
-        dist_fn = math_utils.sample_uniform
-    elif distribution == "log_uniform":
-        dist_fn = math_utils.sample_log_uniform
-    elif distribution == "gaussian":
-        dist_fn = math_utils.sample_gaussian
+    ``mass`` is a config range value ([lo, hi] pair / spec dict / DistributionSpec). Composes the
+    perturbation onto the CURRENT live mass
+    (add/scale; see the comment below), clamps to ``min_mass``, and — when ``recompute_inertia`` —
+    rescales each body's inertia by the SAME factor its mass changed by THIS call (``m_after /
+    m_before``). Unlike IsaacLab's event it draws from the project ``TermSampler`` — so gaussian /
+    log_uniform mean the same thing here as on MuJoCo/IsaacGym and the draw is reproducible per
+    (term, env, episode).
+
+    ``axis`` is the sampler STREAM coord (a plain int) so independent mass draws stay decorrelated — a
+    link-mass SCALE and a base-mass ADD must use different stream coords, or a body in both lists (e.g.
+    the torso) would get perfectly-correlated scale and add. (IsaacGym/MuJoCo decorrelate these the
+    same way; this matches them.)
+
+    ``recompute_inertia`` uses an explicit MULTIPLICATIVE ratio (not PhysX recompute-from-geometry),
+    so it commutes with a separate inertia-shape DR term — order between the two does not matter,
+    unlike a from-geometry recompute which would clobber a prior inertia scale.
+    """
+    spec = DistributionSpec.parse(mass)
+    asset: RigidObject | Articulation = env.scene[asset_cfg.name]
+
+    if env_ids is None:
+        env_ids = torch.arange(env.scene.num_envs, device="cpu")
     else:
-        raise ValueError(f"Unrecognized distribution {distribution}")
+        env_ids = env_ids.cpu()
 
-    return dist_fn
+    body_ids = _resolve_body_ids(asset, asset_cfg)
+
+    # Compose onto the CURRENT live mass (add/scale), matching IsaacGym (``mass += offset`` /
+    # ``mass *= scale``) and MuJoCo (``current + random`` / ``current * random``). DR mass terms are
+    # setup-stage (run once), so onto-current == onto-default at startup; composing onto current is
+    # what keeps "the same config means the same thing" across backends (a reset-to-default here made
+    # a second call return ``draw - prior_draw`` instead of ``draw`` — a cross-backend divergence).
+    masses = asset.root_physx_view.get_masses()
+    mass_before = masses[env_ids[:, None], body_ids].clone()
+
+    # ``axis`` int coord = stream; body_ids as a [1, n_body] coord -> [n_env, n_body] to match the index.
+    bias = sampler.draw(spec, env_ids=env_ids, coords=(axis, body_ids[None, :]), device=masses.device)
+
+    if operation == "add":
+        masses[env_ids[:, None], body_ids] += bias
+    elif operation == "scale":
+        masses[env_ids[:, None], body_ids] *= bias
+    elif operation == "abs":
+        masses[env_ids[:, None], body_ids] = bias
+    else:
+        raise ValueError(f"Unknown operation: '{operation}'. Use 'add', 'abs' or 'scale'.")
+
+    masses[env_ids[:, None], body_ids] = masses[env_ids[:, None], body_ids].clamp(min=min_mass)
+    asset.root_physx_view.set_masses(masses, env_ids)
+
+    if recompute_inertia:
+        # Scale inertia by the per-body mass ratio THIS call produced (commutes with inertia DR).
+        ratios = masses[env_ids[:, None], body_ids] / mass_before.clamp(min=min_mass)
+        inertias = asset.root_physx_view.get_inertias()
+        if isinstance(asset, Articulation):
+            inertias[env_ids[:, None], body_ids] *= ratios[..., None]
+        else:
+            inertias[env_ids] *= ratios
+        asset.root_physx_view.set_inertias(inertias, env_ids)
 
 
 def randomize_body_com(
     env: ManagerBasedEnv,
     env_ids: torch.Tensor | None,
     asset_cfg: SceneEntityCfg,
-    distribution_params: tuple[float, float] | tuple[torch.Tensor, torch.Tensor],
+    specs: Sequence[DistributionSpec],
     operation: Literal["add", "abs", "scale"],
-    distribution: Literal["uniform", "log_uniform", "gaussian"] = "uniform",
-    num_envs: int = 1,  # number of environments
+    sampler: TermSampler,
 ):
-    """Randomize the com of the bodies by adding, scaling or setting random values.
+    """Randomize body center-of-mass by adding/scaling/setting a per-axis (x,y,z) sample.
 
-    This function allows randomizing the center of mass of the bodies of the asset. The function samples
-    random values from the given distribution parameters and adds, scales or sets the values into the
-    physics simulation based on the operation.
-
-    .. tip::
-        This function uses CPU tensors to assign the body masses. It is recommended to use this function
-        only during the initialization of the environment.
+    ``specs`` is one :class:`DistributionSpec` per axis. CoM is reset to ``env.default_coms`` before
+    applying, so repeated calls compose from the original CoM. Draws through the bound keyed sampler,
+    so gaussian (truncated to the band) and log_uniform behave identically to other backends and the
+    draw is reproducible per (term, env, episode). Targets a single torso body (the per-axis sample is
+    shared across any resolved bodies).
     """
-    # extract the used quantities (to enable type-hinting)
     asset: RigidObject | Articulation = env.scene[asset_cfg.name]
 
-    # resolve environment ids
     if env_ids is None:
-        env_ids = torch.arange(num_envs, device="cpu")
+        env_ids = torch.arange(env.scene.num_envs, device="cpu")
     else:
         env_ids = env_ids.cpu()
 
-    # resolve body indices
-    if asset_cfg.body_ids == slice(None):
-        # Check if body_names is provided, if so resolve them to indices
-        if asset_cfg.body_names is not None:
-            body_ids, _ = asset.find_bodies(asset_cfg.body_names)
-            body_ids = torch.tensor(body_ids, dtype=torch.int, device="cpu")
-        else:
-            body_ids = torch.arange(asset.num_bodies, dtype=torch.int, device="cpu")
-    else:
-        body_ids = torch.tensor(asset_cfg.body_ids, dtype=torch.int, device="cpu")
-
-    # get the current masses of the bodies (num_assets, num_bodies)
-    coms = asset.root_physx_view.get_coms()
-    # apply randomization on default values
-    coms[env_ids[:, None], body_ids] = env.default_coms[env_ids[:, None], body_ids].clone()
-
-    dist_fn = resolve_dist_fn(distribution)
-
-    if isinstance(distribution_params[0], torch.Tensor):
-        distribution_params = (distribution_params[0].to(coms.device), distribution_params[1].to(coms.device))
-
-    env.base_com_bias[env_ids, :] = dist_fn(
-        *distribution_params, (env_ids.shape[0], env.base_com_bias.shape[1]), device=coms.device
+    body_ids = _resolve_body_ids(asset, asset_cfg)
+    # One (x,y,z) sample is drawn and applied to every resolved body; CoM DR is meant for a single
+    # body (the torso). Guard so a multi-body asset_cfg fails loudly instead of silently sharing one
+    # draw across bodies.
+    assert body_ids.numel() == 1, (
+        f"randomize_body_com expects a single body, got {body_ids.numel()} "
+        f"(asset_cfg.body_names={asset_cfg.body_names!r}); CoM DR targets one body (the torso)."
     )
 
-    # sample from the given range
+    coms = asset.root_physx_view.get_coms()
+    coms[env_ids[:, None], body_ids] = env.default_coms[env_ids[:, None], body_ids].clone()
+
+    # One (x,y,z) sample per env (first resolved body's row); CoM DR targets the torso, a single body.
+    bias = _sample_columns(sampler, specs, env_ids, body_ids[:1], coms.device)[:, 0, :]
+    env.base_com_bias[env_ids, :] = bias.to(env.base_com_bias.device)
+
     if operation == "add":
         coms[env_ids[:, None], body_ids, :3] += env.base_com_bias[env_ids[:, None], :]
     elif operation == "abs":
@@ -87,10 +184,8 @@ def randomize_body_com(
     elif operation == "scale":
         coms[env_ids[:, None], body_ids, :3] *= env.base_com_bias[env_ids[:, None], :]
     else:
-        raise ValueError(
-            f"Unknown operation: '{operation}' for property randomization. Please use 'add', 'abs' or 'scale'."
-        )
-    # set the mass into the physics simulation
+        raise ValueError(f"Unknown operation: '{operation}'. Use 'add', 'abs' or 'scale'.")
+
     asset.root_physx_view.set_coms(coms, env_ids)
 
 
@@ -98,64 +193,49 @@ def randomize_rigid_body_inertia(
     env: ManagerBasedEnv,
     env_ids: torch.Tensor | None,
     asset_cfg: SceneEntityCfg,
-    inertia_distribution_params: tuple[torch.Tensor, torch.Tensor],
+    specs: Sequence[DistributionSpec],
     operation: Literal["add", "scale", "abs"],
-    distribution: Literal["uniform", "log_uniform", "gaussian"] = "uniform",
+    sampler: TermSampler,
 ):
-    """
-    inertia_distribution_params is a tuple of (min, max) or (min_tensor, max_tensor) for the inertia values.
-    The inertia is a 3x3 matrix, which is symmetric, we only need to randomize the diagonal elements.
-    The inertia matrix is stored in the order of Ixx, Iyx, Izx, Ixy, Iyy, Izy, Ixz, Iyz, Izz.
-    https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.assets.html#isaaclab.assets.RigidObjectData.default_inertia
+    """Randomize the rigid-body inertia tensor by scaling/adding/setting per-component samples.
 
+    ``specs`` holds 6 :class:`DistributionSpec` in the order [Ixx, Iyy, Izz, Ixy, Iyz, Ixz]. The 3x3
+    inertia is symmetric; off-diagonals are mirrored. Draws through the bound keyed sampler, so a
+    gaussian or log_uniform scale config means the same thing as on MuJoCo/IsaacGym and is
+    reproducible per (term, env, episode).
 
-    The inertia distribution params is stored in the order of Ixx, Iyy, Izz, Ixy, Iyz, Ixz.
+    The inertia matrix is stored (PhysX) in the order Ixx, Iyx, Izx, Ixy, Iyy, Izy, Ixz, Iyz, Izz.
     """
-    # extract the used quantities (to enable type-hinting)
     asset: RigidObject | Articulation = env.scene[asset_cfg.name]
 
-    # resolve environment ids
     if env_ids is None:
         env_ids = torch.arange(env.scene.num_envs, device="cpu")
     else:
         env_ids = env_ids.cpu()
 
-    # resolve body indices
-    if asset_cfg.body_ids == slice(None):
-        # Check if body_names is provided, if so resolve them to indices
-        if asset_cfg.body_names is not None:
-            body_ids, _ = asset.find_bodies(asset_cfg.body_names)
-            body_ids = torch.tensor(body_ids, dtype=torch.int, device="cpu")
-        else:
-            body_ids = torch.arange(asset.num_bodies, dtype=torch.int, device="cpu")
-    else:
-        body_ids = torch.tensor(asset_cfg.body_ids, dtype=torch.int, device="cpu")
+    body_ids = _resolve_body_ids(asset, asset_cfg)
 
-    dist_fn = resolve_dist_fn(distribution)
     inertias_original = asset.root_physx_view.get_inertias()  # (num_envs, 9) or (num_envs, num_bodies, 9)
-
     if inertias_original.ndim == 2:
-        inertias = inertias_original.unsqueeze(1).clone()  # Add body_ids dimension (num_envs, 1, 9)
+        inertias = inertias_original.unsqueeze(1).clone()  # (num_envs, 1, 9)
     else:
         inertias = inertias_original.clone()  # (num_envs, num_bodies, 9)
 
-    # The inertia distribution params is stored in the order of Ixx, Iyy, Izz, Ixy, Iyz, Ixz.
-    inertia_random = dist_fn(
-        *inertia_distribution_params, (env_ids.shape[0], body_ids.shape[0], 6), device=inertias.device
+    # Per-component sample, ordered [Ixx, Iyy, Izz, Ixy, Iyz, Ixz] -> (n_env, n_body, 6).
+    inertia_random = _sample_columns(sampler, specs, env_ids, body_ids, inertias.device)
+
+    # Size the bias to the env SUBSET (inertia_random has len(env_ids) rows), not the full view, so the
+    # fill loop and the indexed apply below agree on dim 0 even when env_ids is a strict subset.
+    inertias_bias = torch.ones(
+        (inertia_random.shape[0], inertia_random.shape[1], 9),
+        dtype=inertias.dtype,
+        device=inertias.device,
     )
+    diagonal_elements = [(0, 0), (1, 4), (2, 8)]  # Ixx, Iyy, Izz -> matrix slots 0,4,8
+    off_diagonal_elements = [(3, 1, 3), (4, 7, 5), (5, 6, 2)]  # Ixy, Iyz, Ixz -> symmetric slot pairs
 
-    # Storage order: Ixx, Iyx, Izx, Ixy, Iyy, Izy, Ixz, Iyz, Izz (indices 0-8)
-    inertias_bias = torch.ones_like(inertias)
-    # Diagonal elements: (param_idx, matrix_idx)
-    diagonal_elements = [(0, 0), (1, 4), (2, 8)]  # Ixx, Iyy, Izz
-    # Off-diagonal elements: (param_idx, matrix_idx_primary, matrix_idx_symmetric)
-    off_diagonal_elements = [(3, 1, 3), (4, 7, 5), (5, 6, 2)]  # Ixy, Iyz, Ixz
-
-    # Sample diagonal elements
     for param_idx, matrix_idx in diagonal_elements:
         inertias_bias[:, :, matrix_idx] = inertia_random[:, :, param_idx]
-
-    # Sample off-diagonal elements and set symmetric pairs
     for param_idx, primary_idx, symmetric_idx in off_diagonal_elements:
         inertias_bias[:, :, primary_idx] = inertia_random[:, :, param_idx]
         inertias_bias[:, :, symmetric_idx] = inertias_bias[:, :, primary_idx]
@@ -167,11 +247,93 @@ def randomize_rigid_body_inertia(
     elif operation == "abs":
         inertias[env_ids[:, None], body_ids] = inertias_bias
     else:
-        raise ValueError(
-            f"Unknown operation: '{operation}' for property randomization. Please use 'add', 'abs' or 'scale'."
-        )
+        raise ValueError(f"Unknown operation: '{operation}'. Use 'add', 'abs' or 'scale'.")
 
     if inertias_original.ndim == 2:
         inertias = inertias.squeeze(1)
 
     asset.root_physx_view.set_inertias(inertias, env_ids)
+
+
+def randomize_rigid_body_material(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor | None,
+    asset_cfg: SceneEntityCfg,
+    static_friction: DistributionLike | None,
+    dynamic_friction: DistributionLike | None,
+    restitution: DistributionLike | None,
+    num_buckets: int | None,
+    sampler: TermSampler,
+    make_consistent: bool = True,
+):
+    """Randomize per-shape friction/restitution, bucketed or continuous.
+
+    Each channel is a config range value ([lo, hi] / spec dict / DistributionSpec), or ``None`` to leave
+    that channel at its spawned value.
+
+    ``num_buckets`` controls how the PhysX per-scene material cap (~64k) is respected:
+    - an int (the default path): replicates IsaacLab's mechanism (build ``num_buckets`` materials once,
+      assign each shape a bucket), so total unique materials stay bounded at ``num_buckets`` regardless
+      of env/shape count. The ONE change from IsaacLab: fill each channel with the QUANTILE values of
+      its :class:`DistributionSpec` (via :func:`~holosoma.utils.sampler.quantiles`) instead of
+      ``sample_uniform``, so a gaussian / log_uniform config matches the continuous backends' per-shape
+      marginal APPROXIMATELY as an ``n``-atom staircase (raise ``num_buckets`` to tighten it).
+    - ``None``: draw a CONTINUOUS value per shape (a true marginal), minting up to ~``num_envs`` ×
+      ``num_shapes`` unique materials — opt into this only when that count is comfortably under the cap.
+
+    A channel spec of ``None`` is NOT randomized — that column keeps each shape's spawned value
+    (so a config can randomize, e.g., friction only and leave restitution as authored). Returns
+    early if all three are ``None``.
+
+    ``make_consistent`` clamps dynamic friction <= static friction (PhysX expects this),
+    matching IsaacLab's optional flag; enabled by default here since friction DR always wants it.
+
+    Reproducibility: every draw (bucket fill shuffle, per-shape bucket pick, or continuous value) goes
+    through the keyed ``sampler`` on distinct axes, so a seeded run produces the same realized material.
+    """
+
+    def _spec(leaf: DistributionLike | None) -> DistributionSpec | None:
+        return None if leaf is None else DistributionSpec.parse(leaf)
+
+    static_friction_spec = _spec(static_friction)
+    dynamic_friction_spec = _spec(dynamic_friction)
+    restitution_spec = _spec(restitution)
+    channel_specs = (static_friction_spec, dynamic_friction_spec, restitution_spec)
+    if all(spec is None for spec in channel_specs):
+        return
+
+    asset: RigidObject | Articulation = env.scene[asset_cfg.name]
+
+    if env_ids is None:
+        env_ids = torch.arange(env.scene.num_envs, device="cpu")
+    else:
+        env_ids = env_ids.cpu()
+
+    materials = asset.root_physx_view.get_material_properties()
+    total_num_shapes = asset.root_physx_view.max_shapes
+    samples = materials[env_ids].clone()  # (n_env, n_shapes, 3); start from current, overwrite chosen cols
+    shape_ids = torch.arange(total_num_shapes)
+
+    for k, spec in enumerate(channel_specs):
+        if spec is None:
+            continue
+        if num_buckets is None:
+            # Continuous per shape: channel stream coords 0/1/2 keep the three columns decorrelated;
+            # shape ids as a [1, n_shapes] coord -> an independent per-(env, shape) draw.
+            drawn = sampler.draw(spec, env_ids=env_ids, coords=(k, shape_ids[None, :]))  # (n_env, n_shapes)
+        else:
+            # Bucketed: fill a per-channel bucket column with the spec's quantile values, shuffle it
+            # with a KEYED permutation (distinct stream coord per channel so columns are not
+            # rank-aligned — matches IsaacLab's independent per-column draw, reproducible per seed),
+            # then pick a bucket per shape via the keyed selection (stream coord 3, distinct from 0/1/2).
+            # Total unique materials stay bounded at num_buckets.
+            column = quantiles(spec, num_buckets, "cpu")[sampler.permute(num_buckets, (k,))]
+            bucket_ids = sampler.draw_int(0, num_buckets - 1, env_ids=env_ids, coords=(3, shape_ids[None, :]))
+            drawn = column[bucket_ids]
+        samples[..., k] = drawn
+
+    if make_consistent and (static_friction_spec is not None or dynamic_friction_spec is not None):
+        samples[..., 1] = torch.min(samples[..., 0], samples[..., 1])  # dynamic <= static (PhysX)
+
+    materials[env_ids] = samples.to(materials.dtype)
+    asset.root_physx_view.set_material_properties(materials, env_ids)

--- a/src/holosoma/holosoma/simulator/mujoco/backends/randomization.py
+++ b/src/holosoma/holosoma/simulator/mujoco/backends/randomization.py
@@ -1,20 +1,27 @@
-"""MuJoCo Warp domain randomization utilities.
+"""MuJoCo domain randomization utilities (both backends).
 
 Adapted from mjlab (Apache 2.0): https://github.com/mujocolab/mjlab/blob/main/src/mjlab/sim/randomization.py
 See THIRD_PARTY_LICENSES for full license text.
 
-Provides functions for randomizing model fields across batched environments
-in GPU-accelerated MuJoCo Warp simulations.
+Provides ``randomize_field`` for randomizing model fields, which works on BOTH MuJoCo
+backends: the WarpBackend (GPU, vectorized across the per-world-expanded model via the
+WarpBridge) and the single-env ClassicBackend (CPU, writing the one ``mujoco.MjModel`` field
+in place). ``expand_model_fields`` and its Warp kernel are WarpBackend-only — they tile a
+single-world model across environments and are a no-op for the single-env ClassicBackend.
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 
 import mujoco
-import mujoco_warp as mjwarp
 import torch
 import warp as wp
+
+from holosoma.utils.sampler import DistributionLike, DistributionSpec, TermSampler, quantiles
+
+if TYPE_CHECKING:
+    import mujoco_warp as mjwarp
 
 
 @wp.kernel(module="unique")
@@ -81,7 +88,11 @@ def expand_model_fields(
         return dst
 
     for field in model.__dataclass_fields__:
-        if field in fields_to_expand:
+        # Skip fields already expanded: re-tiling REALLOCATES the array (setattr below), which
+        # would invalidate a captured CUDA step-graph that still points at the old array. Making
+        # this idempotent lets the runtime static-move path call it safely (it's a no-op once the
+        # field was expanded at setup); only the first expansion per field allocates.
+        if field in fields_to_expand and field not in model._expanded_fields:  # type: ignore[attr-defined]
             array = getattr(model, field)
             setattr(model, field, tile(array))
             # Register this field as expanded for validation
@@ -144,32 +155,76 @@ def resolve_entity_ids(mj_model: mujoco.MjModel, names: list[str], entity_type: 
     return indices
 
 
+def _field_view(simulator: Any, field: str) -> torch.Tensor:
+    """A writable ``[num_worlds, ...]`` torch view of MuJoCo model ``field`` on either backend.
+
+    WarpBackend: the per-world bridge view (already ``[num_envs, ...]``). ClassicBackend: the single
+    CPU ``MjModel`` field wrapped as a torch view with a length-1 world axis prepended, so callers
+    index it identically. ``from_numpy`` aliases the live model on Classic, so writes land on the
+    model ``mj_step`` reads.
+    """
+    if hasattr(simulator.backend, "warp_model_bridge"):
+        return getattr(simulator.backend.warp_model_bridge, field)
+    return torch.from_numpy(getattr(simulator.backend.model, field)).unsqueeze(0)
+
+
+def scale_inertia_by_mass_ratio(
+    simulator: Any, body_ids: torch.Tensor, mass_before: torch.Tensor, *, min_mass: float = 1e-6
+) -> None:
+    """Scale ``body_inertia`` rows for ``body_ids`` by each body's CURRENT/``mass_before`` ratio.
+
+    The MuJoCo half of the cross-backend ``recompute_inertia`` contract: after a mass write, multiply
+    each body's diagonal inertia (``body_inertia`` is ``[nbody, 3]`` principal moments) by the factor
+    its mass changed by, so a uniform-density mass change scales inertia consistently with the Isaac
+    backends. Multiplicative => commutes with a separate inertia-shape DR term (order-independent).
+
+    ``mass_before`` is the ``[num_worlds, len(body_ids)]`` mass snapshot taken BEFORE the mass write.
+    """
+    mass_now = _field_view(simulator, "body_mass")[:, body_ids]  # [num_worlds, n_body]
+    ratio = (mass_now / mass_before.clamp(min=min_mass)).to(torch.float64)  # body_inertia is float64-backed
+    inertia = _field_view(simulator, "body_inertia")  # [num_worlds, nbody, 3]
+    inertia[:, body_ids, :] *= ratio.to(inertia.dtype).unsqueeze(-1)
+
+
 def randomize_field(
     simulator: Any,
     field: str,
-    ranges: tuple[float, float] | dict[int, tuple[float, float]],
+    ranges: DistributionLike | dict[int, DistributionLike],
+    sampler: TermSampler,
     env_ids: torch.Tensor | None = None,
     entity_ids: torch.Tensor | None = None,
     entity_names: list[str] | None = None,
     entity_type: str | None = None,
-    distribution: Literal["uniform", "log_uniform", "gaussian"] = "uniform",
     operation: Literal["add", "scale", "abs"] = "abs",
-):
-    """Unified model randomization function for MuJoCo Warp.
+    axis_base: int = 0,
+    num_buckets: int | None = None,
+) -> None:
+    """Unified model randomization for the MuJoCo backends (WarpBackend GPU + ClassicBackend CPU).
 
-    Randomizes physics parameters in the MuJoCo model for specified environments
-    and entities. Supports vectorized operations for efficient GPU execution.
+    Randomizes physics parameters in the MuJoCo model for specified environments and entities.
+    On the WarpBackend this is vectorized across the per-world-expanded model via the
+    WarpBridge; on the single-env ClassicBackend it writes the one ``mujoco.MjModel`` field
+    directly (one sample — there is only one environment). The indexing/sampling logic is
+    shared: the classic field is wrapped as a ``[1, ...]`` view so the same code path applies.
 
     Parameters
     ----------
     simulator : Any
-        The simulator instance with backend.warp_model_bridge
+        The simulator instance (WarpBackend exposes backend.warp_model_bridge; ClassicBackend
+        exposes backend.model).
     field : str
         Model field name to randomize (e.g., 'body_mass', 'geom_friction', 'body_ipos')
     ranges : Union[Tuple[float, float], Dict[int, Tuple[float, float]]]
-        Range(s) for randomization. Can be:
-        - Single tuple (min, max) for scalar fields or all axes
+        Range(s) for randomization. Each value is a ``[lo, hi]`` pair or a
+        ``{kind, low, high, mean, std}`` spec dict. Can be:
+        - Single range for scalar fields or all axes
         - Dict mapping axis indices to ranges for vector fields
+    sampler : TermSampler
+        Bound keyed sampler (from the randomization manager). Supplies the draws so the result is
+        reproducible per (term, env, episode); entity ids key per-entity independence.
+    axis_base : int
+        Offset added to each axis's keying coordinate. Lets a term that calls ``randomize_field``
+        more than once (e.g. mass link-scale then base-add) keep those calls on separate streams.
     env_ids : Optional[torch.Tensor]
         Environment IDs to randomize (default: all environments)
     entity_ids : Optional[torch.Tensor]
@@ -179,10 +234,16 @@ def randomize_field(
     entity_type : Optional[str]
         Type of entity for name resolution (e.g., 'body', 'geom')
         Required if entity_names is provided, otherwise inferred from field
-    distribution : Literal["uniform", "log_uniform", "gaussian"]
-        Distribution to sample from (default: "uniform")
     operation : Literal["add", "scale", "abs"]
         Operation to apply: add to current, scale current, or set absolute value
+    num_buckets : Optional[int]
+        Quantization knob mirroring the PhysX backends' material bucketing, for a config that wants
+        the SAME staircase discretization on MuJoCo. ``None`` (default): draw continuously — MuJoCo
+        writes the model field directly and has no per-scene material cap, so continuous is the true
+        marginal. An int: quantize each axis's draw onto ``num_buckets`` stratified quantile values of
+        its distribution (a shared per-axis table, keyed-shuffled, then each (env, entity) picks a
+        bucket) — the same n-atom staircase the IsaacSim material writer produces. Only the VALUE set
+        is discretized; per-entity granularity is unchanged. Applies to any field/operation.
 
     Raises
     ------
@@ -227,7 +288,8 @@ def randomize_field(
     # -----------------------------------------------------------
     # 1. Retrieve the Field and Determine Shapes
     # -----------------------------------------------------------
-    model_field = getattr(simulator.backend.warp_model_bridge, field)
+    is_warp = hasattr(simulator.backend, "warp_model_bridge")
+    model_field = _field_view(simulator, field)
     full_shape = model_field.shape
 
     ndim = len(full_shape)
@@ -237,10 +299,10 @@ def randomize_field(
     # -----------------------------------------------------------
     # 1.5. Validate Field Expansion
     # -----------------------------------------------------------
-    # Check if field has been explicitly expanded via expand_model_fields()
-    # when there are multiple environments
+    # Per-env expansion (and its validation) only applies to the WarpBackend with >1 env. The
+    # single-env ClassicBackend writes the model field in place — no expansion needed.
     num_envs = simulator.num_envs
-    if num_envs > 1:
+    if is_warp and num_envs > 1:
         mjw_model = simulator.backend.mjw_model
         expanded_fields: set[str] = getattr(mjw_model, "_expanded_fields", set())
 
@@ -265,26 +327,31 @@ def randomize_field(
         entity_ids = entity_ids.to(device, dtype=torch.long)
 
     # -- Target Axes & Ranges --
+    # Keep the raw per-axis ranges (each a [lo, hi] pair OR a {kind/low/high/mean/std} spec dict)
+    # rather than flattening to a float tensor, so an explicit-(mean,std) gaussian survives to the
+    # sampler. ``ranges`` itself may be a dict KEYED BY AXIS INDEX (int -> range) for a vector field;
+    # disambiguate that from a single spec-dict range by inspecting the keys.
     target_axes: torch.Tensor | None = None
+    is_axis_map = isinstance(ranges, dict) and len(ranges) > 0 and all(isinstance(k, int) for k in ranges)
+    if isinstance(ranges, dict) and len(ranges) == 0:
+        raise ValueError("randomize_field: `ranges` is an empty dict; pass at least one axis -> range.")
 
+    range_leaves: list[DistributionLike]
     if ndim == 3:
         # Vector field
-        if isinstance(ranges, dict):
-            axes_list = sorted(ranges.keys())
+        if is_axis_map:
+            axis_map = cast("dict[int, DistributionLike]", ranges)
+            axes_list = sorted(axis_map.keys())
             target_axes = torch.tensor(axes_list, device=device, dtype=torch.long)
-            range_vals = [ranges[ax] for ax in axes_list]
+            range_leaves = [axis_map[ax] for ax in axes_list]
         else:
             target_axes = torch.arange(full_shape[2], device=device, dtype=torch.long)
-            range_vals = [ranges] * full_shape[2]
-
-        axis_ranges = torch.tensor(range_vals, device=device, dtype=torch.float32)
-
+            range_leaves = [cast("DistributionLike", ranges)] * full_shape[2]
     else:
         # Scalar field
-        if isinstance(ranges, dict):
+        if is_axis_map:
             raise ValueError("Cannot specify axis dict for a scalar (2D) field.")
-        target_axes = None
-        axis_ranges = torch.tensor([ranges], device=device, dtype=torch.float32)
+        range_leaves = [cast("DistributionLike", ranges)]
 
     # -----------------------------------------------------------
     # 3. Create Broadcasting Views
@@ -302,33 +369,44 @@ def randomize_field(
     # -----------------------------------------------------------
     # 4. Generate Random Values
     # -----------------------------------------------------------
-    n_e = len(env_ids)
-    n_n = len(entity_ids)
-    n_a = len(target_axes) if target_axes is not None else 1
-
-    lo = axis_ranges[:, 0].view(1, 1, -1)
-    hi = axis_ranges[:, 1].view(1, 1, -1)
-    shape = (n_e, n_n, n_a)
-
-    if distribution == "uniform":
-        rv = torch.rand(shape, device=device)
-        random_values = lo + (hi - lo) * rv
-
-    elif distribution == "log_uniform":
-        log_lo = torch.log(lo)
-        log_hi = torch.log(hi)
-        rv = torch.rand(shape, device=device)
-        random_values = torch.exp(log_lo + (log_hi - log_lo) * rv)
-
-    elif distribution == "gaussian":
-        mean = 0.5 * (lo + hi)
-        std = (hi - lo) / 6.0
-        random_values = torch.randn(shape, device=device) * std + mean
+    # Sample each axis through the bound TermSampler so a MuJoCo config means exactly what it does on
+    # every other backend AND is reproducible per (term, env, episode). Entity ids are the stable MuJoCo
+    # indices (body/geom/dof), passed as a ``[1, n_n]`` coord so a per-entity draw lands on the trailing
+    # dimension and survives iteration-order changes; ``axis_base + k`` is the int STREAM coord keeping
+    # the K axis leaves on independent streams. Validation (log_uniform positivity, high>=low) fires at
+    # spec construction, raising a clean error instead of silently writing NaN. Stack the per-axis draws
+    # back into the (n_e, n_n, n_a) layout the indexer expects.
+    if num_buckets is None:
+        per_axis = [
+            sampler.draw(
+                leaf, env_ids=env_ids, coords=(axis_base + k, entity_ids[None, :]), device=device
+            )  # (n_e, n_n)
+            for k, leaf in enumerate(range_leaves)
+        ]
     else:
-        raise ValueError(f"Unknown distribution: {distribution}")
+        # Bucketed: quantize each axis onto num_buckets stratified quantile values (mirrors the PhysX
+        # material writer). Fill a per-axis bucket table with the spec's quantiles, shuffle it with a
+        # KEYED permutation (distinct stream coord axis_base + k so axes are not rank-aligned), then let
+        # each (env, entity) pick a bucket via the keyed draw_int. Per-entity granularity is preserved —
+        # only the VALUE set is discretized, matching IsaacSim's staircase.
+        per_axis = []
+        for k, leaf in enumerate(range_leaves):
+            column = quantiles(DistributionSpec.parse(leaf), num_buckets, device)[
+                sampler.permute(num_buckets, (axis_base + k,))
+            ]
+            bucket_ids = sampler.draw_int(
+                0, num_buckets - 1, env_ids=env_ids, coords=(axis_base + k, entity_ids[None, :])
+            )  # (n_e, n_n)
+            per_axis.append(column[bucket_ids])
+    random_values = torch.stack(per_axis, dim=-1)  # (n_e, n_n, n_a)
 
     if target_axes is None:
         random_values = random_values.squeeze(-1)
+
+    # Match the destination dtype: the WarpBridge fields are float32, but the ClassicBackend's
+    # fields are views of float64 numpy arrays — an "abs" assignment of float32 into a float64
+    # destination raises a dtype-mismatch in torch's index_put. Casting here is a no-op on Warp.
+    random_values = random_values.to(model_field.dtype)
 
     # -----------------------------------------------------------
     # 5. Apply Operation

--- a/src/holosoma/holosoma/simulator/mujoco/fields.py
+++ b/src/holosoma/holosoma/simulator/mujoco/fields.py
@@ -34,7 +34,7 @@ def collect_required_fields(*managers: Any) -> list[str]:
 
     Examples
     --------
-    >>> from holosoma.simulator.mujoco.field_preparation import collect_required_fields
+    >>> from holosoma.simulator.mujoco.fields import collect_required_fields
     >>> fields = collect_required_fields(randomization_manager, observation_manager)
     >>> # fields might be ["body_mass", "geom_friction", "body_ipos"]
     """
@@ -123,7 +123,7 @@ def prepare_fields(simulator, field_names: list[str]) -> None:
     logger.info(f"Preparing {len(field_names)} fields for per-environment operations")
 
     # Expand model fields (internal implementation detail)
-    from holosoma.simulator.mujoco.backends.warp_randomization import expand_model_fields
+    from holosoma.simulator.mujoco.backends.randomization import expand_model_fields
 
     expand_model_fields(simulator.backend.mjw_model, nworld=simulator.num_envs, fields_to_expand=field_names)
 

--- a/src/holosoma/holosoma/utils/sampler.py
+++ b/src/holosoma/holosoma/utils/sampler.py
@@ -1,0 +1,452 @@
+"""Single source of truth for domain-randomization (DR) sampling.
+
+Every DR term, on every backend, draws through the ONE keyed sampler here (:class:`TermSampler`),
+driven by the ONE spec (:class:`DistributionSpec`, defined in
+:mod:`holosoma.config_types.distribution`). This is what makes a config input mean the *same*
+thing on every backend: the spec defines the meaning and is validated once, at construction; the
+sampler defines the (counter-based, reproducible) draw; backends differ only in where they write the
+result.
+
+Public API
+----------
+- :class:`DistributionSpec` — the validated MEANING of one randomized scalar (kind + bounds /
+  params); re-exported here for convenience, defined in :mod:`holosoma.config_types.distribution`
+  (an import-light module, so a config schema can name it without pulling torch). A term passes a
+  config range value (see :data:`DistributionLike`) and the sampler parses it via
+  :meth:`DistributionSpec.parse`.
+- :class:`TermSampler` — the keyed draw. The randomization manager binds one per term (it holds the
+  seed, term name, lifecycle stage, and per-env episode counter) and passes it to the term; the term
+  calls :meth:`TermSampler.draw` / :meth:`~TermSampler.draw_int` / :meth:`~TermSampler.permute`. A term
+  receives a bound sampler rather than constructing one.
+- :func:`quantiles` — a deterministic stratified bucket-fill, for backends whose physics API caps the
+  number of unique materials (PhysX): fill N buckets, then select per shape with a keyed draw.
+
+The distribution conventions (uniform / log_uniform / gaussian, bounds-first) are documented on
+:class:`DistributionSpec`.
+
+Keyed draws
+-----------
+A draw is ``value = f(coordinates)``: a hash of its coordinates, with no carried state. Two runs
+with the same seed produce identical values for the same coordinate, independent of which other
+terms exist, the order they run in, the number of envs, and which env subset is resetting. The
+coordinate model is documented on :class:`TermSampler`.
+
+Examples
+--------
+**Build a spec from a config range value** (what the sampler does internally; useful in tests):
+>>> DistributionSpec.parse([0.5, 1.5])                       # bare pair -> uniform bounds
+DistributionSpec(kind='uniform', low=0.5, high=1.5, mean=None, std=None)
+>>> DistributionSpec.parse({"kind": "log_uniform", "low": 0.8, "high": 1.2})  # explicit kind
+DistributionSpec(kind='log_uniform', low=0.8, high=1.2, mean=None, std=None)
+>>> DistributionSpec.parse({"kind": "gaussian", "low": -1.0, "high": 1.0})  # non-default via dict
+DistributionSpec(kind='gaussian', low=-1.0, high=1.0, mean=None, std=None)
+
+**Draw inside a DR term** (you are given a bound ``sampler`` and the resetting ``env_ids``):
+>>> # one value per env (a global scalar randomized per environment) -> shape [E]
+>>> friction = sampler.draw([0.5, 1.5], env_ids=env_ids)
+>>> # one value per (env, body): pass the body ids as a [1, N] coord -> shape [E, N]
+>>> per_body = sampler.draw([0.9, 1.1], env_ids=env_ids, coords=(body_ids[None, :],))
+>>> # several independent quantities from one term: give each a distinct int "stream" coord
+>>> com_x = sampler.draw(x_range, env_ids=env_ids, coords=(0,))   # CoM x  (stream 0)
+>>> com_y = sampler.draw(y_range, env_ids=env_ids, coords=(1,))   # CoM y  (stream 1, decorrelated)
+
+**Reproducibility you can rely on** (same coordinate -> same value, regardless of how it is passed):
+>>> a = sampler.draw([0.0, 1.0], env_ids=torch.arange(8))            # full population
+>>> b = sampler.draw([0.0, 1.0], env_ids=torch.tensor([2, 5]))       # a resetting subset
+>>> torch.equal(a[[2, 5]], b)                                        # subset rows match the full draw
+True
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import torch
+
+# DistributionSpec and the config range-value types live in an import-light module so a config schema
+# can name them without pulling torch; re-exported here so a term keeps a single import for the spec
+# it parses and the sampler it draws through.
+from holosoma.config_types.distribution import (  # noqa: F401  (re-export)
+    _SUPPORTED_DISTRIBUTIONS,
+    Distribution,
+    DistributionLike,
+    DistributionSpec,
+)
+
+# Phi(x) = 0.5 * (1 + erf(x / sqrt(2))); Phi^{-1}(p) = sqrt(2) * erfinv(2p - 1).
+_INV_SQRT2 = 1.0 / math.sqrt(2.0)
+_SQRT2 = math.sqrt(2.0)
+# Keep the inverse-CDF argument off the ±1 singularities of erfinv (which map to ±inf).
+_P_EPS = 1e-7
+
+
+def _inverse_cdf(u: torch.Tensor, spec: DistributionSpec) -> torch.Tensor:
+    """Map uniforms ``u`` in [0, 1] to values of ``spec`` via its inverse CDF.
+
+    This is the SINGLE transform shared by :meth:`TermSampler.draw` (keyed ``u``) and
+    :func:`quantiles` (stratified ``u``), so a continuous draw and the bucket-fill agree in
+    distribution.
+    """
+    if spec.kind == "uniform":
+        lo, hi = float(spec.low), float(spec.high)  # type: ignore[arg-type]
+        return lo + (hi - lo) * u
+
+    if spec.kind == "log_uniform":
+        lo, hi = float(spec.low), float(spec.high)  # type: ignore[arg-type]
+        log_lo, log_hi = math.log(lo), math.log(hi)
+        return torch.exp(log_lo + (log_hi - log_lo) * u)
+
+    # gaussian — truncated to whichever bounds are present (none / low-only / high-only / both).
+    mean, std = spec.resolved_mean_std()
+    bound_lo: float | None = float(spec.low) if spec.low is not None else None
+    bound_hi: float | None = float(spec.high) if spec.high is not None else None
+
+    if std == 0.0:
+        # Degenerate: a point mass at ``mean``, clamped into whatever bounds exist.
+        return torch.clamp(
+            u * 0.0 + mean,
+            min=bound_lo if bound_lo is not None else -math.inf,
+            max=bound_hi if bound_hi is not None else math.inf,
+        )
+
+    if bound_lo is not None and bound_hi is not None and bound_lo == bound_hi:
+        return torch.full_like(u, bound_lo)
+
+    # Map u into the CDF sub-interval [Phi(a), Phi(b)], then invert. A missing bound contributes the
+    # open end of the unit interval (Phi(-inf)=0 / Phi(+inf)=1), so this one path covers the
+    # un-truncated draw (no bounds -> [0, 1]), a one-sided truncation, and a two-sided one. Phi bounds
+    # are scalars computed as Python floats (Phi(x)=0.5*(1+erf(x/sqrt2))) — no per-draw tensor alloc.
+    cdf_a = 0.5 * (1.0 + math.erf((bound_lo - mean) / std * _INV_SQRT2)) if bound_lo is not None else 0.0
+    cdf_b = 0.5 * (1.0 + math.erf((bound_hi - mean) / std * _INV_SQRT2)) if bound_hi is not None else 1.0
+    p = cdf_a + u * (cdf_b - cdf_a)
+    p = torch.clamp(p, min=_P_EPS, max=1.0 - _P_EPS)
+    x = mean + std * _SQRT2 * torch.erfinv(2.0 * p - 1.0)
+    # Guard against any residual numerical drift past the present bound(s).
+    return torch.clamp(
+        x,
+        min=bound_lo if bound_lo is not None else -math.inf,
+        max=bound_hi if bound_hi is not None else math.inf,
+    )
+
+
+def quantiles(
+    spec: DistributionSpec,
+    n: int,
+    device: str | torch.device,
+    *,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Return ``n`` stratified quantile values of ``spec``, SORTED (inverse CDF at ``p = (i+0.5)/n``).
+
+    Selecting (with replacement) over these ``n`` values reproduces ``spec``'s distribution as an
+    ``n``-atom staircase — the BUCKET FILL for backends whose physics API caps the number of unique
+    materials (PhysX allows only ~64k), where a per-shape continuous draw is impossible. Both this and
+    :meth:`TermSampler.draw` go through :func:`_inverse_cdf`, so the bucket marginal matches a
+    continuous keyed draw and converges to it as ``n`` grows (stratification keeps it low-variance
+    even at ``n=64``).
+
+    Deterministic by construction (no shuffling here): the result is the same sorted vector every call.
+    The CALLER owns any per-channel shuffle, and the production caller does it with a KEYED permutation
+    (:meth:`TermSampler.permute`) so the realized material is reproducible per seed but the channels are
+    not rank-aligned. The usual pattern is "fill once, then select per shape":
+
+    >>> table = quantiles(DistributionSpec(low=0.5, high=1.5), n=64, device="cpu")   # 64 friction atoms
+    >>> shuffled = table[sampler.permute(64, (0,))]                  # keyed shuffle, channel stream 0
+    >>> picks = sampler.draw_int(0, 63, env_ids=env_ids, coords=(shape_ids[None, :],))  # [E, n_shapes]
+    >>> per_shape_friction = shuffled[picks]                         # gather -> each shape's value
+    """
+    i = torch.arange(n, device=device, dtype=dtype)
+    u = (i + 0.5) / n  # midpoint grid in (0, 1), strictly interior
+    return _inverse_cdf(u, spec)
+
+
+# ==================================================================================================
+# Keyed (counter-based) randomization — reproducible per (term, env, episode), order-independent.
+# ==================================================================================================
+#
+# WHY NOT a plain RNG stream: a sequential generator makes draw N depend on how many draws happened
+# before it, so adding/removing/reordering DR terms, changing num_envs, or resetting a subset of envs
+# all perturb unrelated values. We instead derive each draw from a hash of its COORDINATES, with no
+# carried state: value = f(coordinates). Standard counter-based-RNG idea (Philox/Threefry/JAX); we
+# use a SplitMix64-fold, which is enough for DR and tiny to own. The coordinate model (which
+# coordinates exist, who supplies them, how they shape the output) is documented on
+# :class:`TermSampler`.
+
+_SPLITMIX_IV = np.uint64(0x243F6A8885A308D3)  # nonzero init so all-zero coordinates don't hash to 0
+_SPLITMIX_M1 = np.uint64(0xBF58476D1CE4E5B9)
+_SPLITMIX_M2 = np.uint64(0x94D049BB133111EB)
+_S30, _S27, _S31, _S11 = (np.uint64(s) for s in (30, 27, 31, 11))
+
+
+def _term_id(name: str) -> int:
+    """Stable 63-bit integer id for a term name (process-independent, unlike builtin ``hash``)."""
+    return int.from_bytes(hashlib.blake2b(name.encode(), digest_size=8).digest(), "little") >> 1
+
+
+def keyed_uniform(*coords: int | np.ndarray | torch.Tensor) -> torch.Tensor:
+    """Hash integer ``coords`` to uniforms in ``[0, 1)`` — vectorized, stateless, value = f(coords).
+
+    Each coord is a scalar or an int64 array; NumPy broadcasting sets the output shape, so a per-env
+    loop and a single vectorized call produce bit-identical values. Folds the coords through the
+    SplitMix64 finalizer (a strong-avalanche bijection on 2^64) and takes the top 53 bits as an exact
+    double in ``[0, 1)``.
+
+    The hash stays CPU/numpy: uint64 wraparound is exact and platform-independent, whereas torch
+    int64 ``>>`` is arithmetic (not logical), so the SplitMix shifts would need explicit masking.
+    """
+    arrays = [np.asarray(c).astype(np.int64).astype(np.uint64) for c in coords]
+    shape = np.broadcast_shapes(*(a.shape for a in arrays)) if arrays else ()
+    with np.errstate(over="ignore"):  # uint64 wraparound is the intended modular arithmetic
+        h = np.broadcast_to(_SPLITMIX_IV, shape).copy()
+        for a in arrays:
+            z = h ^ a
+            z = (z ^ (z >> _S30)) * _SPLITMIX_M1
+            z = (z ^ (z >> _S27)) * _SPLITMIX_M2
+            h = z ^ (z >> _S31)
+        u = (h >> _S11).astype(np.float64) * (2.0**-53)
+    return torch.as_tensor(np.ascontiguousarray(u), dtype=torch.float64).reshape(u.shape)
+
+
+# Stage tags folded into the key so a term registered at two lifecycle stages can't collide.
+STAGE_SETUP, STAGE_RESET, STAGE_STEP = 0, 1, 2
+
+# Domain tag folded into permute() keys so a permutation can never alias a draw() of the same fold
+# arity (draw folds (env, episode) where permute would fold (coord, index) — same-position small
+# ints would otherwise hash identically).
+_PERMUTE_TAG = _term_id("__permute__")
+
+
+@dataclass(frozen=True)
+class TermSampler:
+    """The one sampler a randomization term uses — bound by the manager to a term's coordinates.
+
+    The manager (which alone knows each term's stable name, lifecycle stage, and the per-env episode
+    counter) calls :meth:`bind` once and passes the result into the term. The term then draws by
+    MEANING — "a value for this config range, these envs, and these caller coordinates" — and gets back
+    a tensor that is reproducible per (term, env, episode) and independent of the order or set of
+    other terms.
+
+    The draw is a generic keyed function of coordinates (see the module header). The framework fixes
+    ``base_seed``, ``term_id``, ``stage``; the manager supplies the per-env ``episode`` counter, zipped
+    with ``env_ids`` into one leading output dimension; the term supplies the rest as ``coords`` — a
+    tuple in which each entry is a Python ``int`` (no dimension, a distinct stream) or a tensor (a new
+    dimension). A per-entity draw is a tensor coord; an independent stream is an int coord.
+
+    This is the single surface for all DR sampling: continuous draws (:meth:`draw`) and discrete
+    indices (:meth:`draw_int`, e.g. material bucket selection / action delay). A per-actor loop
+    pre-draws the full tensor once and indexes it, rather than drawing one float at a time. Material
+    bucket VALUES are filled separately via :func:`quantiles` (deterministic given the spec); only the
+    per-shape bucket selection is keyed, through :meth:`draw_int`.
+
+    Coordinate shaping
+    ------------------
+    The env/episode dimension is always output axis 0 (length ``len(env_ids)``). Each tensor coord adds
+    a trailing dimension, placed by giving the coord a leading size-1 env axis:
+
+    ======================================  =========================================  ============
+    intent                                  ``coords=``                                output shape
+    ======================================  =========================================  ============
+    one value per env (a global scalar)     ``()``  (omit it)                          ``[E]``
+    two decorrelated per-env quantities     ``(0,)`` and ``(1,)`` in two calls         ``[E]`` each
+    one value per (env, entity)             ``(ids[None, :],)``                        ``[E, N]``
+    per (env, entity) on stream k           ``(k, ids[None, :])``                      ``[E, N]``
+    a per-(env, i, j) matrix / geom-pair    ``(rows[None, :, None], cols[None, None, :])``  ``[E, I, J]``
+    ======================================  =========================================  ============
+
+    An ``int`` coord is a stream tag: it adds no dimension and decorrelates this draw from another. A
+    tensor coord adds a dimension and keys on its VALUES, so a per-entity draw is reproducible by id,
+    not by position. Since ``value = f(coordinate values)``, the same id keyed as a scalar ``int``, a
+    1-element tensor, or one cell of a larger tensor draws the same number — only its position in the
+    output changes. A per-actor scalar loop and a single vectorized tensor-coord draw therefore agree
+    bit-for-bit.
+
+    Coordinate layout is defined by the term: which int means which quantity (CoM x=0 / y=1, the six
+    inertia components, link-scale vs base-add mass) is the term's own convention. Renumbering or
+    reordering the coords changes the draws, so a term's coordinate scheme is fixed once shipped — a
+    change breaks reproducibility against existing runs and checkpoints.
+
+    Examples
+    --------
+    >>> # In production a bound sampler arrives from the manager; one is built directly here.
+    >>> sampler = TermSampler.bind(base_seed=42, term_name="randomize_friction", stage=STAGE_RESET)
+    >>> env_ids = torch.arange(4)
+    >>> sampler.draw([0.5, 1.5], env_ids=env_ids).shape                       # per-env -> [E]
+    torch.Size([4])
+    >>> body_ids = torch.tensor([3, 7, 9])
+    >>> sampler.draw([0.9, 1.1], env_ids=env_ids, coords=(body_ids[None, :],)).shape   # per-body -> [E, N]
+    torch.Size([4, 3])
+    >>> # The same body keyed as a scalar stream matches its column in the vectorized draw:
+    >>> col = sampler.draw([0.9, 1.1], env_ids=env_ids, coords=(body_ids[None, :],))[:, 1]
+    >>> one = sampler.draw([0.9, 1.1], env_ids=env_ids, coords=(int(body_ids[1]),))
+    >>> torch.equal(col, one)
+    True
+    """
+
+    base_seed: int
+    term_id: int
+    stage: int
+    episode: torch.Tensor | None  # per-env episode counter (CPU long), or None at startup (sentinel 0)
+
+    @classmethod
+    def bind(
+        cls,
+        base_seed: int | None,
+        term_name: str,
+        stage: int,
+        episode_count: torch.Tensor | None = None,
+    ) -> TermSampler:
+        """Bind a sampler to one term invocation. ``episode_count`` is the env's per-env reset counter.
+
+        ``base_seed`` MUST be set, a keyed sampler with no seed cannot be reproducible. Pass the run's
+        seed (env ``dr_base_seed`` = the training seed); a seedless run is a configuration error, raised here.
+        """
+        if base_seed is None:
+            raise ValueError(
+                "TermSampler requires a base_seed (the run's DR seed); there is no unseeded/global-RNG "
+                "fallback. Set the training seed (env.dr_base_seed). A seedless DR run is not reproducible!"
+            )
+        ep = None if episode_count is None else episode_count.to(device="cpu", dtype=torch.long)
+        return cls(base_seed=base_seed, term_id=_term_id(term_name), stage=stage, episode=ep)
+
+    @staticmethod
+    def _coord_array(c: int | Sequence[int] | np.ndarray | torch.Tensor) -> np.ndarray:
+        """One caller coordinate as an int64 numpy array (a Python int -> 0-d; a tensor -> its shape).
+
+        The VALUE is what keys the draw; the SHAPE only places it. So a coord may be a CUDA tensor of
+        stable ids — it is pulled to CPU here — without affecting the drawn value.
+        """
+        if isinstance(c, torch.Tensor):
+            return c.detach().to(device="cpu", dtype=torch.long).numpy()
+        return np.asarray(c, dtype=np.int64)
+
+    def _uniforms(
+        self,
+        env_ids: torch.Tensor,
+        coords: Sequence[int | Sequence[int] | np.ndarray | torch.Tensor] = (),
+    ):
+        """Keyed uniforms for (this term, these envs+episodes, these caller ``coords``).
+
+        The env/episode coordinate is the LEADING output axis: ``env_ids`` and the per-env ``episode``
+        counter are ZIPPED elementwise (row k keys on ``(env_ids[k], episode[env_ids[k]])`` TOGETHER,
+        NOT an outer-product grid), contributing ONE dimension of length ``len(env_ids)``. Episode is
+        gathered per env-id, so resetting an env SUBSET keys each row on that env's own count and the
+        draw stays subset-stable. Each entry of ``coords`` is folded as given — a Python ``int`` adds
+        no dimension (it shifts the stream); a tensor adds its own dimension(s).
+
+        Output shape = the env axis broadcast against the tensor coords (``np.broadcast_shapes``-style,
+        right-aligned). The env axis sits on axis 0, so a caller shapes a tensor coord with a leading
+        size-1 env axis: ``ids[None, :]`` (``[1, N]``) yields ``[E, N]``; ``rows[None, :, None]`` +
+        ``cols[None, None, :]`` yields ``[E, R, C]``. No coords -> ``[E]``; only int coords -> ``[E]``.
+        """
+        env_np = env_ids.to(device="cpu", dtype=torch.long).numpy()
+        if self.episode is None:
+            ep_np = np.zeros_like(env_np)  # startup sentinel: no episode counter yet
+        else:
+            ep = self.episode.numpy()
+            if env_np.size and int(env_np.max()) >= ep.shape[0]:
+                raise IndexError(
+                    f"episode counter has length {ep.shape[0]} but env_ids reference index "
+                    f"{int(env_np.max())}; the per-env episode tensor must cover every drawn env id "
+                    "(env and episode are zipped into one dimension and must be the same population)."
+                )
+            ep_np = ep[env_np]  # gather per env-id: row k -> (env_ids[k], episode[env_ids[k]])
+        coord_arrays = [self._coord_array(c) for c in coords]
+        # env/episode sit on axis 0; pad with trailing singletons so their E aligns there against each
+        # tensor coord's leading (size-1) env axis. Scalar-int coords (rank 0) add nothing -> stays [E].
+        pad = max(0, max((a.ndim for a in coord_arrays), default=0) - 1)
+        env_shape = (env_np.shape[0],) + (1,) * pad
+        env_k = env_np.reshape(env_shape)
+        ep_k = ep_np.reshape(env_shape)
+        u = keyed_uniform(self.base_seed, self.term_id, self.stage, env_k, ep_k, *coord_arrays)
+        return u.to(torch.float32)
+
+    def draw(
+        self,
+        spec: DistributionLike,
+        *,
+        env_ids: torch.Tensor,
+        coords: Sequence[int | Sequence[int] | np.ndarray | torch.Tensor] = (),
+        device: str | torch.device = "cpu",
+    ) -> torch.Tensor:
+        """Draw continuous values for one config range value, keyed and reproducible per (term, env, episode).
+
+        See the class "Coordinate shaping" section for how ``coords`` sets the output shape: leading
+        axis = env/episode, each tensor coord = a trailing dimension, each int coord = a decorrelated
+        stream.
+
+        Parameters
+        ----------
+        spec : a :data:`DistributionLike` — a ``[lo, hi]`` pair (always uniform), a ``{kind, low, high,
+            mean, std}`` dict, or a ready :class:`DistributionSpec`. Parsed via
+            :meth:`DistributionSpec.parse`.
+        env_ids : the envs to draw for (1-D long tensor). Becomes output axis 0; zipped with the bound
+            per-env ``episode`` counter — so resetting a subset draws the SAME values those envs got in
+            a full draw at the same episode.
+        coords : tuple of extra coordinates (ints = streams, tensors = dimensions). Default ``()`` -> one
+            value per env, shape ``[E]``.
+        device : device of the returned tensor (the hash itself always runs on CPU; see the module note).
+
+        Returns
+        -------
+        torch.Tensor : float32, shape ``[E, *coord_dims]`` (just ``[E]`` with no tensor coords).
+
+        Examples
+        --------
+        >>> sampler.draw([0.5, 1.5], env_ids=env_ids)                          # per-env friction -> [E]
+        >>> sampler.draw({"kind": "gaussian", "low": -1, "high": 1}, env_ids=env_ids)  # truncated normal
+        >>> sampler.draw([0.9, 1.1], env_ids=env_ids, coords=(body_ids[None, :],))     # per-(env, body)
+        """
+        parsed = DistributionSpec.parse(spec)
+        u = self._uniforms(env_ids, coords).to(device)
+        return _inverse_cdf(u, parsed)
+
+    def draw_int(
+        self,
+        low: int,
+        high: int,
+        *,
+        env_ids: torch.Tensor,
+        coords: Sequence[int | Sequence[int] | np.ndarray | torch.Tensor] = (),
+    ) -> torch.Tensor:
+        """Keyed discrete draw of integers in ``[low, high]`` INCLUSIVE; same coord shaping as :meth:`draw`.
+
+        For material bucket selection and discrete delays — anywhere you need a reproducible integer
+        index per (term, env, episode) rather than a continuous value. Maps a keyed uniform onto the
+        integer range (each of the ``high - low + 1`` values equiprobable).
+
+        Examples
+        --------
+        >>> sampler.draw_int(0, 3, env_ids=env_ids)                              # a per-env delay -> [E]
+        >>> sampler.draw_int(0, 63, env_ids=env_ids, coords=(shape_ids[None, :]))  # per-shape bucket -> [E, S]
+        """
+        span = high - low + 1
+        if span <= 0:
+            raise ValueError(f"draw_int requires high >= low, got [{low}, {high}].")
+        u = self._uniforms(env_ids, coords)
+        return low + (u * span).floor().clamp(max=span - 1).to(torch.long)
+
+    def permute(self, n: int, coords: Sequence[int | Sequence[int] | np.ndarray | torch.Tensor] = ()) -> torch.Tensor:
+        """A keyed permutation of ``range(n)``, reproducible per (term, stage, ``coords``), env-INDEPENDENT.
+
+        Unlike :meth:`draw`/:meth:`draw_int`, it takes no ``env_ids`` and does not key on env/episode.
+        It shuffles a SHARED table that every env then indexes into — the PhysX material bucket case:
+        fill one bucket column with :func:`quantiles`, ``permute`` it once (reproducibly, so the
+        realized material is stable per seed), then have each (env, shape) pick a bucket via
+        :meth:`draw_int`. Pass a distinct int coord per channel so several channels' shuffles are
+        independent (not rank-aligned). Returns a ``[n]`` long tensor that is a true permutation.
+
+        Examples
+        --------
+        >>> order = sampler.permute(64, (0,))           # channel 0's shuffle of 64 buckets, reproducible
+        >>> sorted(order.tolist()) == list(range(64))
+        True
+        """
+        coord_arrays = [self._coord_array(c) for c in coords]
+        u = keyed_uniform(
+            self.base_seed, self.term_id, self.stage, _PERMUTE_TAG, *coord_arrays, np.arange(n, dtype=np.int64)
+        )
+        return torch.argsort(u)

--- a/src/holosoma/holosoma/utils/tests/test_distributions.py
+++ b/src/holosoma/holosoma/utils/tests/test_distributions.py
@@ -1,0 +1,272 @@
+"""Unit tests for the shared DR distribution sampler (backend-free, Mac-runnable).
+
+These exercise :class:`DistributionSpec` validation and the inverse-CDF shaping statistics with no
+simulator dependency, so they run anywhere torch is importable. Production draws ONLY through the
+keyed :class:`TermSampler` (covered in test_keyed_distributions.py); there is no public stateful
+``sample`` — these tests apply the same inverse-CDF transform to a block of uniforms directly.
+"""
+
+import math
+
+import pytest
+import torch
+
+from holosoma.utils.sampler import DistributionSpec, _inverse_cdf, quantiles
+
+_N = 200_000
+_DEVICE = "cpu"
+
+
+def _draw(spec: DistributionSpec) -> torch.Tensor:
+    """Continuous draw of ``spec`` via the SAME inverse-CDF the keyed sampler uses (test-only)."""
+    torch.manual_seed(0)
+    u = torch.rand(_N, device=_DEVICE)
+    return _inverse_cdf(u, spec)
+
+
+# --------------------------------------------------------------------------------------------------
+# Validation (errors fire at construction, identically for every backend)
+# --------------------------------------------------------------------------------------------------
+
+
+def test_unknown_kind_raises():
+    with pytest.raises(ValueError, match="unknown distribution"):
+        DistributionSpec(kind="gaussain", low=0.0, high=1.0)  # type: ignore[arg-type]
+
+
+def test_uniform_requires_bounds():
+    with pytest.raises(ValueError, match="requires both 'low' and 'high'"):
+        DistributionSpec(kind="uniform", low=1.0)
+
+
+def test_high_below_low_raises():
+    with pytest.raises(ValueError, match="must be >= low"):
+        DistributionSpec(kind="uniform", low=1.0, high=0.0)
+
+
+@pytest.mark.parametrize("bounds", [(-1.0, 3.0), (0.0, 2.0), (-2.0, -1.0)])
+def test_log_uniform_non_positive_bounds_raise(bounds):
+    with pytest.raises(ValueError, match="strictly positive bounds"):
+        DistributionSpec(kind="log_uniform", low=bounds[0], high=bounds[1])
+
+
+def test_uniform_rejects_mean_std():
+    with pytest.raises(ValueError, match="does not accept 'mean'/'std'"):
+        DistributionSpec(kind="uniform", low=0.0, high=1.0, mean=0.5, std=0.1)
+
+
+def test_gaussian_requires_params_or_bounds():
+    with pytest.raises(ValueError, match="requires either explicit"):
+        DistributionSpec(kind="gaussian")
+
+
+def test_gaussian_partial_mean_std_raises():
+    with pytest.raises(ValueError, match="together, or neither"):
+        DistributionSpec(kind="gaussian", mean=1.0)
+
+
+def test_gaussian_negative_std_raises():
+    with pytest.raises(ValueError, match="std must be >= 0"):
+        DistributionSpec(kind="gaussian", mean=1.0, std=-0.1)
+
+
+# --------------------------------------------------------------------------------------------------
+# parse parsing
+# --------------------------------------------------------------------------------------------------
+
+
+def test_parse_pair_is_uniform():
+    spec = DistributionSpec.parse([1.0, 4.0])
+    assert spec.kind == "uniform"
+    assert (spec.low, spec.high) == (1.0, 4.0)
+
+
+def test_parse_dict_explicit_kind_and_params():
+    spec = DistributionSpec.parse({"kind": "gaussian", "low": -1.0, "high": 1.0, "mean": 0.0, "std": 0.25})
+    assert spec.kind == "gaussian"
+    assert spec.resolved_mean_std() == (0.0, 0.25)
+
+
+def test_parse_dict_range_key():
+    spec = DistributionSpec.parse({"kind": "uniform", "range": [2.0, 5.0]})
+    assert (spec.low, spec.high) == (2.0, 5.0)
+
+
+def test_parse_unknown_key_raises():
+    with pytest.raises(ValueError, match="unknown distribution spec keys"):
+        DistributionSpec.parse({"kind": "uniform", "low": 0.0, "high": 1.0, "loww": 2.0})
+
+
+def test_parse_range_and_low_high_conflict_raises():
+    # `range` and explicit low/high together is ambiguous -> fail loudly (don't silently let one win).
+    with pytest.raises(ValueError, match="either 'range' or 'low'/'high'"):
+        DistributionSpec.parse({"range": [0.0, 1.0], "low": 5.0})
+
+
+def test_parse_passthrough_spec():
+    spec = DistributionSpec(kind="uniform", low=0.0, high=1.0)
+    assert DistributionSpec.parse(spec) is spec
+
+
+# --------------------------------------------------------------------------------------------------
+# Sampling statistics
+# --------------------------------------------------------------------------------------------------
+
+
+def test_uniform_in_band_and_mean():
+    spec = DistributionSpec(kind="uniform", low=-2.0, high=6.0)
+    x = _draw(spec)
+    assert x.min() >= -2.0 and x.max() <= 6.0
+    assert abs(x.mean().item() - 2.0) < 0.05
+
+
+def test_log_uniform_in_band_and_log_mean():
+    lo, hi = 1.0, 100.0
+    spec = DistributionSpec(kind="log_uniform", low=lo, high=hi)
+    x = _draw(spec)
+    assert x.min() >= lo - 1e-4 and x.max() <= hi + 1e-4
+    # Uniform in log-space -> mean of log(x) ~ midpoint of [log lo, log hi].
+    expected_log_mean = 0.5 * (math.log(lo) + math.log(hi))
+    assert abs(torch.log(x).mean().item() - expected_log_mean) < 0.02
+
+
+def test_gaussian_bounds_derive_mean_std_and_truncate():
+    lo, hi = -1.0, 1.0
+    spec = DistributionSpec(kind="gaussian", low=lo, high=hi)
+    x = _draw(spec)
+    # Truncated strictly inside the band, centered, std ~ (hi-lo)/6.
+    assert x.min() >= lo and x.max() <= hi
+    assert abs(x.mean().item()) < 0.02
+    assert abs(x.std().item() - (hi - lo) / 6.0) < 0.03
+
+
+def test_gaussian_signed_band_centers_at_zero():
+    spec = DistributionSpec(kind="gaussian", low=-0.025, high=0.025)
+    x = _draw(spec)
+    assert x.min() >= -0.025 and x.max() <= 0.025
+    assert abs(x.mean().item()) < 1e-3
+
+
+def test_gaussian_explicit_mean_std_no_bounds_untruncated():
+    spec = DistributionSpec(kind="gaussian", mean=5.0, std=2.0)
+    x = _draw(spec)
+    assert abs(x.mean().item() - 5.0) < 0.05
+    assert abs(x.std().item() - 2.0) < 0.05
+
+
+def test_gaussian_one_sided_low_truncates_below_only():
+    # Half-open [low, +inf): values never below low, but unbounded above; mean shifts up vs the
+    # untruncated 0 because the lower tail is removed.
+    spec = DistributionSpec(kind="gaussian", mean=0.0, std=1.0, low=0.0)
+    x = _draw(spec)
+    assert x.min() >= 0.0
+    assert x.max() > 2.0  # upper tail intact (unbounded above)
+    assert x.mean().item() > 0.5  # lower half removed -> mean pulled up (half-normal mean ~0.8)
+
+
+def test_gaussian_one_sided_high_truncates_above_only():
+    spec = DistributionSpec(kind="gaussian", mean=0.0, std=1.0, high=0.0)
+    x = _draw(spec)
+    assert x.max() <= 0.0
+    assert x.min() < -2.0  # lower tail intact
+    assert x.mean().item() < -0.5  # upper half removed -> mean pulled down
+
+
+def test_gaussian_one_sided_requires_explicit_mean_std():
+    # A lone bound cannot derive (mean, std) -> must raise (fail loud, don't guess).
+    with pytest.raises(ValueError, match="single bound"):
+        DistributionSpec(kind="gaussian", low=0.0)
+    with pytest.raises(ValueError, match="single bound"):
+        DistributionSpec(kind="gaussian", high=1.0)
+
+
+def test_gaussian_explicit_params_with_bounds_truncate():
+    # Explicit (mean, std) but bounds present -> clamp via truncation to the band.
+    spec = DistributionSpec(kind="gaussian", low=0.0, high=1.0, mean=0.5, std=5.0)
+    x = _draw(spec)
+    assert x.min() >= 0.0 and x.max() <= 1.0
+
+
+def test_gaussian_zero_std_is_constant():
+    spec = DistributionSpec(kind="gaussian", mean=3.0, std=0.0)
+    x = _draw(spec)
+    assert torch.allclose(x, torch.full_like(x, 3.0))
+
+
+def test_degenerate_equal_bounds_constant():
+    spec = DistributionSpec(kind="gaussian", low=2.0, high=2.0)
+    x = _draw(spec)
+    assert torch.allclose(x, torch.full_like(x, 2.0))
+
+
+def test_gaussian_zero_std_with_bounds_clamps_to_band():
+    # Explicit mean outside [low, high] with std=0 -> constant clamped to the boundary.
+    spec = DistributionSpec(kind="gaussian", low=0.0, high=1.0, mean=5.0, std=0.0)
+    x = _draw(spec)
+    assert torch.allclose(x, torch.full_like(x, 1.0))
+
+
+def test_gaussian_equal_bounds_explicit_std_constant():
+    # low == high with explicit std>0 -> constant at the bound (truncated-normal short-circuit).
+    spec = DistributionSpec(kind="gaussian", low=2.0, high=2.0, mean=2.0, std=0.5)
+    x = _draw(spec)
+    assert torch.allclose(x, torch.full_like(x, 2.0))
+
+
+def test_seeded_reproducible():
+    spec = DistributionSpec(kind="gaussian", low=-1.0, high=1.0)
+    a = _draw(spec)
+    b = _draw(spec)
+    assert torch.equal(a, b)
+
+
+# --------------------------------------------------------------------------------------------------
+# quantiles() — the bucket-fill primitive for PhysX-material backends
+# --------------------------------------------------------------------------------------------------
+
+
+def test_quantiles_count_and_in_band():
+    spec = DistributionSpec(kind="uniform", low=2.0, high=5.0)
+    q = quantiles(spec, 64, _DEVICE)
+    assert q.shape == (64,)
+    assert q.min() >= 2.0 and q.max() <= 5.0
+
+
+def test_quantiles_uniform_are_evenly_spaced():
+    # Uniform quantiles at (i+0.5)/n are the midpoints of n equal sub-intervals.
+    spec = DistributionSpec(kind="uniform", low=0.0, high=1.0)
+    q = quantiles(spec, 10, _DEVICE)
+    expected = (torch.arange(10, dtype=torch.float32) + 0.5) / 10.0
+    assert torch.allclose(q, expected, atol=1e-6)
+
+
+def test_quantiles_deterministic_and_sorted():
+    # quantiles has NO internal shuffle/global-RNG: same call -> identical, sorted ascending. Any
+    # shuffle is the caller's job (keyed, in the material writer).
+    spec = DistributionSpec(kind="uniform", low=0.0, high=1.0)
+    q1 = quantiles(spec, 64, _DEVICE)
+    q2 = quantiles(spec, 64, _DEVICE)
+    assert torch.equal(q1, q2)
+    assert torch.equal(q1, q1.sort().values)
+
+
+def test_quantiles_uniform_selection_reproduces_distribution():
+    # The bucket scheme: uniform-select (with replacement) over quantile values. The realized
+    # marginal must match a direct continuous draw of the same spec (this is the whole point).
+    spec = DistributionSpec(kind="gaussian", low=-1.0, high=1.0)
+    torch.manual_seed(0)
+    buckets = quantiles(spec, 256, _DEVICE)
+    pick = torch.randint(0, 256, (_N,))
+    bucketed = buckets[pick]
+    direct = _draw(spec)
+    assert bucketed.min() >= -1.0 and bucketed.max() <= 1.0
+    assert abs(bucketed.mean().item() - direct.mean().item()) < 0.02
+    assert abs(bucketed.std().item() - direct.std().item()) < 0.02
+
+
+def test_quantiles_log_uniform_positive_and_log_mean():
+    spec = DistributionSpec(kind="log_uniform", low=1.0, high=100.0)
+    q = quantiles(spec, 128, _DEVICE)
+    assert q.min() >= 1.0 and q.max() <= 100.0
+    # Log-spaced -> mean of log(q) near the midpoint of [log lo, log hi].
+    assert abs(torch.log(q).mean().item() - 0.5 * (math.log(1.0) + math.log(100.0))) < 0.05

--- a/src/holosoma/holosoma/utils/tests/test_keyed_distributions.py
+++ b/src/holosoma/holosoma/utils/tests/test_keyed_distributions.py
@@ -1,0 +1,335 @@
+"""Invariance + KAT tests for the keyed TermSampler (backend-free, Mac-runnable).
+
+These prove the reproducibility contract: a draw is value = f(term, env, episode), independent of the
+set/order of other terms, num_envs, and which env subset resets — and the vectorized hash equals a
+per-env loop bit-for-bit.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from holosoma.utils.sampler import STAGE_RESET, STAGE_SETUP, TermSampler, keyed_uniform
+
+SEED = 12345
+
+
+def _binder(term="randomize_mass_startup", stage=STAGE_RESET, episode=None):
+    return TermSampler.bind(SEED, term, stage, episode)
+
+
+# --- raw hash properties --------------------------------------------------------------------------
+
+
+def test_keyed_uniform_vectorized_equals_loop():
+    envs = np.arange(8)
+    vec = keyed_uniform(SEED, 99, 1, envs, 3, 0, 0)
+    loop = torch.stack([keyed_uniform(SEED, 99, 1, int(e), 3, 0, 0) for e in range(8)])  # 0-d -> [8]
+    assert torch.equal(vec, loop)
+
+
+def test_keyed_uniform_in_unit_interval():
+    u = keyed_uniform(SEED, 7, 1, np.arange(100000), 0, 0, 0)
+    assert u.min() >= 0.0 and u.max() < 1.0
+    assert abs(u.mean().item() - 0.5) < 0.01
+
+
+def test_keyed_uniform_kat():
+    # Pinned wire-format vector: changing the IV/mixer breaks this on purpose.
+    assert keyed_uniform(SEED, 99, 1, 7, 3, 0, 0).item() == pytest.approx(0.08690584629403264, abs=1e-12)
+
+
+# --- TermSampler.draw invariances (the whole point) ----------------------------------------------
+
+
+def _draw_env(sampler, env_id, leaf=(2.0, 3.0)):
+    return sampler.draw(leaf, env_ids=torch.tensor([env_id])).item()
+
+
+def test_subset_reset_invariance():
+    s = _binder()
+    all_envs = s.draw((2.0, 3.0), env_ids=torch.arange(8))
+    subset = s.draw((2.0, 3.0), env_ids=torch.tensor([2, 5]))
+    assert subset[0].item() == all_envs[2].item()
+    assert subset[1].item() == all_envs[5].item()
+
+
+def test_num_envs_invariance():
+    s = _binder()
+    big = s.draw((2.0, 3.0), env_ids=torch.arange(4096))
+    small = s.draw((2.0, 3.0), env_ids=torch.arange(1024))
+    assert torch.equal(big[:1024], small)
+
+
+def _shared_term_draw_within_run(other_terms, episode):
+    """Simulate ONE DR-manager run: draw the SHARED term plus a set of OTHER terms (whatever else the
+    config happens to include), and return only the shared term's per-(env, episode) values.
+
+    The keyed sampler is stateless (value = f(term, env, episode)), so binding/drawing the other
+    terms — in any order, with any params — must NOT perturb the shared term. Drawing them here
+    proves that end-to-end, the way a manager would interleave term draws in a real run.
+    """
+    env_ids = torch.arange(16)
+    # The other terms run (different bands, different order between runs) — their draws are discarded;
+    # the point is that they exist and execute alongside the shared term.
+    for name, band in other_terms:
+        TermSampler.bind(SEED, name, STAGE_RESET, episode).draw(
+            band, env_ids=env_ids, coords=(torch.arange(4)[None, :],)
+        )
+    shared = TermSampler.bind(SEED, "shared_term", STAGE_RESET, episode)
+    return shared.draw((0.0, 1.0), env_ids=env_ids)
+
+
+def test_shared_term_invariant_across_different_runs():
+    """User-requested consistency guarantee: run DR with one set of terms+params, then AGAIN with
+    DIFFERENT terms and DIFFERENT params for everything EXCEPT one shared term — that shared term must
+    produce identical values per (env, episode) across both runs. (Independence from the term
+    set/order and from other terms' parameters is the whole reason for counter-based keying.)"""
+    episode = torch.zeros(16, dtype=torch.long)
+    run1 = _shared_term_draw_within_run(
+        [("term_A", (0.0, 1.0)), ("term_B", (-2.0, 2.0)), ("term_C", (5.0, 6.0))], episode
+    )
+    run2 = _shared_term_draw_within_run(
+        # Different term SET (A dropped, D/E added), different ORDER, different PARAMS on the rest.
+        [("term_E", (10.0, 20.0)), ("term_B", (0.1, 0.2)), ("term_D", (-9.0, -8.0))],
+        episode,
+    )
+    assert torch.equal(run1, run2), "shared term's draws changed when other terms/params changed"
+    # And distinct per episode (so it's a real per-(env, episode) draw, not a constant).
+    run3 = _shared_term_draw_within_run([("term_B", (0.1, 0.2))], torch.full((16,), 7, dtype=torch.long))
+    assert not torch.equal(run1, run3), "shared term did not vary with episode"
+
+
+def test_term_independence():
+    a = TermSampler.bind(SEED, "term_A", STAGE_RESET).draw((0.0, 1.0), env_ids=torch.arange(64))
+    b = TermSampler.bind(SEED, "term_B", STAGE_RESET).draw((0.0, 1.0), env_ids=torch.arange(64))
+    assert not torch.equal(a, b)
+
+
+def test_stage_independence():
+    setup = TermSampler.bind(SEED, "term_A", STAGE_SETUP).draw((0.0, 1.0), env_ids=torch.arange(64))
+    reset = TermSampler.bind(SEED, "term_A", STAGE_RESET).draw((0.0, 1.0), env_ids=torch.arange(64))
+    assert not torch.equal(setup, reset)
+
+
+def test_stream_coord_independence():
+    # An int coord is a STREAM tag: two draws differing only in their int coord must decorrelate
+    # (this is what used to be ``axis=``). It adds no dimension, so the shape stays [E].
+    s = _binder()
+    x = s.draw((0.0, 1.0), env_ids=torch.arange(64), coords=(0,))
+    y = s.draw((0.0, 1.0), env_ids=torch.arange(64), coords=(1,))
+    assert tuple(x.shape) == (64,) and tuple(y.shape) == (64,)
+    assert not torch.equal(x, y)
+
+
+def test_episode_progression_reproducible_and_distinct():
+    ep0 = torch.zeros(8, dtype=torch.long)
+    ep1 = torch.ones(8, dtype=torch.long)
+    s0 = TermSampler.bind(SEED, "term_A", STAGE_RESET, ep0)
+    s1 = TermSampler.bind(SEED, "term_A", STAGE_RESET, ep1)
+    v0 = s0.draw((0.0, 1.0), env_ids=torch.arange(8))
+    v1 = s1.draw((0.0, 1.0), env_ids=torch.arange(8))
+    assert not torch.equal(v0, v1)  # different episode -> different value
+    # reproducible: same episode again matches
+    assert torch.equal(
+        v0, TermSampler.bind(SEED, "term_A", STAGE_RESET, ep0.clone()).draw((0.0, 1.0), env_ids=torch.arange(8))
+    )
+
+
+def test_async_episode_per_env():
+    # env 5 at episode 12 must match whether or not its neighbours share that episode.
+    ep_async = torch.tensor([3, 3, 3, 3, 3, 12, 3, 3], dtype=torch.long)
+    ep_all12 = torch.full((8,), 12, dtype=torch.long)
+    a = TermSampler.bind(SEED, "term_A", STAGE_RESET, ep_async).draw((0.0, 1.0), env_ids=torch.arange(8))
+    b = TermSampler.bind(SEED, "term_A", STAGE_RESET, ep_all12).draw((0.0, 1.0), env_ids=torch.arange(8))
+    assert a[5].item() == b[5].item()  # env 5 @ ep12 identical regardless of neighbours
+    assert a[0].item() != b[0].item()  # env 0 differs (ep3 vs ep12)
+
+
+def test_seed_sensitivity():
+    a = TermSampler.bind(1, "term_A", STAGE_RESET).draw((0.0, 1.0), env_ids=torch.arange(64))
+    b = TermSampler.bind(2, "term_A", STAGE_RESET).draw((0.0, 1.0), env_ids=torch.arange(64))
+    assert not torch.equal(a, b)
+
+
+def test_unseeded_bind_raises():
+    # A seed is REQUIRED — there is NO global-RNG fallback. bind(None) must fail loudly so a seedless
+    # DR run is caught at bind time rather than silently producing non-reproducible draws.
+    with pytest.raises(ValueError, match="requires a base_seed"):
+        TermSampler.bind(None, "term_A", STAGE_RESET)
+
+
+# --- draw shaping reuses the converters ----------------------------------------------------------
+
+
+def test_draw_gaussian_truncated_in_band():
+    s = _binder()
+    x = s.draw({"kind": "gaussian", "low": -1.0, "high": 1.0}, env_ids=torch.arange(200000))
+    assert x.min() >= -1.0 and x.max() <= 1.0
+    assert abs(x.mean().item()) < 0.02
+
+
+def test_per_actor_loop_draw_reproducible():
+    # A per-actor loop pre-draws the full [n_env, 1] vector once and indexes it.
+    s = _binder()
+    a = s.draw((2.0, 3.0), env_ids=torch.arange(5)).squeeze(-1)
+    b = s.draw((2.0, 3.0), env_ids=torch.arange(5)).squeeze(-1)
+    assert torch.equal(a, b)
+    assert a.min() >= 2.0 and a.max() <= 3.0
+
+
+def test_draw_int_in_range_and_reproducible():
+    s = _binder()
+    a = s.draw_int(0, 3, env_ids=torch.arange(1000))
+    assert int(a.min()) >= 0 and int(a.max()) <= 3
+    b = s.draw_int(0, 3, env_ids=torch.arange(1000))
+    assert torch.equal(a, b)
+
+
+def test_entity_broadcast_shape():
+    # A tensor coord adds a trailing dimension: a [1, 3] coord (entity ids on a leading size-1 env
+    # axis) broadcasts against the [E]-on-axis-0 env coordinate to [E, 3].
+    s = _binder()
+    x = s.draw((0.0, 1.0), env_ids=torch.arange(4), coords=(torch.arange(3)[None, :],))
+    assert tuple(x.shape) == (4, 3)
+    # each entity column independent
+    assert not torch.equal(x[:, 0], x[:, 1])
+
+
+def test_stable_entity_ids_keep_draw_under_reordering():
+    # Drawing for entities [10, 20, 30] then [30, 10] must agree per id, not per position — the value
+    # keys on the id VALUE, never its position in the coord tensor.
+    s = _binder()
+    a = s.draw((0.0, 1.0), env_ids=torch.arange(4), coords=(torch.tensor([10, 20, 30])[None, :],))
+    b = s.draw((0.0, 1.0), env_ids=torch.arange(4), coords=(torch.tensor([30, 10])[None, :],))
+    assert torch.equal(a[:, 0], b[:, 1])  # id 10
+    assert torch.equal(a[:, 2], b[:, 0])  # id 30
+
+
+def test_permute_is_keyed_valid_and_coord_independent():
+    # The IsaacSim material bucket-shuffle relies on permute() being a REPRODUCIBLE permutation
+    # (so seeded material values are stable run-to-run) with per-channel independence via a stream
+    # coord (so the three friction/restitution channels are not rank-aligned).
+    s1, s2 = _binder(), _binder()
+    p = s1.permute(64, (0,))
+    assert sorted(p.tolist()) == list(range(64))  # a genuine permutation
+    assert torch.equal(p, s2.permute(64, (0,)))  # same key -> same perm (reproducible)
+    assert not torch.equal(p, s1.permute(64, (1,)))  # distinct stream coords -> distinct perms
+    assert not torch.equal(p, _binder(term="other_term").permute(64, (0,)))  # term-keyed
+    # permute is env/episode-INDEPENDENT (a shared table), unlike draw_int.
+    assert torch.equal(
+        _binder(episode=torch.zeros(4, dtype=torch.long)).permute(8, (0,)),
+        _binder(episode=torch.full((4,), 9, dtype=torch.long)).permute(8, (0,)),
+    )
+
+
+# --- variadic-coordinate shaping: rank comes from the tensor coords' broadcast -------------------
+
+
+def test_zero_coord_global_flag_shape():
+    # A global flag (a single value shared by every env): no caller coords -> output is just the env
+    # dimension [E]. This is the degenerate "one stream, per env" draw.
+    s = _binder()
+    x = s.draw((2.0, 3.0), env_ids=torch.arange(8))
+    assert tuple(x.shape) == (8,)
+    assert x.min() >= 2.0 and x.max() <= 3.0
+
+
+def test_geom_pair_2d_entity_shape():
+    # A per-(env, i, j) geom-PAIR draw: two tensor coords placed on distinct trailing axes broadcast
+    # against the [E]-on-axis-0 env coord -> [E, I, J]. (e.g. a friction-pair matrix between shapes.)
+    s = _binder()
+    rows = torch.arange(3).reshape(1, 3, 1)  # i on axis 1
+    cols = torch.arange(4).reshape(1, 1, 4)  # j on axis 2
+    x = s.draw((0.0, 1.0), env_ids=torch.arange(5), coords=(rows, cols))
+    assert tuple(x.shape) == (5, 3, 4)
+    # distinct (i, j) cells decorrelate
+    assert not torch.equal(x[:, 0, 0], x[:, 1, 2])
+
+
+def test_matrix_draw_shape():
+    # A per-(env, r, c) matrix draw (e.g. a 3x3 inertia-like block): same mechanism as the geom-pair,
+    # asserting the full [E, R, C] grid materialises with independent cells.
+    s = _binder()
+    r = torch.arange(3).reshape(1, 3, 1)
+    c = torch.arange(3).reshape(1, 1, 3)
+    x = s.draw((0.0, 1.0), env_ids=torch.arange(2), coords=(r, c))
+    assert tuple(x.shape) == (2, 3, 3)
+    flat = x.reshape(2, 9)
+    assert flat.unique().numel() == flat.numel()  # all 18 cells distinct (no accidental aliasing)
+
+
+# --- env and episode are ONE zipped dimension (not an outer product) -----------------------------
+
+
+def test_env_episode_zipped_single_dimension():
+    # env_ids and the per-env episode counter are zipped elementwise into ONE row dimension: row k
+    # keys on (env_ids[k], episode[env_ids[k]]) TOGETHER. Changing one env's episode must move only
+    # that row, and the output length is len(env_ids) (NOT len(env)*len(episode)).
+    ep = torch.tensor([0, 0, 0, 0], dtype=torch.long)
+    base = TermSampler.bind(SEED, "term_A", STAGE_RESET, ep).draw((0.0, 1.0), env_ids=torch.arange(4))
+    assert tuple(base.shape) == (4,)
+    ep2 = ep.clone()
+    ep2[2] = 7  # bump only env 2's episode
+    bumped = TermSampler.bind(SEED, "term_A", STAGE_RESET, ep2).draw((0.0, 1.0), env_ids=torch.arange(4))
+    assert bumped[2].item() != base[2].item()  # env 2's row moved
+    assert torch.equal(bumped[[0, 1, 3]], base[[0, 1, 3]])  # the others are untouched (zip, not grid)
+
+
+def test_env_episode_mismatched_length_raises():
+    # The episode tensor must cover every drawn env id (env and episode are the same population, zipped
+    # into one dimension). A counter shorter than the referenced env ids is a configuration error.
+    short_ep = torch.zeros(4, dtype=torch.long)
+    s = TermSampler.bind(SEED, "term_A", STAGE_RESET, short_ep)
+    with pytest.raises(IndexError):
+        s.draw((0.0, 1.0), env_ids=torch.arange(8))  # env id 7 has no episode entry
+
+
+# --- the SAME fundamental coordinate draws the SAME value however it is passed --------------------
+
+
+def test_coord_form_invariance_scalar_vs_tensor():
+    """value = f(coordinate VALUES): the SHAPE of a coord only places the value, never changes it.
+
+    So entity id 5 keyed as a scalar int coord, as a 1-element tensor coord, or as one element of a
+    multi-element tensor coord must all draw the SAME number for the same (term, env). This is the
+    property that lets a per-actor loop (scalar coord per actor) and a vectorized draw (tensor coord
+    over all actors) agree bit-for-bit.
+    """
+    s = _binder()
+    env_ids = torch.arange(6)
+
+    # (a) scalar int coord 5  vs  a 1-element tensor coord [5] (on the trailing axis).
+    as_int = s.draw((0.0, 1.0), env_ids=env_ids, coords=(5,))  # [E]
+    as_len1 = s.draw((0.0, 1.0), env_ids=env_ids, coords=(torch.tensor([5])[None, :],))  # [E, 1]
+    assert torch.equal(as_int, as_len1[:, 0])
+
+    # (b) the same id inside a MULTI-element tensor coord lands the identical value at its position.
+    multi = s.draw((0.0, 1.0), env_ids=env_ids, coords=(torch.tensor([3, 5, 9])[None, :],))
+    assert torch.equal(as_int, multi[:, 1])  # column for id 5
+
+    # (c) per-actor scalar loop == one vectorized tensor-coord draw, element-for-element.
+    ids = [10, 20, 30]
+    looped = torch.stack([s.draw((0.0, 1.0), env_ids=env_ids, coords=(i,)) for i in ids], dim=-1)
+    vectorized = s.draw((0.0, 1.0), env_ids=env_ids, coords=(torch.tensor(ids)[None, :],))
+    assert torch.equal(looped, vectorized)
+
+    # (d) a multi-coord draw equals the matching scalar-stream draw cell-by-cell: stream coord k +
+    #     entity id e (tensor) must equal the scalar draw coords=(k, e).
+    streamed = s.draw((0.0, 1.0), env_ids=env_ids, coords=(2, torch.tensor([7, 8])[None, :]))  # [E, 2]
+    cell_70 = s.draw((0.0, 1.0), env_ids=env_ids, coords=(2, 7))  # [E]
+    cell_81 = s.draw((0.0, 1.0), env_ids=env_ids, coords=(2, 8))
+    assert torch.equal(streamed[:, 0], cell_70)
+    assert torch.equal(streamed[:, 1], cell_81)
+
+
+def test_coord_form_invariance_numpy_python_tensor_equal():
+    # The coord container is irrelevant — a Python int, a numpy int, and a 0-d/CPU/CUDA tensor of the
+    # same value all key identically (the value is converted to int64 before hashing).
+    import numpy as np
+
+    s = _binder()
+    env_ids = torch.arange(4)
+    base = s.draw((0.0, 1.0), env_ids=env_ids, coords=(5,))
+    assert torch.equal(base, s.draw((0.0, 1.0), env_ids=env_ids, coords=(np.int64(5),)))
+    assert torch.equal(base, s.draw((0.0, 1.0), env_ids=env_ids, coords=(torch.tensor(5),)))


### PR DESCRIPTION
### Summary
Make domain randomization **reproducible and order-independent**: a single validated
`DistributionSpec` plus a keyed, counter-based `TermSampler`, so the same `(term, env, episode)`
draws the same value regardless of term set/order, `num_envs`, or which env subset resets. The
sampler is threaded through the randomization manager and every robot-DR term, and the IsaacSim
physics-DR writers are moved off IsaacLab's `mdp.randomize_rigid_body_*` onto project-owned writers
that honour the project's `[lo, hi]` bounds convention.

> ⚠️ **Not just plumbing — this changes DR *results* and backend *support* for the shipped presets
> `loco/g1`, `loco/t1`, `wbt/g1`.** The changes are individually small and (we believe) more correct,
> but **no seeded run reproduces a pre-PR run.** Treat existing checkpoints, reward curves, and
> regression fixtures as invalidated — re-baseline, don't reproduce.

## Behavior changes

All verified against the `main…02_reproducible_dr_sampling` diff and the three shipped presets.

### Different dynamics (a seeded run behaves differently, not just draws different numbers)

- **Mass DR now rescales body inertia** (`randomize_mass_startup`, `recompute_inertia` default
  **True**). Before, a mass change left inertia as authored (MuJoCo-Warp) or recomputed it from
  collision geometry (IsaacGym); now every backend scales the *authored* inertia by the mass ratio
  `m_after/m_before`. Opt out with `recompute_inertia=False`.
- **Base-CoM DR on IsaacGym no longer recomputes inertia from geometry** (`randomize_base_com_startup`;
  enabled in `loco/g1`, `wbt/g1`). A CoM offset now leaves the inertia tensor unchanged, matching the
  other backends. No opt-out.
- **IsaacSim friction DR no longer forces restitution to 0** (`randomize_friction_startup`; `loco/g1`,
  `loco/t1`). Before, the friction term silently zeroed restitution on every robot shape; now it
  leaves restitution at its authored value.
- **IsaacSim material DR now clamps dynamic friction ≤ static friction** (was an independent draw that
  could exceed static). Lowers the realized dynamic-friction on `loco/g1`/`loco/t1`; caps dynamic at
  the static draw for `wbt/g1` robot material.
- **Friction DR is quantized into `num_buckets` discrete values (default 64) on all backends** — this
  bounds the count of unique PhysX materials. MuJoCo-Warp, previously a continuous per-geom draw, is
  now a 64-value staircase by default; pass `num_buckets=None` for a continuous marginal.

### Newly supported

- **Classic (CPU) MuJoCo now runs robot mass / friction / base-CoM DR.** `mujoco_backend` defaults to
  `CLASSIC`; on `main` these terms raised `RandomizerNotSupportedError` on the classic backend, so a
  default-backend `loco/g1`/`loco/t1` run went from "DR errors at setup" to "DR applies".

### Reproducibility (no fixed seed reproduces a pre-PR run)

- **DR is drawn from the keyed sampler**, not the global RNG. Per-term distributions are unchanged and
  draws are now independent of term order / `num_envs` / reset subset, but the exact per-seed values
  differ from `main`. Affects every preset.
- **DR no longer consumes the global torch/numpy RNG stream.** Any *other* stochastic code sharing
  that stream (reset/observation/action noise, policy exploration) now sees a different sequence — a
  **run-wide** shift, not confined to DR values.
- **Per-env episode keying** re-keys reset/step-stage DR by each env's episode index (subset-stable);
  does not change *when* or *how often* any term fires.

### Latent (no shipped preset triggers these today)

- A DR run with **no seed now raises** (`TermSampler` requires one; `TrainingConfig.seed` defaults to
  42, so shipped presets never hit it).
- A `gaussian` spec is now a **truncated** normal on `[lo, hi]` (was an unbounded `randn·std+mean`);
  `log_uniform` bounds are validated (finite, strictly positive) at construction.
- Term-name collisions across DR term classes now **raise** instead of silently reusing an instance.

### Risk
Moderate. **Config-driven DR needs no API change** (the manager injects the sampler) and every
preset's ranges are preserved — but the PR is **not** result-preserving (see above). Library-level
break: custom `RandomizationTermBase` subclasses and direct DR-term calls now take a keyword-only
`sampler: TermSampler` (Migration Guide §1).

## Migration Guide

### 1 Custom DR terms / direct term calls gain a `sampler`
`setup`/`reset`/`step` and every term function now require a keyword-only `sampler: TermSampler`
(bind with `TermSampler.bind(seed, term_name, stage, episode_count)`). **Config-only users need no
change** — the manager injects it. Range params are typed `DistributionLike`: the same `[lo, hi]`
pair, or `{kind, low, high, mean, std}` for gaussian / log_uniform (bounds validated at construction).

### 2 Module rename
`simulator.mujoco.backends.warp_randomization` → `simulator.mujoco.backends.randomization`.

### 3 IsaacSim physics-DR writers take specs + `sampler`
The writers in `simulator/isaacsim/events.py` no longer route through IsaacLab's
`mdp.randomize_rigid_body_*`. `randomize_body_com` / `randomize_rigid_body_inertia` take a
`Sequence[DistributionSpec]`; `randomize_rigid_body_mass` / `randomize_rigid_body_material` take a
`DistributionLike` (or per-channel config); all take a keyword-only `sampler`. The old `distribution=`
/ `*_distribution_params` arguments are removed.

### 4 Re-baseline, don't reproduce
DR results change and no seed reproduces a pre-PR run, so any pre-PR checkpoint / reward curve /
regression fixture is not comparable value-for-value. `recompute_inertia=False` restores the old mass
behaviour; the CoM-inertia, restitution, and friction-quantization changes are intended fixes with no
opt-out — re-baseline against them.
