### PR TITLE
chore: bump SDK pins to stub-fixed releases (unitree 0.1.5, booster 0.1.1)

### DIFF
--- a/docker/thor/Dockerfile
+++ b/docker/thor/Dockerfile
@@ -125,7 +125,7 @@ FROM common-deps AS app-deps
 
 # far-unitree-sdk from PyPI. pip resolves the correct wheel for the
 # interpreter/platform. Bump UNITREE_SDK2_VERSION in one place on a new release.
-ARG UNITREE_SDK2_VERSION=0.1.4
+ARG UNITREE_SDK2_VERSION=0.1.5
 RUN uv pip install "far-unitree-sdk==${UNITREE_SDK2_VERSION}"
 
 # holosoma_inference source (editable install, --no-deps since common-deps
@@ -235,7 +235,7 @@ RUN uv pip install \
 # ─── Stage: app-deps-ros ──────────────────────────────────────────────────────
 FROM common-deps-ros AS app-deps-ros
 
-ARG UNITREE_SDK2_VERSION=0.1.4
+ARG UNITREE_SDK2_VERSION=0.1.5
 RUN uv pip install "far-unitree-sdk==${UNITREE_SDK2_VERSION}"
 
 COPY src/holosoma_inference /opt/holosoma-src/src/holosoma_inference

--- a/docker/thor/README.md
+++ b/docker/thor/README.md
@@ -134,7 +134,7 @@ installed on top of ROS's system packages to avoid ABI surprises.
 - **CUDA**: `nvcr.io/nvidia/cuda:13.0.2-devel-ubuntu24.04` (matches JetPack 7.1
   + CUDA 13 on Thor).
 - **ROS 2**: Jazzy (Noble native; compatible with common ROS nav stacks).
-- **`far-unitree-sdk`**: `0.1.4` (set via `--build-arg UNITREE_SDK2_VERSION=...`).
+- **`far-unitree-sdk`**: `0.1.5` (set via `--build-arg UNITREE_SDK2_VERSION=...`).
   Installed from PyPI; bump when a new release is published.
 - **Python deps**: unpinned by design — let `uv` resolve. Source of truth
   for the dep list is `src/holosoma_inference/setup.py`.

--- a/src/holosoma/setup.py
+++ b/src/holosoma/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 # Robot SDKs are published to PyPI (FAR forks). The import names are unchanged
 # (`unitree_interface`, `booster_robotics_sdk`) — only the distribution names
 # differ from the historical GitHub-release wheels.
-UNITREE_VERSION = "0.1.4"
-BOOSTER_VERSION = "0.1.0"
+UNITREE_VERSION = "0.1.5"
+BOOSTER_VERSION = "0.1.1"
 
 setup(
     extras_require={

--- a/src/holosoma_inference/docker/service/Dockerfile.x86
+++ b/src/holosoma_inference/docker/service/Dockerfile.x86
@@ -113,7 +113,7 @@ FROM common-deps AS app-deps
 
 # far-unitree-sdk from PyPI. pip resolves the correct wheel for the
 # interpreter/platform. Bump UNITREE_SDK2_VERSION in one place on a new release.
-ARG UNITREE_SDK2_VERSION=0.1.4
+ARG UNITREE_SDK2_VERSION=0.1.5
 RUN uv pip install "far-unitree-sdk==${UNITREE_SDK2_VERSION}"
 
 # holosoma_inference source (editable install, --no-deps since common-deps
@@ -202,7 +202,7 @@ RUN uv pip install \
 # ─── Stage: app-deps-ros ──────────────────────────────────────────────────────
 FROM common-deps-ros AS app-deps-ros
 
-ARG UNITREE_SDK2_VERSION=0.1.4
+ARG UNITREE_SDK2_VERSION=0.1.5
 RUN uv pip install "far-unitree-sdk==${UNITREE_SDK2_VERSION}"
 
 COPY src/holosoma_inference /opt/holosoma-src/src/holosoma_inference

--- a/src/holosoma_inference/setup.py
+++ b/src/holosoma_inference/setup.py
@@ -4,8 +4,8 @@ from setuptools import find_packages, setup
 # (`unitree_interface`, `booster_robotics_sdk`) — only the distribution names
 # differ from the historical GitHub-release wheels. pip resolves the correct
 # wheel for the running interpreter/platform from the PyPI index.
-UNITREE_VERSION = "0.1.4"
-BOOSTER_VERSION = "0.1.0"
+UNITREE_VERSION = "0.1.5"
+BOOSTER_VERSION = "0.1.1"
 
 unitree_extras = [f"far-unitree-sdk=={UNITREE_VERSION}"]
 booster_extras = [f"far-booster-sdk=={BOOSTER_VERSION}"]


### PR DESCRIPTION
## What

Bump the pinned FAR SDK versions to the newly published, **stub-fixed** releases:

| SDK | old | new |
|-----|-----|-----|
| `far-unitree-sdk` | 0.1.4 | **0.1.5** |
| `far-booster-sdk` | 0.1.0 | **0.1.1** |

## Why

The 0.1.4 / 0.1.0 wheels shipped a `py.typed` marker **without** a `.pyi` stub (the pybind11-stubgen step was best-effort/silently-non-fatal while `py.typed` was written unconditionally). mypy therefore treated the compiled extensions as *typed-but-empty* modules and reported 13 `attr-defined` errors on the `unitree_interface` / `booster_robotics_sdk` imports in the bridge code — breaking the **Static Checks** CI job (e.g. PR #145).

The SDK repos now ship a real `.pyi` deterministically and hard-guard against ever shipping `py.typed` without a stub again:
- `far-unitree-sdk 0.1.5` — ships `unitree_interface.pyi` + `py.typed`
- `far-booster-sdk 0.1.1` — ships `booster_robotics_sdk_python.pyi` + `py.typed` (also now on **real PyPI**, not TestPyPI)

Both publish workflows are green and both wheels are verified live on PyPI with the stubs. Bumping the pins here pulls the fix into the holosoma images so mypy resolves the real symbols.

## Changes

- `docker/thor/Dockerfile` — `ARG UNITREE_SDK2_VERSION` 0.1.4 → 0.1.5 (both stages)
- `src/holosoma_inference/docker/service/Dockerfile.x86` — same (both stages)
- `docker/thor/README.md` — doc reference 0.1.4 → 0.1.5
- `src/holosoma/setup.py` — `UNITREE_VERSION`/`BOOSTER_VERSION` extras (base image installs `holosoma[unitree,booster]`, so this is the pin the sim/static-check images actually resolve)
- `src/holosoma_inference/setup.py` — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)