### PR TITLE
Cross-backend object physics domain randomization

### DIFF
--- a/src/holosoma/holosoma/config_types/randomization.py
+++ b/src/holosoma/holosoma/config_types/randomization.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import field
-from typing import Any
+from typing import Any, Literal
 
 from pydantic.dataclasses import dataclass
 
@@ -12,6 +12,79 @@ from pydantic.dataclasses import dataclass
 # names the same range type the sampler parses via DistributionSpec.parse. DistributionSpec is
 # imported so pydantic can resolve the forward reference inside the DistributionLike union.
 from holosoma.config_types.distribution import DistributionLike, DistributionSpec  # noqa: F401
+
+
+@dataclass(frozen=True)
+class IsaacGymMaterialDR:
+    """Material-DR ranges IsaacGym honors (per-shape ``RigidShapeProperties``).
+
+    IsaacGym friction is a SINGLE sliding coefficient (no static/dynamic split), and restitution is
+    native per-shape. A field left ``None`` is not randomized. Mirrors
+    :class:`~holosoma.config_types.scene.IsaacGymPhysicsConfig`'s channel set.
+    """
+
+    friction: DistributionLike | None = None
+    """Sliding-friction range. ``None`` keeps the spawned friction."""
+
+    restitution: DistributionLike | None = None
+    """Restitution range. ``None`` keeps the spawned restitution."""
+
+
+@dataclass(frozen=True)
+class IsaacSimMaterialDR:
+    """Material-DR ranges IsaacSim honors (per-shape PhysX material, via a bucket table).
+
+    IsaacSim splits friction into static/dynamic and has native restitution. Mirrors
+    :class:`~holosoma.config_types.scene.IsaacSimPhysicsConfig`'s channel set.
+    """
+
+    static_friction: DistributionLike | None = None
+    """Static-friction range. ``None`` keeps the spawned value."""
+
+    dynamic_friction: DistributionLike | None = None
+    """Dynamic-friction range. ``None`` keeps the spawned value."""
+
+    restitution: DistributionLike | None = None
+    """Restitution range. ``None`` keeps the spawned value."""
+
+
+@dataclass(frozen=True)
+class MujocoMaterialDR:
+    """Material-DR ranges MuJoCo honors, on a geom's ``geom_friction`` / ``geom_solref`` / ``geom_solimp``.
+
+    MuJoCo has no ``[0,1]`` restitution coefficient — contact bounce/stiffness live in the solver
+    reference (``solref = [timeconst, dampratio]``) and impedance (``solimp = [dmin, dmax, width,
+    midpoint, power]``). So instead of a faked restitution channel, MuJoCo exposes its real solver
+    vectors. Mirrors the randomizable subset of :class:`~holosoma.config_types.scene.MujocoPhysicsConfig`.
+
+    ``solref``/``solimp`` are VECTOR fields, so each is a dict mapping a 0-based component index to its
+    range value (e.g. ``{0: [0.01, 0.03]}`` randomizes only ``solref[0]`` = the contact time constant);
+    unlisted components keep their spawned value.
+    """
+
+    sliding_friction: DistributionLike | None = None
+    """Sliding (tangential) friction range. ``None`` keeps the spawned value."""
+
+    solref: dict[Literal[0, 1], DistributionLike] | None = None
+    """Per-component ranges for ``geom_solref`` (index 0=timeconst, 1=dampratio). ``None`` -> unchanged."""
+
+    solimp: dict[Literal[0, 1, 2, 3, 4], DistributionLike] | None = None
+    """Per-component ranges for ``geom_solimp`` (indices 0..4). ``None`` -> unchanged."""
+
+
+@dataclass(frozen=True)
+class MaterialRandomizationConfig:
+    """Per-backend material-DR ranges, mirroring scene.py's ``PhysicsConfig`` backend split.
+
+    Each backend sub-block names ONLY the channels that backend's API honors, so a channel can never
+    be silently dropped: if a backend can't do restitution, its block simply has no restitution
+    field. A backend whose sub-block is ``None`` randomizes nothing. Each channel range is a
+    ``[lo, hi]`` pair (uniform) or a spec dict for a non-uniform distribution.
+    """
+
+    isaacgym: IsaacGymMaterialDR | None = None
+    isaacsim: IsaacSimMaterialDR | None = None
+    mujoco: MujocoMaterialDR | None = None
 
 
 @dataclass(frozen=True)
@@ -25,6 +98,25 @@ class BaseComRange:
     x: DistributionLike = (0.0, 0.0)
     y: DistributionLike = (0.0, 0.0)
     z: DistributionLike = (0.0, 0.0)
+
+
+@dataclass(frozen=True)
+class InertiaScale:
+    """Per-component inertia-tensor SCALE ranges for ``randomize_object_rigid_body_inertia_startup``.
+
+    Each component is a ``[lo, hi]`` pair (uniform), spec dict, or :class:`DistributionSpec` that
+    MULTIPLIES the spawned moment; the default ``(1.0, 1.0)`` leaves a component unchanged, so name
+    only what you randomize, e.g. ``InertiaScale(Ixx=[0.5, 1.5])``. MuJoCo stores inertia as the three
+    diagonal principal moments and scales only Ixx/Iyy/Izz (the off-diagonals stay at their identity
+    default there); IsaacSim/IsaacGym scale all six.
+    """
+
+    Ixx: DistributionLike = (1.0, 1.0)
+    Iyy: DistributionLike = (1.0, 1.0)
+    Izz: DistributionLike = (1.0, 1.0)
+    Ixy: DistributionLike = (1.0, 1.0)
+    Iyz: DistributionLike = (1.0, 1.0)
+    Ixz: DistributionLike = (1.0, 1.0)
 
 
 @dataclass(frozen=True)

--- a/src/holosoma/holosoma/config_values/wbt/g1/randomization.py
+++ b/src/holosoma/holosoma/config_values/wbt/g1/randomization.py
@@ -2,6 +2,11 @@
 
 from holosoma.config_types.randomization import (
     BaseComRange,
+    InertiaScale,
+    IsaacGymMaterialDR,
+    IsaacSimMaterialDR,
+    MaterialRandomizationConfig,
+    MujocoMaterialDR,
     RandomizationManagerCfg,
     RandomizationTermCfg,
 )
@@ -27,6 +32,37 @@ robot_state_dr_at_setup = {
         params={
             "dof_pos_bias_range": [-0.01, 0.01],
             "enabled": True,
+        },
+    ),
+}
+
+object_state_dr_at_setup = {
+    "randomize_object_rigid_body_material_startup": RandomizationTermCfg(
+        func="holosoma.managers.randomization.terms.objects:randomize_object_rigid_body_material_startup",
+        params={
+            # Per-backend channels via the typed config — each backend names ONLY what it honors
+            # (no silent cross-backend drop). MuJoCo has no restitution channel (it's solref).
+            "material": MaterialRandomizationConfig(
+                isaacgym=IsaacGymMaterialDR(friction=[0.1, 0.6], restitution=[0.0, 1.0]),
+                isaacsim=IsaacSimMaterialDR(
+                    static_friction=[0.1, 0.6], dynamic_friction=[0.1, 0.6], restitution=[0.0, 1.0]
+                ),
+                mujoco=MujocoMaterialDR(sliding_friction=[0.1, 0.6]),
+            ),
+        },
+    ),
+    "randomize_object_rigid_body_mass_startup": RandomizationTermCfg(
+        func="holosoma.managers.randomization.terms.objects:randomize_object_rigid_body_mass_startup",
+        params={
+            "mass_distribution_params": [1.0, 4.0],
+        },
+    ),
+    "randomize_object_rigid_body_inertia_startup": RandomizationTermCfg(
+        func="holosoma.managers.randomization.terms.objects:randomize_object_rigid_body_inertia_startup",
+        params={
+            # Only Ixx is randomized, reproducing beyondmimic. Unnamed components default to
+            # identity [1.0, 1.0]; name more to randomize them.
+            "inertia_distribution_params_dict": InertiaScale(Ixx=[0.5, 1.5]),
         },
     ),
 }
@@ -99,11 +135,10 @@ g1_29dof_wbt_randomization = RandomizationManagerCfg(
     step_terms={**base_step_terms},
 )
 
-# Same as the base preset on this branch — the object-DR follow-up branch adds the
-# object_state_dr_at_setup terms (material/mass/inertia) into this preset's setup_terms.
 g1_29dof_wbt_randomization_w_object = RandomizationManagerCfg(
     setup_terms={
         **base_setup_terms,
+        **object_state_dr_at_setup,
     },
     reset_terms={
         **base_reset_terms,

--- a/src/holosoma/holosoma/examples/object_managers_demo.py
+++ b/src/holosoma/holosoma/examples/object_managers_demo.py
@@ -1,0 +1,380 @@
+"""End-to-end example: the object-aware managers on a scene of free + static + scene-file bodies.
+
+This is a runnable, self-documenting tour of the scene-asset + object-manager features. It
+builds a REAL, fully-managed locomotion environment (the same production path training uses —
+``training_context`` + ``get_class(env_class)(...)``, NO shims) on a scene that mixes every
+asset kind, then drives each manager-layer feature in turn and narrates what happened. Reading
+the printed output (or this source) shows how the pieces compose in a real setup. It is
+backend-switchable: sections 1-4 are identical code on all four backends (only ``--backend``
+changes); section 5 (physics DR) dispatches per backend and reads the result back on MuJoCo.
+
+What it demonstrates, in order:
+
+  1. SCENE SPAWN — a declarative ``SceneConfig`` (sibling of robot/terrain) spawns standalone
+     rigid bodies (a free box, a free box with a configured initial velocity, a static pillar)
+     AND a 1->N scene FILE that expands into a free + a static body. Every body is addressed by
+     its ObjectRegistry name through the unified actor API ``get_actor_states(names, env_ids)``.
+
+  2. OBJECT OBSERVATIONS — the task-independent base-frame observation terms
+     (``object_pos_b`` / ``object_quat_b`` / ``object_lin_vel_b`` / ``object_ang_vel_b``) are
+     wired into the env's REAL ``ObservationManager`` as an ``object_obs`` group and computed via
+     ``env.observation_manager.compute()``. The group's dimension (k * N for N free bodies) is
+     MEASURED by the manager, not declared — so the same term config works for any object count.
+
+  3. EPISODE RESET — ``env.reset_envs_idx(env_ids)`` runs the real per-env reset chain;
+     ``BaseTask._reset_objects_callback`` restores every free body to its configured initial pose
+     AND initial velocity (so a body set to start moving re-starts moving). Static bodies untouched.
+
+  4. POSE JITTER ON RESET — ``jitter_object_pose_on_reset`` is wired into the env's REAL
+     ``RandomizationManager`` as a *reset* term, so step 3's reset already ran it: each free body's
+     XY/yaw is perturbed per env (around the baseline reset pose) while its velocity is preserved.
+     Omitting the term gives a clean deterministic reset; eval disables the manager, so eval is clean.
+
+  5. PHYSICS DR — the object mass / material(friction) / inertia randomizers are wired as the
+     RandomizationManager's *setup* terms, so the manager APPLIES them once at env build (the demo
+     never calls a term directly — it sets config and reads the result back). Each term dispatches
+     per backend: on MuJoCo (Warp GPU + Classic CPU) every property routes through the shared
+     ``randomize_field`` chokepoint, while IsaacGym uses native ``gym.set_actor_rigid_*_properties``
+     and IsaacSim uses isaaclab event helpers. Mass, friction, and inertia are ALL cross-backend.
+     The demo reads mass + friction back from the live model on MuJoCo (verifying they landed in
+     the configured bands); on IsaacGym/IsaacSim it reports which setup terms the manager ran (the
+     per-backend physics effect is asserted in the dedicated DR tests).
+
+Run it (MuJoCo CPU needs no GPU; the others need their SDK + a CUDA device):
+
+    # MuJoCo, single env, CPU classic backend:
+    python -m holosoma.examples.object_managers_demo --backend mujoco
+
+    # MuJoCo Warp, 4 envs, GPU (per-env randomization is visible with >1 env):
+    python -m holosoma.examples.object_managers_demo --backend mjwarp --num-envs 4
+
+    # Isaac backends (need the respective SDK):
+    python -m holosoma.examples.object_managers_demo --backend isaacgym --num-envs 4
+    python -m holosoma.examples.object_managers_demo --backend isaacsim
+
+The scene is the ``object-managers-demo`` preset (``config_values/scene.py``); it is also
+selectable from the normal CLI, e.g. ``run_sim.py simulator:mujoco scene:object-managers-demo``.
+
+Exits 0 on success, non-zero on failure, so it doubles as a smoke test (see
+``tests/simulators/mujoco/test_object_managers_demo.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+
+# name -> config_values.simulator preset attribute. MuJoCo classic is CPU + single-env only;
+# mjwarp/isaacgym/isaacsim are GPU and support multiple envs.
+_BACKENDS = {
+    "mujoco": ("mujoco", "cpu"),
+    "mjwarp": ("mjwarp", "cuda:0"),
+    "isaacgym": ("isaacgym", "cuda:0"),
+    "isaacsim": ("isaacsim", "cuda:0"),
+}
+
+# The four base-frame object observation terms, as a reusable group config. Each defaults to
+# "all registered free bodies", so the group is object-count- and scene-agnostic; the manager
+# measures the resulting k*N dimension at init.
+_OBJ_OBS_TERMS = "holosoma.managers.observation.terms.objects"
+# The pose-jitter randomization reset term.
+_OBJ_RAND = "holosoma.managers.randomization.terms.objects"
+
+
+def _experiment_config(backend: str, num_envs: int, headless: bool):
+    """Build the ExperimentConfig for the demo: the g1_29dof locomotion preset, retargeted to the
+    chosen backend + the object-managers demo scene, with the object managers wired in PURELY via
+    config — the env then runs them through its real manager stack, exactly as training does:
+
+    - object observation terms -> a new ``object_obs`` group on the ObservationManager (its OWN
+      group, not actor/critic, so it doesn't perturb the policy's fixed obs dimension);
+    - object physics-DR terms (mass / material / inertia) -> the RandomizationManager's
+      ``setup_terms`` (the manager applies them once at env build, like any startup randomizer);
+    - the pose-jitter term -> the RandomizationManager's ``reset_terms`` (runs on every reset).
+
+    The demo never calls a randomization term directly — it sets config knobs and lets the
+    managers drive, then reads the results back.
+    """
+    from holosoma.config_types.observation import ObsGroupCfg, ObsTermCfg
+    from holosoma.config_types.randomization import RandomizationTermCfg
+    from holosoma.config_values import experiment as experiment_values
+    from holosoma.config_values import scene as scene_values
+    from holosoma.config_values import simulator as simulator_values
+
+    base = experiment_values.g1_29dof
+    sim_cfg = getattr(simulator_values, _BACKENDS[backend][0])
+    assert base.observation is not None, "g1_29dof preset must define an ObservationManager"
+    assert base.randomization is not None, "g1_29dof preset must define a RandomizationManager"
+
+    # Add an object_obs group alongside the preset's existing actor/critic groups.
+    obs_groups = dict(base.observation.groups)
+    obs_groups["object_obs"] = ObsGroupCfg(
+        concatenate=True,
+        enable_noise=False,
+        history_length=1,
+        terms={
+            "object_pos_b": ObsTermCfg(func=f"{_OBJ_OBS_TERMS}:object_pos_b"),
+            "object_quat_b": ObsTermCfg(func=f"{_OBJ_OBS_TERMS}:object_quat_b"),
+            "object_lin_vel_b": ObsTermCfg(func=f"{_OBJ_OBS_TERMS}:object_lin_vel_b"),
+            "object_ang_vel_b": ObsTermCfg(func=f"{_OBJ_OBS_TERMS}:object_ang_vel_b"),
+        },
+    )
+    observation = dataclasses.replace(base.observation, groups=obs_groups)
+
+    # Object physics DR as startup randomizers: the RandomizationManager applies these once at
+    # env build (after expanding the required model fields). Exaggerated, far-from-default bands
+    # so the effect is unambiguous when we read it back (default box mass is 0.1 kg << [5,6]).
+    setup_terms = dict(base.randomization.setup_terms)
+    setup_terms["randomize_object_mass"] = RandomizationTermCfg(
+        func=f"{_OBJ_RAND}:randomize_object_rigid_body_mass_startup",
+        params={"mass_distribution_params": [5.0, 6.0]},
+    )
+    setup_terms["randomize_object_material"] = RandomizationTermCfg(
+        func=f"{_OBJ_RAND}:randomize_object_rigid_body_material_startup",
+        params={
+            "material": {
+                "isaacgym": {"friction": [0.2, 0.3], "restitution": [0.0, 0.0]},
+                "isaacsim": {
+                    "static_friction": [0.2, 0.3],
+                    "dynamic_friction": [0.2, 0.3],
+                    "restitution": [0.0, 0.0],
+                },
+                "mujoco": {"sliding_friction": [0.2, 0.3]},
+            }
+        },
+    )
+    setup_terms["randomize_object_inertia"] = RandomizationTermCfg(
+        func=f"{_OBJ_RAND}:randomize_object_rigid_body_inertia_startup",
+        params={
+            "inertia_distribution_params_dict": {
+                "Ixx": [2.0, 3.0],
+                "Iyy": [1.0, 1.0],
+                "Izz": [1.0, 1.0],
+                "Ixy": [1.0, 1.0],
+                "Iyz": [1.0, 1.0],
+                "Ixz": [1.0, 1.0],
+            }
+        },
+    )
+
+    # Pose-jitter as a reset randomizer (runs on every reset).
+    reset_terms = dict(base.randomization.reset_terms)
+    reset_terms["jitter_object_pose"] = RandomizationTermCfg(
+        func=f"{_OBJ_RAND}:jitter_object_pose_on_reset",
+        params={"xy_range": 0.1, "yaw_range": 0.3, "enabled": True},
+    )
+    # ignore_unsupported=True: a backend that can't do a given randomizer is skipped (and listed
+    # in the manager's _failed_randomizers) rather than crashing the build. The object DR terms
+    # are cross-backend, so nothing is skipped here today — this just keeps the demo robust.
+    randomization = dataclasses.replace(
+        base.randomization, setup_terms=setup_terms, reset_terms=reset_terms, ignore_unsupported=True
+    )
+
+    return dataclasses.replace(
+        base,
+        simulator=sim_cfg,
+        scene=scene_values.object_managers_demo,
+        observation=observation,
+        randomization=randomization,
+        training=dataclasses.replace(
+            base.training, num_envs=num_envs, headless=headless, seed=0, torch_deterministic=False
+        ),
+    )
+
+
+def _section(title: str) -> None:
+    # flush=True so output survives even if a backend hard-terminates the process at teardown
+    # (IsaacSim's app close can kill the interpreter before block-buffered stdout is written).
+    print(f"\n{'=' * 78}\n{title}\n{'=' * 78}", flush=True)
+
+
+def run_demo(backend: str, num_envs: int, headless: bool = True) -> int:
+    """Run the full object-managers tour on ``backend`` via a real env. Returns an exit code.
+
+    Builds the env inside ``training_context`` (which owns the IsaacSim app lifecycle — closing it
+    only at block exit), so the whole demo runs while the simulator is alive.
+    """
+    # Imported lazily so the per-backend launcher (isaacgym/isaacsim) initializes before torch.
+    from holosoma.config_types.env import get_tyro_env_config
+    from holosoma.simulator.shared.object_registry import ObjectType
+    from holosoma.train_agent import training_context
+    from holosoma.utils.common import seeding
+    from holosoma.utils.helpers import get_class
+    from holosoma.utils.safe_torch_import import torch
+    from holosoma.utils.simulator_config import SimulatorType
+
+    device = _BACKENDS[backend][1]
+    _section(f"BUILD — backend={backend}  num_envs={num_envs}  device={device}")
+    cfg = _experiment_config(backend, num_envs, headless)
+    seeding(cfg.training.seed)
+
+    with training_context(cfg):
+        env = get_class(cfg.env_class)(get_tyro_env_config(cfg), device=device)
+        sim = env.simulator
+        env_ids = torch.arange(env.num_envs, device=env.device)
+
+        # ---- 1. SCENE SPAWN --------------------------------------------------------------
+        _section("1. SCENE SPAWN — free + static standalone bodies AND a 1->N scene file")
+        free_names = sim.object_registry.get_names_by_type(ObjectType.INDIVIDUAL)
+        static_names = sim.object_registry.get_names_by_type(ObjectType.SCENE)
+        print(f"free  (INDIVIDUAL) bodies: {free_names}")
+        print(f"static (SCENE)     bodies: {static_names}")
+        if not free_names or not static_names:
+            print("FAIL: expected both free and static bodies registered")
+            return 1
+        for nm in free_names + static_names:
+            st = sim.get_actor_states([nm], env_ids)  # [num_envs, 13] = [pos3, quat_xyzw4, linvel3, angvel3]
+            print(f"  {nm:18s} env0 pos={_fmt(st[0, :3])} quat={_fmt(st[0, 3:7])}")
+            if st.shape != (env.num_envs, 13):
+                print(f"FAIL: {nm} state shape {tuple(st.shape)} != ({env.num_envs}, 13)")
+                return 1
+
+        # ---- 2. OBJECT OBSERVATIONS ------------------------------------------------------
+        _section("2. OBJECT OBSERVATIONS — base-frame state via the env's real ObservationManager")
+        n_free = len(free_names)
+        dims = env.observation_manager.get_obs_dims()  # measured by calling each term once
+        print(f"observation groups: {sorted(dims)}")
+        print(f"measured 'object_obs' dim for {n_free} free bodies: {dims['object_obs']}")
+        print(f"  expected k*N = (3 pos + 4 quat + 3 linvel + 3 angvel) * {n_free} = {13 * n_free}")
+        if dims["object_obs"] != 13 * n_free:
+            print(f"FAIL: object obs dim {dims['object_obs']} != {13 * n_free}")
+            return 1
+        obs = env.observation_manager.compute()["object_obs"]
+        print(f"  computed 'object_obs' tensor shape: {tuple(obs.shape)}  (finite={bool(torch.isfinite(obs).all())})")
+        if obs.shape != (env.num_envs, 13 * n_free) or not torch.isfinite(obs).all():
+            print("FAIL: object observation tensor malformed")
+            return 1
+
+        # ---- 3. EPISODE RESET (pose + velocity restore) + 4. POSE JITTER -----------------
+        # reset_envs_idx runs the real per-env reset chain: baseline _reset_objects_callback
+        # (restore pose + configured velocity) THEN the randomization manager's reset terms
+        # (our jitter term perturbs the pose). We snapshot before/after one reset and check both.
+        _section("3. EPISODE RESET — reset_envs_idx restores pose + configured velocity (real chain)")
+        moving = "moving_box"
+        want_vel = sim.get_actor_initial_velocities([moving], env_ids)[0]  # [6], configured
+        before_reset = {nm: sim.get_actor_states([nm], env_ids).clone() for nm in free_names}
+        static_before = sim.get_actor_states([static_names[0]], env_ids)[:, :2].clone()
+
+        env.reset_envs_idx(env_ids)
+
+        after = sim.get_actor_states([moving], env_ids)[0]
+        print(f"'{moving}' env0 after reset: pos={_fmt(after[:3])} vel={_fmt(after[7:10])}/{_fmt(after[10:13])}")
+        print(f"  configured initial velocity (restored, not zeroed): {_fmt(want_vel[:3])} / {_fmt(want_vel[3:6])}")
+        if not torch.allclose(after[7:13], want_vel, atol=1e-2):
+            print("FAIL: reset did not restore the configured initial velocity")
+            return 1
+
+        _section("4. POSE JITTER ON RESET — jitter term (a real reset randomizer) perturbed XY/yaw")
+        max_dxy = 0.0
+        for nm in free_names:
+            st = sim.get_actor_states([nm], env_ids)
+            dxy = (st[:, :2] - before_reset[nm][:, :2]).abs().max().item()
+            max_dxy = max(max_dxy, dxy)
+            # The jitter is around the BASELINE reset pose, so dxy is bounded by xy_range (0.1),
+            # not by the drift before the reset. A nonzero dxy proves the reset-time jitter ran.
+            z_kept = _close(st[:, 2], before_reset[nm][:, 2])
+            print(f"  {nm:18s} XY moved {dxy:.4f} m by the reset+jitter (z kept={z_kept})")
+        if max_dxy <= 1e-6:
+            print("FAIL: reset-time pose jitter moved no free body (jitter term inert)")
+            return 1
+        if not _close(sim.get_actor_states([static_names[0]], env_ids)[:, :2], static_before):
+            print(f"FAIL: static body '{static_names[0]}' was moved on reset")
+            return 1
+        print(f"  static '{static_names[0]}' untouched on reset: OK")
+
+        # ---- 5. PHYSICS DR ---------------------------------------------------------------
+        # The object mass/material/inertia randomizers are SETUP terms on the env's
+        # RandomizationManager (see _experiment_config), so the manager ALREADY applied them at
+        # build via randomization_manager.setup() — we don't call any term here, we read the
+        # result the manager produced. Default box mass is 0.1 kg, so a per-body mass in the
+        # configured [5,6] band is unambiguous proof the manager's startup DR ran.
+        _section("5. PHYSICS DR — object mass/material/inertia applied by the RandomizationManager at build")
+        rm = env.randomization_manager
+        ran = [n for n in rm._setup_names if n not in rm._failed_randomizers and n.startswith("randomize_object_")]
+        skipped = [n for n in rm._failed_randomizers if n.startswith("randomize_object_")]
+        print(f"manager setup DR terms applied: {ran}")
+        if skipped:
+            print(f"  (skipped as unsupported on this backend: {skipped})")
+        if not _report_object_dr(env, free_names, is_mujoco=sim.get_simulator_type() == SimulatorType.MUJOCO):
+            return 1
+
+        _section("DEMO COMPLETE — all object-manager features ran successfully")
+        return 0
+
+
+def _report_object_dr(env, free_names, *, is_mujoco: bool) -> bool:
+    """Read back the physics state the RandomizationManager's startup DR already produced.
+
+    Reads (does NOT apply) each free body's mass + sliding friction. On MuJoCo, reads from the
+    live model (per-world GPU bridge on WarpBackend, else the CPU model) and verifies the values
+    landed in the configured bands (default 0.1 kg mass << [5,6] proves the manager ran the DR).
+    On IsaacGym/IsaacSim the model fields aren't introspected here — the per-backend physics
+    effect is asserted in the dedicated DR tests — so just confirm the bodies are addressable.
+    """
+    sim = env.simulator
+
+    if not is_mujoco:
+        print(f"  startup DR applied on {sim.get_simulator_type()} for {free_names}")
+        print("  (per-backend physics effect is asserted in the dedicated DR tests)")
+        return True
+
+    from holosoma.managers.randomization.terms.objects import _mujoco_object_bodies, _mujoco_object_geom_ids
+
+    is_warp = hasattr(sim.backend, "warp_model_bridge")
+
+    def _mass(name):
+        body_ids = [bid for bid, _ in _mujoco_object_bodies(sim, name)]
+        if is_warp:
+            bm = sim.backend.warp_model_bridge.body_mass  # [num_envs, nbody]
+            return float(sum(bm[0, bid] for bid in body_ids))
+        return float(sum(sim.backend.model.body_mass[bid] for bid in body_ids))
+
+    def _friction0(name):
+        geoms = _mujoco_object_geom_ids(sim, name)
+        if not geoms:
+            return None
+        if is_warp:
+            return float(sim.backend.warp_model_bridge.geom_friction[0, geoms[0], 0])
+        return float(sim.backend.model.geom_friction[geoms[0], 0])
+
+    for nm in free_names:
+        m = _mass(nm)
+        print(f"  mass '{nm:16s}' = {m:.3f} kg  (default 0.1; configured startup-DR band [5,6]/body)")
+        if m < 5.0 - 1e-3:  # at least the per-body additive floor over the 0.1 default
+            print(f"FAIL: object '{nm}' mass {m:.3f} below configured band — startup DR did not apply")
+            return False
+    for nm in free_names:
+        fr = _friction0(nm)
+        if fr is not None:
+            print(f"  friction '{nm:16s}' geom[0] sliding = {fr:.3f}  (configured band [0.2,0.3])")
+            if not (0.2 - 1e-3 <= fr <= 0.3 + 1e-3):
+                print(f"FAIL: object '{nm}' friction {fr:.3f} outside configured band [0.2,0.3]")
+                return False
+    return True
+
+
+def _fmt(t):
+    return "[" + ", ".join(f"{float(v):+.3f}" for v in t) + "]"
+
+
+def _close(a, b, atol=1e-4):
+    from holosoma.utils.safe_torch_import import torch
+
+    return bool(torch.allclose(a, b, atol=atol))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--backend", choices=list(_BACKENDS), default="mujoco", help="Simulator backend.")
+    parser.add_argument("--num-envs", type=int, default=1, help="Parallel envs (>1 needs mjwarp/isaacgym/isaacsim).")
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    args = parser.parse_args()
+
+    if args.backend == "mujoco" and args.num_envs > 1:
+        parser.error("the MuJoCo classic (CPU) backend is single-env; use --backend mjwarp for --num-envs > 1.")
+
+    return run_demo(args.backend, args.num_envs, headless=args.headless == "true")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/holosoma/holosoma/managers/randomization/terms/locomotion.py
+++ b/src/holosoma/holosoma/managers/randomization/terms/locomotion.py
@@ -909,8 +909,11 @@ def randomize_friction_startup(
     ``None`` for a continuous marginal where the material count is safely under the cap. ``uniform`` is
     exact when continuous; ``gaussian``/``log_uniform`` match up to the bucket quantization.
 
-    GRANULARITY still differs per backend here (IsaacGym one value per env, IsaacSim per shape, MuJoCo
-    per geom); ``num_buckets`` unifies the value set, not the granularity.
+    GRANULARITY is unified too: this term draws ONE friction per env (per robot) on every backend —
+    IsaacGym sets it on each shape, IsaacSim via the material writer's ``per_env=True``, MuJoCo via
+    ``randomize_field``'s ``shared_across_entities=True``. So a single robot contacting the floor has a
+    single contact-friction coefficient (the legged_gym / IsaacGym convention), not a different value
+    per link/geom.
     """
     env._randomize_friction = bool(enabled)
     env._friction_range = friction_range
@@ -961,13 +964,14 @@ def randomize_friction_startup(
             restitution=None,  # leave restitution at each shape's spawned value (friction-only term);
             # matches the IsaacGym/MuJoCo branches, which never touch restitution here.
             num_buckets=num_buckets,  # same quantization policy as the IsaacGym branch
+            per_env=True,  # one friction per robot (all shapes share), matching IsaacGym/MuJoCo
             sampler=sampler,
         )
 
     elif simulator.get_simulator_type() == SimulatorType.MUJOCO:
-        # MuJoCo writes geom_friction directly (no material cap), so continuous per-geom is the true
-        # marginal (num_buckets=None). When num_buckets is set, quantize onto the same staircase the
-        # PhysX backends use so a bucketed friction config reads consistently across all three.
+        # MuJoCo writes geom_friction directly (no material cap). num_buckets matches the PhysX
+        # backends' quantization; shared_across_entities gives the whole robot ONE friction (per-env
+        # granularity) instead of an independent per-geom draw, matching IsaacGym/IsaacSim.
         from holosoma.simulator.mujoco.backends.randomization import randomize_field
 
         randomize_field(
@@ -978,6 +982,7 @@ def randomize_friction_startup(
             env_ids=idx,
             operation="abs",
             num_buckets=num_buckets,
+            shared_across_entities=True,  # one friction per robot (all geoms share), matching IsaacGym
         )
 
     else:  # pragma: no cover - defensive

--- a/src/holosoma/holosoma/managers/randomization/terms/objects.py
+++ b/src/holosoma/holosoma/managers/randomization/terms/objects.py
@@ -1,8 +1,14 @@
-"""Object reset-time randomization term (pose jitter).
+"""Randomization terms for scene objects (free bodies).
 
-The object physics-DR *startup* terms (mass / material / inertia / damping) live in this module
-on the full feature branch; the object-DR follow-up branch adds them. This scene-objects branch
-carries only the reset-time pose-jitter term, which resets alongside the object reset it perturbs.
+These act on registered free bodies (``ObjectType.INDIVIDUAL``) spawned by the scene-asset
+config. They default to "all registered free bodies", so a preset stays object-count-agnostic
+and no-ops cleanly on a robot-only scene.
+
+- ``randomize_object_rigid_body_mass_startup`` / ``..._material_startup`` /
+  ``..._inertia_startup`` — startup physics DR on free bodies, cross-backend (IsaacSim /
+  IsaacGym / MuJoCo), each branch addressing the object's own bodies/geoms (mirrors the robot
+  mass/friction DR in ``locomotion.py``).
+- ``jitter_object_pose_on_reset`` — opt-in reset-time pose jitter on free bodies.
 """
 
 from __future__ import annotations
@@ -12,10 +18,18 @@ from typing import Any, Sequence
 import torch
 from loguru import logger
 
-from holosoma.managers.randomization.terms._shared import _ensure_env_ids_tensor
+from holosoma.config_types.randomization import InertiaScale, MaterialRandomizationConfig
+from holosoma.managers.randomization.exceptions import RandomizerNotSupportedError
+from holosoma.managers.randomization.terms._shared import (
+    _MATERIAL_NUM_BUCKETS,
+    _ensure_env_ids_tensor,
+)
+from holosoma.simulator import mujoco_required_field
+from holosoma.simulator.shared.field_decorators import MUJOCO_FIELD_ATTR
 from holosoma.simulator.shared.object_registry import ObjectType
 from holosoma.utils.rotations import quat_from_angle_axis, quat_mul
-from holosoma.utils.sampler import DistributionLike, DistributionSpec, TermSampler
+from holosoma.utils.sampler import DistributionLike, DistributionSpec, TermSampler, quantiles
+from holosoma.utils.simulator_config import SimulatorType
 
 
 def _resolve_object_names(env: Any, object_names: Sequence[str] | None) -> list[str]:
@@ -75,6 +89,743 @@ def _mujoco_object_bodies(simulator: Any, name: str) -> list[tuple[int, str]]:
                 subtree.add(bid)
                 break
     return [(bid, mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, bid)) for bid in sorted(subtree)]
+
+
+def _mujoco_object_body_names(simulator: Any, name: str) -> list[str]:
+    """Prefixed compiled-model body names owned by object ``name``."""
+    return [bname for _bid, bname in _mujoco_object_bodies(simulator, name)]
+
+
+def _mujoco_object_body_ids(simulator: Any, name: str) -> list[int]:
+    """Body IDs owned by object ``name`` in the compiled CPU model.
+
+    URDF-imported descendant bodies are often unnamed (``mj_id2name`` returns ``None``), so the
+    mass/inertia randomizers resolve bodies by ID — mirroring ``_mujoco_object_geom_ids`` — and
+    pass them as pre-resolved ``entity_ids`` to ``randomize_field``, bypassing the by-name
+    ``resolve_entity_ids`` path that would choke on a ``None`` name.
+    """
+    return [bid for bid, _bname in _mujoco_object_bodies(simulator, name)]
+
+
+def _mujoco_object_geom_ids(simulator: Any, name: str) -> list[int]:
+    """Geom IDs owned by object ``name``'s bodies in the compiled CPU model.
+
+    URDF-imported geoms are usually unnamed, so resolve by body ownership (``geom_bodyid``)
+    rather than by name — the MuJoCo randomizer accepts pre-resolved geom IDs directly.
+    """
+    model = simulator.backend.model
+    body_ids = {bid for bid, _bname in _mujoco_object_bodies(simulator, name)}
+    return [g for g in range(model.ngeom) if int(model.geom_bodyid[g]) in body_ids]
+
+
+def _coerce_material_cfg(material: MaterialRandomizationConfig | dict) -> MaterialRandomizationConfig:
+    """Accept either a :class:`MaterialRandomizationConfig` or an equivalent nested dict.
+
+    Configs constructed in Python pass the dataclass; a config loaded from a plain dict (e.g. a
+    serialized preset) passes the nested-dict form. Both resolve to the typed config so the term
+    body only ever sees backend sub-blocks.
+    """
+    if isinstance(material, MaterialRandomizationConfig):
+        return material
+    return MaterialRandomizationConfig(**material)
+
+
+def _draw_material_channel(
+    sampler: TermSampler,
+    spec: DistributionLike,
+    env_ids: torch.Tensor,
+    obj_ids: torch.Tensor,
+    stream: int,
+    num_buckets: int | None,
+) -> torch.Tensor:
+    """Draw a per-(env, object) material value, continuous or quantized onto ``num_buckets``.
+
+    ``None``: one continuous keyed draw per (env, object) on stream ``stream`` -> [n_env, n_obj].
+    An int: fill ``num_buckets`` buckets with the spec's quantile values (keyed permute so the
+    staircase is reproducible-but-shuffled per seed), then pick a bucket per (env, object) via the
+    keyed selection — same quantization the IsaacSim material writer / robot friction term use, so a
+    bucketed object-material config reads consistently across backends.
+    """
+    if num_buckets is None:
+        return sampler.draw(spec, env_ids=env_ids, coords=(stream, obj_ids))
+    column = quantiles(DistributionSpec.parse(spec), num_buckets, "cpu")[sampler.permute(num_buckets, (stream,))]
+    bucket_ids = sampler.draw_int(0, num_buckets - 1, env_ids=env_ids, coords=(stream, obj_ids))
+    return column[bucket_ids]
+
+
+@mujoco_required_field("geom_friction")
+def randomize_object_rigid_body_material_startup(
+    env,
+    env_ids: Sequence[int] | torch.Tensor | None = None,
+    *,
+    sampler: TermSampler,
+    material: MaterialRandomizationConfig | dict,
+    object_names: Sequence[str] | None = None,
+    num_buckets: int | None = _MATERIAL_NUM_BUCKETS,
+    enabled: bool = True,
+    **_,
+) -> None:
+    """Randomize free-body rigid-body material properties, with PER-BACKEND channel configs.
+
+    ``material`` is a :class:`MaterialRandomizationConfig` (or an equivalent nested dict) whose
+    backend sub-blocks name ONLY the channels that backend honors — no silent cross-backend drop:
+    - **isaacgym** ``{friction, restitution}`` — single sliding friction + native restitution.
+    - **isaacsim** ``{static_friction, dynamic_friction, restitution}`` — via a quantile bucket table
+      (PhysX caps unique materials per scene).
+    - **mujoco**   ``{sliding_friction, solref, solimp}`` — ``geom_friction`` tangential coefficient
+      plus the per-component ``geom_solref``/``geom_solimp`` vectors through which MuJoCo expresses
+      contact stiffness/restitution (no scalar ``[0,1]`` restitution channel; ``solref``/``solimp``
+      are dicts of {component index -> range}).
+    A backend whose sub-block is absent randomizes nothing on it; an absent channel within a present
+    block is left at the spawned value. Each channel is a config range value — a ``[lo, hi]`` pair (uniform)
+    or a ``{kind, low, high, mean, std}`` spec dict. Targets every registered free body by default;
+    pass ``object_names`` to narrow it. No-ops on a robot-only scene.
+
+    ``num_buckets`` controls VALUE QUANTIZATION uniformly across backends (mirrors the robot friction
+    term). An int (default 64) quantizes every channel's draw onto that many stratified quantile
+    values — required on IsaacSim to respect PhysX's per-scene material cap, and applied identically on
+    IsaacGym/MuJoCo (which have no cap) so a bucketed config reads consistently everywhere. ``None``
+    draws continuously; use it when the per-object material count is safely under the cap. Granularity
+    is unchanged (per-object on IsaacGym, per-shape on IsaacSim, per-geom on MuJoCo) — objects keep
+    their within-env material variety.
+    """
+    if not enabled:
+        return
+    material = _coerce_material_cfg(material)
+
+    idx = _ensure_env_ids_tensor(env, env_ids)
+    if idx.numel() == 0:
+        return
+
+    names = _resolve_object_names(env, object_names)
+    if not names:  # robot-only scene -> nothing to randomize, not an error
+        return
+
+    simulator = env.simulator
+    sim_type = simulator.get_simulator_type()
+
+    if sim_type == SimulatorType.ISAACGYM:
+        ig_cfg = material.isaacgym
+        if ig_cfg is None:
+            return
+        gym = simulator.gym
+        idx_cpu = idx.to(device="cpu", dtype=torch.long)
+        # One keyed value per (env, object) per requested channel (distinct int stream coord),
+        # written to the object's shapes — per-object like the mass/inertia branches, so objects
+        # within one env get independent materials (matching MuJoCo/IsaacSim's within-env variety).
+        # A None channel is left at the spawned value. friction -> single sliding coeff (stream 0);
+        # restitution -> native per-shape restitution (stream 1). num_buckets quantizes each draw the
+        # same way as the IsaacSim writer. -> [E, n_names].
+        obj_ids = torch.arange(len(names))[None, :]
+        fric = (
+            _draw_material_channel(sampler, ig_cfg.friction, idx_cpu, obj_ids, 0, num_buckets)
+            if ig_cfg.friction is not None
+            else None
+        )
+        rest = (
+            _draw_material_channel(sampler, ig_cfg.restitution, idx_cpu, obj_ids, 1, num_buckets)
+            if ig_cfg.restitution is not None
+            else None
+        )
+        if fric is None and rest is None:
+            return
+        for offset, env_id in enumerate(idx_cpu.tolist()):
+            env_ptr = simulator.envs[env_id]
+            for name_off, name in enumerate(names):
+                actor = simulator.object_handles[name][env_id]
+                shape_props = gym.get_actor_rigid_shape_properties(env_ptr, actor)
+                for prop in shape_props:
+                    if fric is not None:
+                        prop.friction = float(fric[offset, name_off])
+                    if rest is not None:
+                        prop.restitution = float(rest[offset, name_off])
+                gym.set_actor_rigid_shape_properties(env_ptr, actor, shape_props)
+        return
+
+    if sim_type == SimulatorType.ISAACSIM:
+        isim_cfg = material.isaacsim
+        if isim_cfg is None:
+            return
+        try:
+            from isaaclab.managers import SceneEntityCfg
+        except ImportError as exc:  # pragma: no cover - defensive
+            raise RuntimeError("IsaacSim material randomization requires isaaclab.") from exc
+        from holosoma.simulator.isaacsim.events import randomize_rigid_body_material
+
+        env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
+        for name in names:
+            asset_cfg = SceneEntityCfg(name, body_names=".*")
+            asset_cfg.resolve(simulator.scene)
+            randomize_rigid_body_material(
+                simulator,
+                env_ids_cpu,
+                asset_cfg,
+                static_friction=isim_cfg.static_friction,
+                dynamic_friction=isim_cfg.dynamic_friction,
+                restitution=isim_cfg.restitution,
+                num_buckets=num_buckets,
+                sampler=sampler,
+            )
+        return
+
+    if sim_type == SimulatorType.MUJOCO:
+        mj_cfg = material.mujoco
+        if mj_cfg is None or (mj_cfg.sliding_friction is None and mj_cfg.solref is None and mj_cfg.solimp is None):
+            return
+        # No material cap here, but num_buckets still applies for cross-backend value consistency
+        # (None = continuous per-geom, the true marginal). Each present channel writes its own geom
+        # field; a distinct axis_base keeps the sampler streams independent.
+        from holosoma.simulator.mujoco.backends.randomization import randomize_field
+
+        # (geom field, ranges-by-axis, axis_base) for each requested channel. friction -> geom_friction
+        # axis 0 (sliding); solref/solimp -> their per-component dicts as given.
+        writes = []
+        if mj_cfg.sliding_friction is not None:
+            writes.append(("geom_friction", {0: mj_cfg.sliding_friction}, 0))
+        if mj_cfg.solref is not None:
+            # axis_base offset so streams don't collide
+            writes.append(("geom_solref", {int(k): v for k, v in mj_cfg.solref.items()}, 10))
+        if mj_cfg.solimp is not None:
+            writes.append(("geom_solimp", {int(k): v for k, v in mj_cfg.solimp.items()}, 20))
+        for name in names:
+            geom_ids = _mujoco_object_geom_ids(simulator, name)
+            if not geom_ids:
+                logger.warning(f"Object '{name}' has no geoms; material randomization skipped.")
+                continue
+            geom_ids_t = torch.tensor(geom_ids, device=simulator.sim_device, dtype=torch.long)
+            for field, ranges, axis_base in writes:
+                randomize_field(
+                    simulator,
+                    field=field,
+                    ranges=ranges,
+                    sampler=sampler,
+                    env_ids=idx,
+                    entity_ids=geom_ids_t,
+                    operation="abs",
+                    axis_base=axis_base,
+                    num_buckets=num_buckets,
+                )
+        return
+
+    raise RandomizerNotSupportedError(
+        f"randomize_object_rigid_body_material_startup does not support {type(simulator).__name__}."
+    )
+
+
+@mujoco_required_field("body_mass")
+def randomize_object_rigid_body_mass_startup(
+    env,
+    env_ids: Sequence[int] | torch.Tensor | None = None,
+    *,
+    sampler: TermSampler,
+    mass_distribution_params: DistributionLike,
+    object_names: Sequence[str] | None = None,
+    enabled: bool = True,
+    recompute_inertia: bool = True,
+    **_,
+) -> None:
+    """Randomize free-body rigid-body mass (additive offset), one offset per object.
+
+    Cross-backend (IsaacSim / IsaacGym / MuJoCo Warp GPU + Classic CPU); the offset is sampled
+    from ``mass_distribution_params`` and ADDED, identically on every backend. Scene objects are
+    single rigid bodies (no articulated-object support), so "per (env, object)" and "per body" are
+    the same draw. Targets every registered free body by default; pass ``object_names`` to narrow
+    it. No-ops on a robot-only scene. MuJoCo Classic CPU is single-env.
+
+    ``recompute_inertia`` (default True): when True, each body's inertia is rescaled by the SAME
+    factor its mass changed by (``m_after / m_before``), identically on all backends (explicit
+    multiplicative ratio — NOT a from-geometry recompute — so it commutes with a separate inertia
+    DR term, order-independent). When False, mass changes and inertia is left untouched.
+
+    ``mass_distribution_params`` is a config range value — a ``[lo, hi]`` pair (uniform) or a
+    ``{kind, low, high, mean, std}`` spec dict (gaussian / log_uniform) — honored identically on ALL
+    backends (IsaacGym per-actor loop, MuJoCo ``randomize_field``, project-owned IsaacSim
+    ``randomize_rigid_body_mass``), all via the shared keyed
+    :meth:`holosoma.utils.sampler.TermSampler.draw`. gaussian is a truncated normal on ``[lo, hi]``;
+    log_uniform requires positive bounds.
+    """
+    if not enabled:
+        return
+
+    idx = _ensure_env_ids_tensor(env, env_ids)
+    if idx.numel() == 0:
+        return
+
+    names = _resolve_object_names(env, object_names)
+    if not names:  # robot-only scene -> nothing to randomize, not an error
+        return
+
+    simulator = env.simulator
+    sim_type = simulator.get_simulator_type()
+
+    if sim_type == SimulatorType.ISAACGYM:
+        gym = simulator.gym
+        # One keyed offset per (env, object), added to all of that object's bodies — keyed by the
+        # object's index among ``names`` (stable) so the draw is reproducible per (term, env, episode).
+        # Object indices as a [1, n_names] coord -> [n_env, n_names].
+        obj_ids = torch.arange(len(names))[None, :]
+        offsets = sampler.draw(mass_distribution_params, env_ids=idx, coords=(obj_ids,), device="cpu")
+        for env_off, env_id in enumerate(idx.tolist()):
+            env_ptr = simulator.envs[env_id]
+            for name_off, name in enumerate(names):
+                actor = simulator.object_handles[name][env_id]
+                body_props = gym.get_actor_rigid_body_properties(env_ptr, actor)
+                delta = float(offsets[env_off, name_off])  # add operation, matches the other backends
+                for prop in body_props:
+                    m_before = prop.mass
+                    # Clamp like the IsaacSim helper (min_mass=1e-6): a signed band on a light body
+                    # must not produce a non-positive mass (which would also flip the inertia sign).
+                    prop.mass = max(m_before + delta, 1e-6)
+                    if recompute_inertia and m_before > 0.0:
+                        # Explicit per-body mass-ratio scale (NOT recomputeInertia=True, which would
+                        # recompute from geometry — a different result that also clobbers a prior
+                        # inertia-DR scale). Multiplicative => commutes with the inertia term.
+                        r = prop.mass / m_before
+                        inertia = prop.inertia  # gymapi.Mat33, symmetric
+                        inertia.x.x *= r
+                        inertia.y.y *= r
+                        inertia.z.z *= r
+                        inertia.x.y *= r
+                        inertia.y.x *= r
+                        inertia.y.z *= r
+                        inertia.z.y *= r
+                        inertia.x.z *= r
+                        inertia.z.x *= r
+                # recomputeInertia=False: we set inertia explicitly above (or leave it untouched).
+                gym.set_actor_rigid_body_properties(env_ptr, actor, body_props, recomputeInertia=False)
+        return
+
+    if sim_type == SimulatorType.ISAACSIM:
+        from isaaclab.managers import SceneEntityCfg
+
+        from holosoma.simulator.isaacsim.events import randomize_rigid_body_mass
+
+        env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
+
+        for name in names:
+            asset_cfg = SceneEntityCfg(name, body_names=".*")
+            asset_cfg.resolve(simulator.scene)
+            randomize_rigid_body_mass(
+                simulator,
+                env_ids_cpu,
+                asset_cfg,
+                mass_distribution_params,
+                operation="add",
+                sampler=sampler,
+                recompute_inertia=recompute_inertia,
+            )
+        return
+
+    if sim_type == SimulatorType.MUJOCO:
+        from holosoma.simulator.mujoco.backends.randomization import (
+            _field_view,
+            randomize_field,
+            scale_inertia_by_mass_ratio,
+        )
+
+        for name in names:
+            body_ids = _mujoco_object_body_ids(simulator, name)
+            body_ids_t = torch.tensor(body_ids, device=simulator.sim_device, dtype=torch.long)
+            # Snapshot mass BEFORE so the inertia rescale uses the exact ratio this write produced
+            # (matches IsaacGym/IsaacSim's explicit m_after/m_before scale).
+            mass_before = _field_view(simulator, "body_mass")[:, body_ids_t].clone() if recompute_inertia else None
+            randomize_field(
+                simulator,
+                field=getattr(randomize_object_rigid_body_mass_startup, MUJOCO_FIELD_ATTR),
+                ranges=mass_distribution_params,
+                sampler=sampler,
+                env_ids=idx,
+                # Resolve by ID (URDF descendant bodies are often unnamed) — mirrors the geom path.
+                entity_ids=body_ids_t,
+                operation="add",
+                # One offset per object, shared by all its bodies (matches the IsaacGym branch,
+                # which adds one delta to every body of the actor).
+                shared_across_entities=True,
+            )
+            # Clamp like the Isaac paths (min_mass=1e-6): a signed band on a light body must not
+            # leave a non-positive mass in the model.
+            mass_view = _field_view(simulator, "body_mass")
+            mass_view[:, body_ids_t] = mass_view[:, body_ids_t].clamp(min=1e-6)
+            if recompute_inertia:
+                scale_inertia_by_mass_ratio(simulator, body_ids_t, mass_before)
+        return
+
+    raise RandomizerNotSupportedError(
+        f"randomize_object_rigid_body_mass_startup does not support {type(simulator).__name__}."
+    )
+
+
+_INERTIA_ORDER = ["Ixx", "Iyy", "Izz", "Ixy", "Iyz", "Ixz"]
+
+_IDENTITY_SCALE: DistributionLike = (1.0, 1.0)
+
+
+def _coerce_inertia_params(
+    params: InertiaScale | dict[str, DistributionLike],
+) -> dict[str, DistributionLike]:
+    """Normalize the inertia-scale config to a full ``{Ixx..Ixz}`` dict of leaves.
+
+    Accepts an :class:`InertiaScale` or an equivalent (possibly partial) dict — a serialized config
+    arrives as a dict. Absent components default to the identity scale ``[1.0, 1.0]`` (no-op), so a
+    caller names only the components it randomizes.
+    """
+    if isinstance(params, InertiaScale):
+        return {k: getattr(params, k) for k in _INERTIA_ORDER}
+    unknown = set(params) - set(_INERTIA_ORDER)
+    if unknown:
+        raise ValueError(f"unknown inertia component(s) {sorted(unknown)}; expected {_INERTIA_ORDER}.")
+    return {k: params.get(k, _IDENTITY_SCALE) for k in _INERTIA_ORDER}
+
+
+def _is_identity_scale(leaf: DistributionLike) -> bool:
+    """Whether a config range value is the identity scale [1.0, 1.0] (no-op off-diagonal)."""
+    try:
+        spec = DistributionSpec.parse(leaf)
+    except (ValueError, TypeError):
+        return False
+    return spec.low == 1.0 and spec.high == 1.0 and spec.mean is None and spec.std is None
+
+
+def _warn_off_diagonal_inertia_ignored(backend: str, inertia_params: dict[str, DistributionLike]) -> None:
+    """One-time warning when a backend that can only scale the diagonal moments is asked to
+    scale an off-diagonal (Ixy/Iyz/Ixz) by a non-identity factor. ``[1.0, 1.0]`` is the
+    identity scale (no-op), matching how the shipped config leaves off-diagonals untouched."""
+    offending = [k for k in ("Ixy", "Iyz", "Ixz") if not _is_identity_scale(inertia_params.get(k, (1.0, 1.0)))]
+    if offending:
+        logger.warning(
+            f"{backend} object inertia DR scales only the diagonal principal moments "
+            f"(Ixx/Iyy/Izz); off-diagonal scale(s) {offending} are ignored."
+        )
+
+
+@mujoco_required_field("body_inertia")
+def randomize_object_rigid_body_inertia_startup(
+    env,
+    env_ids: Sequence[int] | torch.Tensor | None = None,
+    *,
+    sampler: TermSampler,
+    inertia_distribution_params_dict: InertiaScale | dict[str, DistributionLike],
+    object_names: Sequence[str] | None = None,
+    enabled: bool = True,
+    **_,
+) -> None:
+    """Randomize free-body rigid-body inertia (scale the inertia tensor).
+
+    Cross-backend. ``inertia_distribution_params_dict`` is an :class:`InertiaScale` (or an equivalent,
+    possibly partial, dict) of per-component SCALE ranges keyed [Ixx, Iyy, Izz, Ixy, Iyz, Ixz]; each
+    value is a ``[lo, hi]`` pair (uniform) or a spec dict, and an unnamed component defaults to the
+    identity scale [1.0, 1.0]:
+    - **IsaacSim / IsaacGym** scale the full symmetric 3x3 (all 6 components).
+    - **MuJoCo** (Warp GPU or Classic CPU) stores inertia as the 3 DIAGONAL principal moments
+      in a principal frame (``body_inertia`` is [nbody, 3]; off-diagonals are 0 by construction),
+      so it scales only Ixx/Iyy/Izz and logs a one-time warning if a non-identity off-diagonal
+      range is requested. The shipped config leaves off-diagonals at [1.0, 1.0] (identity), so
+      MuJoCo reproduces it faithfully.
+
+    Order-independent w.r.t. the mass DR term: both scale inertia MULTIPLICATIVELY (this term by the
+    configured factors; mass DR by its mass ratio when ``recompute_inertia=True``), and the IsaacGym
+    write uses ``recomputeInertia=False``, so neither clobbers the other regardless of which runs
+    first. Targets every registered free body by default; pass ``object_names`` to narrow. No-ops on a
+    robot-only scene. MuJoCo classic-CPU is single-env (one sample); MuJoCo classic via the shared
+    ``randomize_field`` path.
+
+    Each scale range is honored identically on ALL backends — IsaacGym per-component loop, MuJoCo
+    ``randomize_field``, and the project-owned IsaacSim ``randomize_rigid_body_inertia`` — all via the
+    shared keyed :meth:`holosoma.utils.sampler.TermSampler.draw`. A gaussian spec is a truncated normal
+    on each ``[lo, hi]``; log_uniform requires positive bounds (satisfied by identity-and-up scales).
+    """
+    if not enabled:
+        return
+
+    idx = _ensure_env_ids_tensor(env, env_ids)
+    if idx.numel() == 0:
+        return
+
+    names = _resolve_object_names(env, object_names)
+    if not names:  # robot-only scene -> nothing to randomize, not an error
+        return
+
+    inertia_distribution_params_dict = _coerce_inertia_params(inertia_distribution_params_dict)
+    simulator = env.simulator
+    sim_type = simulator.get_simulator_type()
+
+    if sim_type == SimulatorType.ISAACGYM:
+        # Full 6-component scale via the per-actor RigidBodyProperties Mat33 inertia tensor, with
+        # recomputeInertia=False (we set the tensor explicitly). The mass DR term also uses
+        # recomputeInertia=False + a multiplicative mass-ratio scale, so the two inertia writes
+        # commute — no clobber, no ordering requirement.
+        gym = simulator.gym
+        # Pre-draw one scale per (env, object) for each of the 6 components, keyed by object index
+        # (stable, a [1, n_names] coord) and a distinct int stream coord per component, then apply to
+        # every body of that object. -> each entry [n_env, n_names].
+        obj_ids = torch.arange(len(names))[None, :]
+        comp_draws = {
+            k: sampler.draw(inertia_distribution_params_dict[k], env_ids=idx, coords=(axis, obj_ids), device="cpu")
+            for axis, k in enumerate(_INERTIA_ORDER)
+        }
+        for env_off, env_id in enumerate(idx.tolist()):
+            env_ptr = simulator.envs[env_id]
+            for name_off, name in enumerate(names):
+                actor = simulator.object_handles[name][env_id]
+                body_props = gym.get_actor_rigid_body_properties(env_ptr, actor)
+                fxx, fyy, fzz = (float(comp_draws[k][env_off, name_off]) for k in ("Ixx", "Iyy", "Izz"))
+                fxy, fyz, fxz = (float(comp_draws[k][env_off, name_off]) for k in ("Ixy", "Iyz", "Ixz"))
+                for prop in body_props:
+                    inertia = prop.inertia  # gymapi.Mat33, symmetric
+                    inertia.x.x *= fxx
+                    inertia.y.y *= fyy
+                    inertia.z.z *= fzz
+                    inertia.x.y *= fxy
+                    inertia.y.x *= fxy
+                    inertia.y.z *= fyz
+                    inertia.z.y *= fyz
+                    inertia.x.z *= fxz
+                    inertia.z.x *= fxz
+                gym.set_actor_rigid_body_properties(env_ptr, actor, body_props, recomputeInertia=False)
+        return
+
+    if sim_type == SimulatorType.ISAACSIM:
+        from isaaclab.managers import SceneEntityCfg
+
+        from holosoma.simulator.isaacsim.events import randomize_rigid_body_inertia
+
+        env_ids_cpu = idx.to(device="cpu", dtype=torch.long)
+        # One spec per component in [Ixx, Iyy, Izz, Ixy, Iyz, Ixz] order.
+        specs = [DistributionSpec.parse(inertia_distribution_params_dict[key]) for key in _INERTIA_ORDER]
+        for name in names:
+            asset_cfg = SceneEntityCfg(name, body_names=".*")
+            asset_cfg.resolve(simulator.scene)
+            randomize_rigid_body_inertia(simulator, env_ids_cpu, asset_cfg, specs, operation="scale", sampler=sampler)
+        return
+
+    if sim_type == SimulatorType.MUJOCO:
+        # MuJoCo body_inertia is [nbody, 3] diagonal principal moments — scale Ixx/Iyy/Izz only.
+        from holosoma.simulator.mujoco.backends.randomization import randomize_field
+
+        _warn_off_diagonal_inertia_ignored("MuJoCo", inertia_distribution_params_dict)
+        ranges = {axis: inertia_distribution_params_dict[k] for axis, k in enumerate(("Ixx", "Iyy", "Izz"))}
+        for name in names:
+            body_ids = _mujoco_object_body_ids(simulator, name)
+            randomize_field(
+                simulator,
+                field=getattr(randomize_object_rigid_body_inertia_startup, MUJOCO_FIELD_ATTR),
+                ranges=ranges,  # axis 0/1/2 = Ixx/Iyy/Izz principal moments
+                sampler=sampler,
+                env_ids=idx,
+                # Resolve by ID (URDF descendant bodies are often unnamed) — mirrors the geom path.
+                entity_ids=torch.tensor(body_ids, device=simulator.sim_device, dtype=torch.long),
+                operation="scale",
+                # One scale per object, shared by all its bodies (matches the IsaacGym branch).
+                shared_across_entities=True,
+            )
+        return
+
+    raise RandomizerNotSupportedError(
+        f"randomize_object_rigid_body_inertia_startup does not support {type(simulator).__name__}."
+    )
+
+
+# Freejoint DOF layout: a free body's 6 velocity DOFs are [vx, vy, vz, wx, wy, wz], so the
+# linear-damping DOFs are the first 3 and the angular-damping DOFs the last 3, counted from the
+# freejoint's qvel base (object_addrs[name]["qvel_addr"]).
+_FREEJOINT_LINEAR_DOFS = (0, 1, 2)
+_FREEJOINT_ANGULAR_DOFS = (3, 4, 5)
+
+# Body-damping randomization. Damping is expressed differently per engine but means the same
+# physically (a drag that bleeds linear/angular velocity), and is randomized as a single linear +
+# single angular scalar per body on every backend (PhysX's model), kept aligned:
+# - MuJoCo: ``dof_damping`` on the freejoint, one shared value across its 3 linear / 3 angular DOFs.
+# - IsaacSim: the USD ``PhysxRigidBodyAPI.linearDamping``/``angularDamping`` scalar, writable at
+#   runtime (the live PhysX sim picks up the edit on the next step).
+# - IsaacGym: NO runtime path. Source-verified the gym exposes damping only on ``AssetOptions`` at
+#   asset import; neither ``RigidBodyProperties`` (mass/inertia/com only) nor ``RigidShapeProperties``
+#   (friction/restitution/compliance/offsets only) carries damping, and the only runtime damping
+#   setter, ``set_actor_dof_properties``, is for articulation joints, not free-body drag. So
+#   IsaacGym raises (set damping via PhysXPhysicsConfig at spawn instead).
+_DAMPING_ISAACGYM_MSG = (
+    "Runtime body-damping randomization is unsupported on IsaacGym. "
+    "Set damping via PhysXPhysicsConfig at spawn instead."
+)
+
+
+def _isaacsim_randomize_body_damping(
+    simulator, names, idx, *, axis: str, leaf: DistributionLike, sampler: TermSampler
+) -> None:
+    """Set free-body linear/angular damping per (object, env) on IsaacSim via the live USD schema.
+
+    Writes ``PhysxRigidBodyAPI.{axis}Damping`` on each object's per-env rigid-body prim to a keyed
+    sample (one value per (env, object), keyed by the object index). The running PhysX sim reflects
+    the edit on the next step. ``axis`` is "linear" or "angular". Unlike the mass/com/inertia paths,
+    this writes the USD attr directly, drawing through the bound ``sampler`` AND reproducibly.
+
+    The stage is traversed ONCE into a list of API-bearing prims (rather than re-walking the full
+    stage for every (name, env) pair); the per-(name, env) work then scans only that list.
+    """
+    import omni.usd
+    from pxr import PhysxSchema
+
+    stage = omni.usd.get_context().get_stage()
+    env_id_list = idx.to(device="cpu", dtype=torch.long).tolist()
+    # One keyed value per (env, object), keyed by object index (stable across the run); object indices
+    # as a [1, n_names] coord -> [n_env, n_names].
+    obj_ids = torch.arange(len(names))[None, :]
+    damping = sampler.draw(leaf, env_ids=idx, coords=(obj_ids,), device="cpu")
+
+    # One pass over the stage: collect (path_str, prim) for every PhysxRigidBodyAPI prim.
+    rigid_prims = [
+        (str(prim.GetPath()), prim) for prim in stage.Traverse() if prim.HasAPI(PhysxSchema.PhysxRigidBodyAPI)
+    ]
+
+    for name_off, name in enumerate(names):
+        for env_off, e in enumerate(env_id_list):
+            prefix = f"/World/envs/env_{e}/{name}"
+            value = float(damping[env_off, name_off])
+            for path_str, prim in rigid_prims:
+                # Boundary-anchored match: the prim is this body or a child of it. A bare
+                # startswith would over-match siblings (env_1 -> env_10, box -> box2).
+                if path_str != prefix and not path_str.startswith(prefix + "/"):
+                    continue
+                api = PhysxSchema.PhysxRigidBodyAPI(prim)
+                attr = api.GetLinearDampingAttr() if axis == "linear" else api.GetAngularDampingAttr()
+                attr.Set(value)
+
+
+def _randomize_object_freejoint_damping(
+    env,
+    env_ids,
+    sampler: TermSampler,
+    *,
+    dofs: tuple[int, ...],
+    axis: str,
+    damping_range: DistributionLike,
+    object_names: Sequence[str] | None,
+    field_attr: str,
+) -> None:
+    """Shared core for linear/angular body-damping DR (MuJoCo + IsaacSim; IsaacGym unsupported).
+
+    ``axis`` is "linear" or "angular"; ``dofs`` are the freejoint-relative DOF offsets MuJoCo
+    writes (linear 0:3 / angular 3:6). One value is sampled per env and applied to the whole axis
+    group — matching PhysX's single linear/angular damping scalar, so the concept is identical on
+    every supported backend (MuJoCo shares it across the 3 freejoint DOFs; IsaacSim sets the one
+    PhysxRigidBodyAPI scalar).
+
+    ``damping_range`` is a config range value ([lo, hi] pair or spec dict), honored on BOTH MuJoCo (via
+    ``randomize_field``) and IsaacSim (the live-USD writer). IsaacGym has no runtime damping path and
+    raises regardless.
+    """
+    idx = _ensure_env_ids_tensor(env, env_ids)
+    if idx.numel() == 0:
+        return
+    names = _resolve_object_names(env, object_names)
+    if not names:  # robot-only scene -> nothing to randomize, not an error
+        return
+
+    simulator = env.simulator
+    sim_type = simulator.get_simulator_type()
+
+    if sim_type == SimulatorType.ISAACGYM:
+        raise RandomizerNotSupportedError(_DAMPING_ISAACGYM_MSG)
+
+    if sim_type == SimulatorType.ISAACSIM:
+        _isaacsim_randomize_body_damping(simulator, names, idx, axis=axis, leaf=damping_range, sampler=sampler)
+        return
+
+    if sim_type == SimulatorType.MUJOCO:
+        from holosoma.simulator.mujoco.backends.randomization import randomize_field
+
+        for name in names:
+            qvel_base = simulator.object_addrs[name]["qvel_addr"]  # freejoint's 6-DOF velocity base
+            dof_ids = torch.tensor([qvel_base + d for d in dofs], device=simulator.sim_device, dtype=torch.long)
+            randomize_field(
+                simulator,
+                field=field_attr,
+                ranges=damping_range,
+                sampler=sampler,
+                env_ids=idx,
+                entity_ids=dof_ids,
+                operation="abs",
+                shared_across_entities=True,
+            )
+        return
+
+    raise RandomizerNotSupportedError(
+        f"{field_attr} damping randomization does not support {type(simulator).__name__}."
+    )
+
+
+@mujoco_required_field("dof_damping")
+def randomize_object_linear_damping_startup(
+    env,
+    env_ids: Sequence[int] | torch.Tensor | None = None,
+    *,
+    sampler: TermSampler,
+    damping_range: DistributionLike,
+    object_names: Sequence[str] | None = None,
+    enabled: bool = True,
+    **_,
+) -> None:
+    """Randomize free-body LINEAR (translational) damping — drag on linear velocity.
+
+    MuJoCo (Classic + Warp, via freejoint ``dof_damping``) and IsaacSim (via the live USD
+    ``PhysxRigidBodyAPI.linearDamping``); IsaacGym is unsupported and raises (it accepts body
+    damping only at asset import — see the error). One value per env is applied as the body's
+    single linear-damping scalar (on MuJoCo, shared across the 3 translational freejoint DOFs), so
+    the concept matches PhysX on every backend. Targets every registered free body by default. On
+    the WarpBackend keep ``damping_range`` <= ~0.05 (freejoint dof_damping diverges above that at
+    the default dt); the ClassicBackend and IsaacSim are stable at any value.
+
+    ``damping_range`` is a config range value — a ``[lo, hi]`` pair (uniform) or a spec dict — honored on
+    both MuJoCo and IsaacSim; gaussian truncates to ``[lo, hi]`` and log_uniform requires positive
+    bounds.
+    """
+    if not enabled:
+        return
+    _randomize_object_freejoint_damping(
+        env,
+        env_ids,
+        sampler,
+        dofs=_FREEJOINT_LINEAR_DOFS,
+        axis="linear",
+        damping_range=damping_range,
+        object_names=object_names,
+        field_attr=getattr(randomize_object_linear_damping_startup, MUJOCO_FIELD_ATTR),
+    )
+
+
+@mujoco_required_field("dof_damping")
+def randomize_object_angular_damping_startup(
+    env,
+    env_ids: Sequence[int] | torch.Tensor | None = None,
+    *,
+    sampler: TermSampler,
+    damping_range: DistributionLike,
+    object_names: Sequence[str] | None = None,
+    enabled: bool = True,
+    **_,
+) -> None:
+    """Randomize free-body ANGULAR (rotational) damping — drag on angular velocity.
+
+    MuJoCo (Classic + Warp) and IsaacSim (via the live USD ``PhysxRigidBodyAPI.angularDamping``);
+    IsaacGym unsupported (see :func:`randomize_object_linear_damping_startup`). One value per env is
+    applied as the body's single angular-damping scalar (on MuJoCo, shared across the 3 rotational
+    freejoint DOFs), matching PhysX on every backend. WarpBackend stable band <= ~0.05.
+
+    ``damping_range`` is a config range value — a ``[lo, hi]`` pair (uniform) or a spec dict — honored on
+    both MuJoCo and IsaacSim; gaussian truncates to ``[lo, hi]`` and log_uniform requires positive
+    bounds.
+    """
+    if not enabled:
+        return
+    _randomize_object_freejoint_damping(
+        env,
+        env_ids,
+        sampler,
+        dofs=_FREEJOINT_ANGULAR_DOFS,
+        axis="angular",
+        damping_range=damping_range,
+        object_names=object_names,
+        field_attr=getattr(randomize_object_angular_damping_startup, MUJOCO_FIELD_ATTR),
+    )
 
 
 def _jitter_spec(range_cfg: float | DistributionLike) -> DistributionSpec | None:

--- a/src/holosoma/holosoma/simulator/isaacsim/events.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/events.py
@@ -11,13 +11,14 @@ term boundary) and write through ``asset.root_physx_view``; CoM/inertia reset to
 defaults (``asset.data.default_*``) before applying, so repeated calls compose from the original.
 
 The MATERIAL writer (:func:`randomize_rigid_body_material`) is different in kind because PhysX caps
-the number of unique physics materials per scene (~64k). It takes a ``num_buckets`` knob: an int
-fills ``num_buckets`` materials with the distribution's QUANTILE values
-(:func:`~holosoma.utils.sampler.quantiles`) and lets each shape pick a bucket (matching IsaacLab's
-mechanism), bounding unique materials at ``num_buckets`` — an ``n``-atom staircase matching the
-continuous backends' per-shape marginal APPROXIMATELY (raise to tighten). ``num_buckets=None`` draws
-continuously per shape — a true marginal, but safe only when the per-shape material count is under
-the cap.
+the number of unique physics materials per scene (~64k). It has two orthogonal knobs. ``num_buckets``
+controls VALUE QUANTIZATION: an int fills ``num_buckets`` materials with the distribution's QUANTILE
+values (:func:`~holosoma.utils.sampler.quantiles`) and picks a bucket (matching IsaacLab's mechanism),
+bounding unique materials at ``num_buckets`` — an ``n``-atom staircase matching the continuous
+backends APPROXIMATELY (raise to tighten); ``None`` draws continuously. ``per_env`` controls
+GRANULARITY: ``False`` (default) draws per shape (IsaacLab-native, for object/robot material terms),
+``True`` draws one value per env broadcast across its shapes — matching the IsaacGym per-env friction
+path and capping unique materials at ~``num_envs`` when continuous.
 """
 
 from __future__ import annotations
@@ -265,21 +266,29 @@ def randomize_rigid_body_material(
     num_buckets: int | None,
     sampler: TermSampler,
     make_consistent: bool = True,
+    per_env: bool = False,
 ):
-    """Randomize per-shape friction/restitution, bucketed or continuous.
+    """Randomize friction/restitution, bucketed or continuous, per shape or per env.
 
     Each channel is a config range value ([lo, hi] / spec dict / DistributionSpec), or ``None`` to leave
     that channel at its spawned value.
 
-    ``num_buckets`` controls how the PhysX per-scene material cap (~64k) is respected:
+    ``num_buckets`` controls VALUE QUANTIZATION (how the PhysX per-scene material cap ~64k is respected):
     - an int (the default path): replicates IsaacLab's mechanism (build ``num_buckets`` materials once,
-      assign each shape a bucket), so total unique materials stay bounded at ``num_buckets`` regardless
-      of env/shape count. The ONE change from IsaacLab: fill each channel with the QUANTILE values of
-      its :class:`DistributionSpec` (via :func:`~holosoma.utils.sampler.quantiles`) instead of
-      ``sample_uniform``, so a gaussian / log_uniform config matches the continuous backends' per-shape
-      marginal APPROXIMATELY as an ``n``-atom staircase (raise ``num_buckets`` to tighten it).
-    - ``None``: draw a CONTINUOUS value per shape (a true marginal), minting up to ~``num_envs`` ×
-      ``num_shapes`` unique materials — opt into this only when that count is comfortably under the cap.
+      assign a bucket), so total unique materials stay bounded at ``num_buckets`` regardless of
+      env/shape count. The ONE change from IsaacLab: fill each channel with the QUANTILE values of its
+      :class:`DistributionSpec` (via :func:`~holosoma.utils.sampler.quantiles`) instead of
+      ``sample_uniform``, so a gaussian / log_uniform config matches the continuous backends' marginal
+      APPROXIMATELY as an ``n``-atom staircase (raise ``num_buckets`` to tighten it).
+    - ``None``: draw a CONTINUOUS value per channel (a true marginal).
+
+    ``per_env`` controls GRANULARITY (independent of quantization):
+    - ``False`` (default): draw independently PER SHAPE — the IsaacLab-native behavior, kept for the
+      object/robot material terms.
+    - ``True``: draw ONE value per env and broadcast it across that env's shapes, matching the IsaacGym
+      per-env friction path (and MuJoCo's ``shared_across_entities``). The friction term uses this so
+      one robot has a single contact-friction coefficient on every backend. Per-env also caps unique
+      materials at ~``num_envs`` when continuous, keeping it under the PhysX limit.
 
     A channel spec of ``None`` is NOT randomized — that column keeps each shape's spawned value
     (so a config can randomize, e.g., friction only and leave restitution as authored). Returns
@@ -288,8 +297,8 @@ def randomize_rigid_body_material(
     ``make_consistent`` clamps dynamic friction <= static friction (PhysX expects this),
     matching IsaacLab's optional flag; enabled by default here since friction DR always wants it.
 
-    Reproducibility: every draw (bucket fill shuffle, per-shape bucket pick, or continuous value) goes
-    through the keyed ``sampler`` on distinct axes, so a seeded run produces the same realized material.
+    Reproducibility: every draw (bucket fill shuffle, bucket pick, or continuous value) goes through
+    the keyed ``sampler`` on distinct axes, so a seeded run produces the same realized material.
     """
 
     def _spec(leaf: DistributionLike | None) -> DistributionSpec | None:
@@ -312,25 +321,29 @@ def randomize_rigid_body_material(
     materials = asset.root_physx_view.get_material_properties()
     total_num_shapes = asset.root_physx_view.max_shapes
     samples = materials[env_ids].clone()  # (n_env, n_shapes, 3); start from current, overwrite chosen cols
+
+    # ``per_env`` picks the shape coordinate: absent -> one draw per env, broadcast across shapes;
+    # present (a [1, n_shapes] coord) -> an independent per-(env, shape) draw. The trailing shape
+    # broadcast/assignment is identical either way.
     shape_ids = torch.arange(total_num_shapes)
+    shape_coord: tuple = () if per_env else (shape_ids[None, :],)
 
     for k, spec in enumerate(channel_specs):
         if spec is None:
             continue
         if num_buckets is None:
-            # Continuous per shape: channel stream coords 0/1/2 keep the three columns decorrelated;
-            # shape ids as a [1, n_shapes] coord -> an independent per-(env, shape) draw.
-            drawn = sampler.draw(spec, env_ids=env_ids, coords=(k, shape_ids[None, :]))  # (n_env, n_shapes)
+            # Continuous: channel stream coords 0/1/2 keep the three columns decorrelated.
+            drawn = sampler.draw(spec, env_ids=env_ids, coords=(k, *shape_coord))  # [n_env] or [n_env, n_shapes]
         else:
             # Bucketed: fill a per-channel bucket column with the spec's quantile values, shuffle it
             # with a KEYED permutation (distinct stream coord per channel so columns are not
             # rank-aligned — matches IsaacLab's independent per-column draw, reproducible per seed),
-            # then pick a bucket per shape via the keyed selection (stream coord 3, distinct from 0/1/2).
-            # Total unique materials stay bounded at num_buckets.
+            # then pick a bucket via the keyed selection (stream coord 3, distinct from 0/1/2). Total
+            # unique materials stay bounded at num_buckets.
             column = quantiles(spec, num_buckets, "cpu")[sampler.permute(num_buckets, (k,))]
-            bucket_ids = sampler.draw_int(0, num_buckets - 1, env_ids=env_ids, coords=(3, shape_ids[None, :]))
+            bucket_ids = sampler.draw_int(0, num_buckets - 1, env_ids=env_ids, coords=(3, *shape_coord))
             drawn = column[bucket_ids]
-        samples[..., k] = drawn
+        samples[..., k] = drawn[:, None] if per_env else drawn  # broadcast per-env value over shapes
 
     if make_consistent and (static_friction_spec is not None or dynamic_friction_spec is not None):
         samples[..., 1] = torch.min(samples[..., 0], samples[..., 1])  # dynamic <= static (PhysX)

--- a/src/holosoma/holosoma/simulator/mujoco/backends/randomization.py
+++ b/src/holosoma/holosoma/simulator/mujoco/backends/randomization.py
@@ -196,6 +196,7 @@ def randomize_field(
     entity_names: list[str] | None = None,
     entity_type: str | None = None,
     operation: Literal["add", "scale", "abs"] = "abs",
+    shared_across_entities: bool = False,
     axis_base: int = 0,
     num_buckets: int | None = None,
 ) -> None:
@@ -236,6 +237,11 @@ def randomize_field(
         Required if entity_names is provided, otherwise inferred from field
     operation : Literal["add", "scale", "abs"]
         Operation to apply: add to current, scale current, or set absolute value
+    shared_across_entities : bool
+        If True, every entity gets the SAME per-env sample (the first entity's), instead of an
+        independent draw each. Use to randomize a group of entities as one logical unit — e.g.
+        a freejoint's 3 linear ``dof_damping`` DOFs sharing one value (PhysX exposes a single
+        linear damping scalar, so this keeps the concept aligned across backends).
     num_buckets : Optional[int]
         Quantization knob mirroring the PhysX backends' material bucketing, for a config that wants
         the SAME staircase discretization on MuJoCo. ``None`` (default): draw continuously — MuJoCo
@@ -369,6 +375,10 @@ def randomize_field(
     # -----------------------------------------------------------
     # 4. Generate Random Values
     # -----------------------------------------------------------
+    n_e = len(env_ids)
+    n_n = len(entity_ids)
+    n_a = len(target_axes) if target_axes is not None else 1
+
     # Sample each axis through the bound TermSampler so a MuJoCo config means exactly what it does on
     # every other backend AND is reproducible per (term, env, episode). Entity ids are the stable MuJoCo
     # indices (body/geom/dof), passed as a ``[1, n_n]`` coord so a per-entity draw lands on the trailing
@@ -399,6 +409,11 @@ def randomize_field(
             )  # (n_e, n_n)
             per_axis.append(column[bucket_ids])
     random_values = torch.stack(per_axis, dim=-1)  # (n_e, n_n, n_a)
+
+    # Share one per-env sample across the whole entity group (the first entity's draw), so a
+    # multi-DOF/entity unit is randomized as one value rather than independently per entity.
+    if shared_across_entities and n_n > 1:
+        random_values = random_values[:, :1, :].expand(n_e, n_n, n_a).clone()
 
     if target_axes is None:
         random_values = random_values.squeeze(-1)

--- a/src/holosoma/tests/simulators/_dr_matrix.py
+++ b/src/holosoma/tests/simulators/_dr_matrix.py
@@ -1,14 +1,36 @@
-"""Shared DR test helper: a bound TermSampler for calling DR terms directly in tests.
+"""Shared cross-backend domain-randomization (DR) checks.
 
-On the full feature branch this module also holds the cross-backend DR *matrix* runners
-(``run_robot_dr`` / ``run_object_dr`` / ``run_distribution_dr``) and the ``ModelReader`` protocol;
-the object-DR follow-up branch adds those. This scene-objects branch keeps only ``_sampler``, which
-the reset-time pose-jitter test needs.
+The DR terms themselves are backend-agnostic: every term is called identically on every
+backend (the per-backend dispatch lives inside the term). Only *reading back* the mutated
+physics-model field differs — MuJoCo classic exposes float64 numpy on ``backend.model``,
+MuJoCo Warp a per-world ``warp_model_bridge`` view, IsaacGym/IsaacSim per-actor property
+structs. So these helpers take a small ``ModelReader`` that abstracts the four read-backs and
+run the FULL matrix of DR terms against ONE already-built real environment.
+
+This is deliberately "one sim, many asserts": building a full env (real action_manager +
+randomization_manager, no shims) is the expensive step, so each backend's thin test file builds
+the env once and calls ``run_robot_dr`` + ``run_object_dr`` here. Manager/action-state and
+actor-state read-backs (PD/RFI scales, push velocity, object pose) are backend-agnostic and read
+directly off the live env, so they live here too.
+
+All ranges below are deliberately exaggerated and disjoint from the defaults so a no-op or a
+wrong-backend write is unambiguous.
 """
 
 from __future__ import annotations
 
+import dataclasses
+from contextlib import contextmanager
+from typing import Protocol, cast
+
+import torch
+
+from holosoma.managers.randomization.exceptions import RandomizerNotSupportedError
+from holosoma.managers.randomization.terms import locomotion as L
+from holosoma.managers.randomization.terms import objects as O
+from holosoma.simulator.shared.object_registry import ObjectType
 from holosoma.utils.sampler import STAGE_RESET, TermSampler
+from holosoma.utils.simulator_config import SimulatorType
 
 
 def _sampler(env, term: str = "dr_matrix_test") -> TermSampler:
@@ -20,3 +42,556 @@ def _sampler(env, term: str = "dr_matrix_test") -> TermSampler:
     base_seed = getattr(env, "dr_base_seed", None) or 0
     episode = getattr(env, "dr_episode_count", None)
     return TermSampler.bind(base_seed, term, STAGE_RESET, episode)
+
+
+@contextmanager
+def build_full_env(simulator_cfg, *, num_envs: int, device: str, scene_cfg=None, seed: int = 0):
+    """Yield a real, fully-managed locomotion env for DR testing — NO shims.
+
+    Swaps the ``simulator`` (and optionally ``scene``) of the ``g1_29dof`` experiment preset and
+    constructs the env through the production path (``get_class(env_class)(get_tyro_env_config)``
+    under ``training_context``), so it has a real action_manager (with the ``joint_control`` term)
+    and randomization_manager (push/actuator states) wired exactly as training does. The
+    ``g1_29dof`` randomization preset already runs the setup DR terms during construction; this
+    yields the built env (NO ``reset_all``) so the per-term checks can re-run each term with known
+    ranges and read the result straight off the model.
+
+    ``reset_all`` is deliberately NOT called: it steps physics, which triggers the locomotion
+    terrain height-scan (warp ray-cast) — unrelated to DR and version-fragile — while the DR
+    checks need only the constructed env + managers, not a physics step.
+
+    A context manager (not a plain return) so ``training_context`` stays open for the whole test —
+    its ``__exit__`` calls ``close_simulation_app``, which would tear down the IsaacSim app early.
+
+    Parameters
+    ----------
+    simulator_cfg : SimulatorConfig
+        One of ``config_values.simulator.{mujoco, mjwarp, isaacgym, isaacsim}``.
+    num_envs : int
+        1 for the MuJoCo ClassicBackend (single-env only); >1 for the GPU backends.
+    device : str
+        ``"cpu"`` for classic, ``"cuda:0"`` for the GPU backends.
+    scene_cfg : SceneConfig | None
+        Scene preset; defaults to ``free_and_static`` so object DR has a free body to target.
+    """
+    # Imported lazily: importing config_values / train_agent pulls in the simulator stack, which
+    # the per-backend launcher (isaacgym/isaacsim) must initialize before torch is imported.
+    from holosoma.config_types.env import get_tyro_env_config
+    from holosoma.config_values import experiment
+    from holosoma.train_agent import training_context
+    from holosoma.utils.common import seeding
+    from holosoma.utils.helpers import get_class
+
+    # Default object scene is a test preset (free + static bodies), injected here by object (no tyro).
+    from tests.simulators._scene_presets import free_and_static
+
+    seeding(seed)
+    base = experiment.g1_29dof
+    cfg = dataclasses.replace(
+        base,
+        simulator=simulator_cfg,
+        scene=free_and_static if scene_cfg is None else scene_cfg,
+        training=dataclasses.replace(
+            base.training, num_envs=num_envs, headless=True, seed=seed, torch_deterministic=False
+        ),
+    )
+    with training_context(cfg):
+        env = get_class(cfg.env_class)(get_tyro_env_config(cfg), device=device)
+        yield env
+
+
+class ModelReader(Protocol):
+    """Backend-specific read-back of physics-model fields for a single env (env 0).
+
+    Implementations return the *current* live value the term should have mutated. For
+    multi-env backends, read env 0 (the terms are applied to all env_ids passed in).
+
+    Capability flags tell the matrix which fields a backend can honestly read back from the
+    LIVE solver state (vs a field the backend's API does not reflect or does not model). When a
+    flag is False the corresponding band assertion is SKIPPED (not faked-green) and the success
+    banner does not claim that field for the backend.
+    """
+
+    # Whether ``body_com`` returns the live integrated CoM after a CoM write (see _IsaacGymReader).
+    COM_READBACK_TRUSTED: bool = True
+    # Whether the backend models restitution and exposes it (only IsaacSim, see _IsaacSimReader).
+    RESTITUTION_READBACK_TRUSTED: bool = False
+
+    def body_mass(self, body_name: str) -> float: ...
+    def geom_friction_for_body(self, body_name: str) -> float: ...
+    def body_inertia(self, body_name: str) -> tuple[float, float, float]: ...
+    def body_com(self, body_name: str) -> tuple[float, float, float]: ...
+    # Optional, IsaacSim-only (gated by RESTITUTION_READBACK_TRUSTED):
+    def restitution_for_body(self, body_name: str) -> float: ...
+    def dynamic_friction_for_body(self, body_name: str) -> float: ...
+
+
+# --- exaggerated, disjoint-from-default ranges so any change is unambiguous -------------------
+ROBOT_BASE_MASS_ADD = (2.0, 3.0)
+ROBOT_FRICTION = (0.5, 0.7)
+# Distinct band for the distribution-DR friction re-draw: run_robot_dr already sets friction in
+# ROBOT_FRICTION, and the keyed sampler draws the SAME underlying uniform for an identical (term,
+# stage, band), so a uniform and a gaussian over the SAME band would land ~1e-3 apart and the
+# "changed" assertion would flake. A disjoint band makes the change unambiguous regardless of
+# sampler correlation (the point of that check is "gaussian friction lands in band and took effect").
+GAUSS_FRICTION = (0.85, 0.95)
+# Distinct band again for the IsaacSim robot-MATERIAL term (separate from randomize_friction_startup,
+# which already set GAUSS_FRICTION) so its "landed in band" check is unambiguous.
+ROBOT_MATERIAL_FRICTION = (0.30, 0.40)
+ROBOT_LINK_MASS_SCALE = (2.0, 3.0)
+ROBOT_BASE_COM_X = (0.05, 0.06)
+PD_SCALE = (2.0, 3.0)
+RFI_SCALE = (2.0, 3.0)
+ACTION_DELAY = 2
+DOF_POS_BIAS = (0.5, 0.6)
+DOF_VEL = (0.1, 0.2)
+OBJ_MASS_ADD = (5.0, 6.0)
+OBJ_FRICTION = (0.2, 0.3)
+# Restitution band disjoint from friction so a mis-wired slot is unambiguous; IsaacSim only
+# (the only backend that models restitution — IsaacGym/MuJoCo ignore it, gated below).
+OBJ_RESTITUTION = (0.7, 0.8)
+OBJ_INERTIA_IXX_SCALE = (2.0, 3.0)
+
+
+def _env_ids(env) -> torch.Tensor:
+    return torch.arange(env.num_envs, device=env.device, dtype=torch.long)
+
+
+def run_robot_dr(env, reader: ModelReader) -> list[str]:
+    """Run every robot DR term against ``env`` and assert each took effect.
+
+    Covers: link/base mass, friction, base CoM (physics-model fields via ``reader``); PD-gain,
+    RFI-limit, action-delay, DOF-state randomizers (manager/action state, read directly).
+
+    Returns the list of check labels that were SKIPPED because the backend cannot honestly read
+    the live field back (e.g. ``["base CoM"]`` on IsaacGym). The caller uses this to scope the
+    success banner so it never claims a field it did not actually verify.
+    """
+    skipped: list[str] = []
+    idx = _env_ids(env)
+    torso = env.robot_config.torso_name
+    link_names = list(env.robot_config.randomize_link_body_names or [])
+    assert link_names, "robot config declares no randomize_link_body_names"
+
+    # --- base mass (additive offset); isolate from link scaling --------------------------------
+    before = reader.body_mass(torso)
+    L.randomize_mass_startup(
+        env,
+        idx,
+        sampler=_sampler(env),
+        enable_link_mass=False,
+        enable_base_mass=True,
+        added_mass_range=ROBOT_BASE_MASS_ADD,
+    )
+    after = reader.body_mass(torso)
+    assert ROBOT_BASE_MASS_ADD[0] - 1e-2 <= after - before <= ROBOT_BASE_MASS_ADD[1] + 1e-2, (
+        f"robot base mass offset out of band: {before} -> {after}"
+    )
+
+    # --- link mass (scale); exaggerated factor so the change is unambiguous ---------------------
+    link0 = link_names[0]
+    before = reader.body_mass(link0)
+    L.randomize_mass_startup(
+        env,
+        idx,
+        sampler=_sampler(env),
+        enable_link_mass=True,
+        link_mass_range=ROBOT_LINK_MASS_SCALE,
+        enable_base_mass=False,
+    )
+    after = reader.body_mass(link0)
+    assert ROBOT_LINK_MASS_SCALE[0] - 1e-3 <= after / before <= ROBOT_LINK_MASS_SCALE[1] + 1e-3, (
+        f"robot link mass scale out of band: {after / before}"
+    )
+
+    # --- friction (abs) -------------------------------------------------------------------------
+    before = reader.geom_friction_for_body(torso)
+    L.randomize_friction_startup(env, idx, sampler=_sampler(env), friction_range=ROBOT_FRICTION)
+    after = reader.geom_friction_for_body(torso)
+    assert ROBOT_FRICTION[0] - 1e-3 <= after <= ROBOT_FRICTION[1] + 1e-3, f"robot friction out of band: {after}"
+    assert abs(after - before) > 1e-3, "robot friction unchanged"
+
+    # --- base CoM (add to body_ipos) ------------------------------------------------------------
+    # The setup preset already applied a base-CoM bias, and the backends differ in how a second
+    # call composes: MuJoCo ADDs to body_ipos (accumulate), IsaacGym overwrites from the original.
+    # A zero-range call first neutralizes any prior bias to a clean baseline so the before/after
+    # delta equals exactly this call's offset on either semantics.
+    #
+    # The band assertion reads the LIVE CoM via reader.body_com and is gated by the reader's
+    # COM_READBACK_TRUSTED flag. On IsaacGym that flag is False: its get_actor_rigid_body_properties
+    # does not reliably reflect a CoM write back (undocumented/version-fragile) and the state tensor
+    # carries no body-frame CoM, so there is NO trustworthy live read-back in this harness. We still
+    # RUN the term (so a hard write-path failure raises) but SKIP the band assertion and record it,
+    # rather than re-adding the term's own recorded bias (which would be a green tautology).
+    L.randomize_base_com_startup(
+        env, idx, sampler=_sampler(env), base_com_range={"x": [0.0, 0.0], "y": [0.0, 0.0], "z": [0.0, 0.0]}
+    )
+    com_trusted = getattr(reader, "COM_READBACK_TRUSTED", True)
+    com_before: tuple[float, float, float] | None = reader.body_com(torso) if com_trusted else None
+    L.randomize_base_com_startup(
+        env, idx, sampler=_sampler(env), base_com_range={"x": list(ROBOT_BASE_COM_X), "y": [0.0, 0.0], "z": [0.0, 0.0]}
+    )
+    if com_before is not None:
+        com_after = reader.body_com(torso)
+        assert ROBOT_BASE_COM_X[0] - 1e-3 <= com_after[0] - com_before[0] <= ROBOT_BASE_COM_X[1] + 1e-3, (
+            f"robot base CoM x offset out of band: {com_after[0] - com_before[0]}"
+        )
+        assert abs(com_after[1] - com_before[1]) < 1e-3 and abs(com_after[2] - com_before[2]) < 1e-3, (
+            "CoM y/z wrongly shifted"
+        )
+    else:
+        skipped.append("base CoM (no trustworthy live read-back on this backend)")
+
+    # --- PD gains (actuator-state randomizer; read via the joint action term) -------------------
+    jt = env.action_manager.get_term("joint_control")
+    kp_before, _ = jt.get_pd_scale_tensors()
+    kp_before = kp_before.clone()
+    L.randomize_pd_gains(env, idx, sampler=_sampler(env), kp_range=PD_SCALE, kd_range=PD_SCALE, enabled=True)
+    kp_after, _ = jt.get_pd_scale_tensors()
+    assert torch.all(kp_after >= PD_SCALE[0] - 1e-3) and torch.all(kp_after <= PD_SCALE[1] + 1e-3), (
+        f"PD kp scale out of band: {kp_after.min()}..{kp_after.max()}"
+    )
+    assert (kp_after - kp_before).abs().max() > 1e-3, "PD kp scale unchanged"
+
+    # --- RFI limits -----------------------------------------------------------------------------
+    L.randomize_rfi_limits(env, idx, sampler=_sampler(env), rfi_lim_range=RFI_SCALE, enabled=True)
+    rfi_after = jt.get_rfi_scale_tensor()
+    assert torch.all(rfi_after >= RFI_SCALE[0] - 1e-3) and torch.all(rfi_after <= RFI_SCALE[1] + 1e-3), (
+        f"RFI scale out of band: {rfi_after.min()}..{rfi_after.max()}"
+    )
+
+    # --- action delay (integer index in [lo, hi]) -----------------------------------------------
+    env._ctrl_delay_step_range = [ACTION_DELAY, ACTION_DELAY]
+    env._randomize_ctrl_delay = True
+    L.randomize_action_delay(
+        env, idx, sampler=_sampler(env), ctrl_delay_step_range=[ACTION_DELAY, ACTION_DELAY], enabled=True
+    )
+    assert int(env.action_delay_idx[0]) == ACTION_DELAY, f"action delay idx not set: {env.action_delay_idx[0]}"
+
+    # --- DOF state (pos bias + velocity; scale held at 1.0 so the bias band is exact) -----------
+    L.randomize_dof_state(
+        env,
+        idx,
+        sampler=_sampler(env),
+        joint_pos_scale_range=[1.0, 1.0],
+        joint_pos_bias_range=list(DOF_POS_BIAS),
+        joint_vel_range=list(DOF_VEL),
+        randomize_dof_pos_bias=True,
+    )
+    dpos = env.simulator.dof_pos[0] - env.default_dof_pos[0]
+    assert float(dpos.min()) >= DOF_POS_BIAS[0] - 1e-3 and float(dpos.max()) <= DOF_POS_BIAS[1] + 1e-3, (
+        f"DOF pos bias out of band: {float(dpos.min())}..{float(dpos.max())}"
+    )
+    dvel = env.simulator.dof_vel[0]
+    assert float(dvel.min()) >= DOF_VEL[0] - 1e-3 and float(dvel.max()) <= DOF_VEL[1] + 1e-3, (
+        f"DOF vel out of band: {float(dvel.min())}..{float(dvel.max())}"
+    )
+
+    # --- DOF-pos bias setup (default pose shifted within band; distinct from randomize_dof_state) ---
+    base = env.default_dof_pos_base[0].clone()
+    L.setup_dof_pos_bias(env, sampler=_sampler(env), dof_pos_bias_range=list(DOF_POS_BIAS), enabled=True)
+    bias = env.default_dof_pos[0] - base
+    assert float(bias.min()) >= DOF_POS_BIAS[0] - 1e-3 and float(bias.max()) <= DOF_POS_BIAS[1] + 1e-3, (
+        f"setup_dof_pos_bias out of band: {float(bias.min())}..{float(bias.max())}"
+    )
+
+    # --- torque-RFI setup (configures the joint action term; read the flag/limit back) ----------
+    L.setup_torque_rfi(env, sampler=_sampler(env), enabled=True, rfi_lim=0.123)
+    assert jt._randomize_torque_rfi is True, "setup_torque_rfi did not enable torque RFI on the action term"
+    assert abs(jt._rfi_lim - 0.123) < 1e-6, f"setup_torque_rfi did not set rfi_lim: {jt._rfi_lim}"
+
+    return skipped
+
+
+def run_push_dr(env) -> None:
+    """Run the push DR terms and assert a push imparts root velocity (backend-agnostic read).
+
+    Covers BOTH the reset-stage ``randomize_push_schedule`` (+ a direct ``_push_robots``) AND the
+    step-stage ``apply_pushes`` (the schedule -> due-envs -> push flow that runs every step in
+    training), so the registered push term — not just the manager helper — is exercised.
+    """
+    idx = _env_ids(env)
+    L.randomize_push_schedule(
+        env, idx, sampler=_sampler(env), push_interval_s=[1.0, 1.0], max_push_vel=[5.0, 5.0], enabled=True
+    )
+    vel_before = env.simulator.robot_root_states[:, 7:9].clone()
+    env._push_robots(idx)
+    vel_after = env.simulator.robot_root_states[:, 7:9]
+    assert (vel_after - vel_before).abs().max() > 1e-3, "push did not change root velocity"
+
+    # apply_pushes (step term): drive the real schedule -> due -> push flow. apply_pushes' own
+    # configure() sets a [1s,1s] interval (=> interval_steps = round(1/dt)); set every env's counter to
+    # exactly that so due_envs() fires this step, making the push deterministic (not schedule-flaky).
+    state = env.randomization_manager.get_state("push_randomizer_state")
+    state.configure(enabled=True, push_interval_s=[1.0, 1.0], max_push_vel=[5.0, 5.0])
+    state.push_robot_counter[idx] = (state.push_interval_s[idx] / env.dt).to(torch.int)
+    vel_before = env.simulator.robot_root_states[:, 7:9].clone()
+    L.apply_pushes(env, sampler=_sampler(env), enabled=True, push_interval_s=[1.0, 1.0], max_push_vel=[5.0, 5.0])
+    vel_after = env.simulator.robot_root_states[:, 7:9]
+    assert (vel_after - vel_before).abs().max() > 1e-3, "apply_pushes did not change root velocity"
+
+
+def run_object_dr(env, reader: ModelReader) -> None:
+    """Run every object DR term against the first free body and assert each took effect.
+
+    Covers object mass, material (friction), inertia (physics-model fields via ``reader``) and
+    pose jitter (actor state, read directly). Asserts the scene actually has a free object.
+    """
+    idx = _env_ids(env)
+    free = env.simulator.object_registry.get_names_by_type(ObjectType.INDIVIDUAL)
+    assert free, "scene has no free (INDIVIDUAL) objects to randomize"
+    # Pass the backend-neutral registry object name (e.g. "free0"); each backend's reader resolves
+    # it to its own handle (MuJoCo body "free0_baseLink", gym actor, isaaclab RigidObject) by
+    # prefix-match. Resolving via a MuJoCo-only helper here would import mujoco on the Isaac envs.
+    name = free[0]
+
+    # --- object mass (add) ----------------------------------------------------------------------
+    before = reader.body_mass(name)
+    O.randomize_object_rigid_body_mass_startup(
+        env, idx, sampler=_sampler(env), mass_distribution_params=OBJ_MASS_ADD, object_names=[name]
+    )
+    after = reader.body_mass(name)
+    assert OBJ_MASS_ADD[0] - 1e-2 <= after - before <= OBJ_MASS_ADD[1] + 1e-2, (
+        f"object mass offset out of band: {before} -> {after}"
+    )
+
+    # --- object material (friction abs; + restitution on IsaacSim only) -------------------------
+    # Restitution is modelled only by IsaacSim (PhysX material slot 2); IsaacGym and MuJoCo ignore
+    # restitution_range entirely (they log a warning and set sliding friction only). So we pass a
+    # DISJOINT restitution band and assert it only when the reader declares restitution trusted —
+    # never where the backend would ignore the write (which would make the assert vacuous/false).
+    restitution_trusted = getattr(reader, "RESTITUTION_READBACK_TRUSTED", False)
+    restitution_range = OBJ_RESTITUTION if restitution_trusted else (0.0, 0.0)
+    before = reader.geom_friction_for_body(name)
+    rest_before = reader.restitution_for_body(name) if restitution_trusted else None
+    dyn_before = reader.dynamic_friction_for_body(name) if restitution_trusted else None
+    # Per-backend material config: each backend gets the channels it honors. friction band OBJ_FRICTION
+    # on all; restitution only where the reader trusts the read-back (IsaacSim) — elsewhere [0,0] / absent.
+    O.randomize_object_rigid_body_material_startup(
+        env,
+        idx,
+        sampler=_sampler(env),
+        object_names=[name],
+        material={
+            "isaacgym": {"friction": OBJ_FRICTION, "restitution": restitution_range},
+            "isaacsim": {
+                "static_friction": OBJ_FRICTION,
+                "dynamic_friction": OBJ_FRICTION,
+                "restitution": restitution_range,
+            },
+            "mujoco": {"sliding_friction": OBJ_FRICTION},
+        },
+    )
+    after = reader.geom_friction_for_body(name)
+    assert OBJ_FRICTION[0] - 1e-3 <= after <= OBJ_FRICTION[1] + 1e-3, f"object friction out of band: {after}"
+    assert abs(after - before) > 1e-3, "object friction unchanged"
+    if restitution_trusted and rest_before is not None and dyn_before is not None:
+        # Live PhysX restitution (material slot 2) must land in the disjoint band AND have changed.
+        rest_after = reader.restitution_for_body(name)
+        assert OBJ_RESTITUTION[0] - 1e-3 <= rest_after <= OBJ_RESTITUTION[1] + 1e-3, (
+            f"object restitution out of band: {rest_after}"
+        )
+        assert abs(rest_after - rest_before) > 1e-3, "object restitution unchanged"
+        # Dynamic friction (slot 1) was driven by the same disjoint OBJ_FRICTION band; verify live.
+        dyn_after = reader.dynamic_friction_for_body(name)
+        assert OBJ_FRICTION[0] - 1e-3 <= dyn_after <= OBJ_FRICTION[1] + 1e-3, (
+            f"object dynamic friction out of band: {dyn_after}"
+        )
+        assert abs(dyn_after - dyn_before) > 1e-3, "object dynamic friction unchanged"
+
+    # --- object inertia (scale Ixx only; Iyy/Izz + off-diagonals identity) ----------------------
+    inertia_before = reader.body_inertia(name)
+    O.randomize_object_rigid_body_inertia_startup(
+        env,
+        idx,
+        sampler=_sampler(env),
+        object_names=[name],
+        # Only Ixx is randomized; the other five components default to the identity scale [1.0, 1.0].
+        inertia_distribution_params_dict={"Ixx": OBJ_INERTIA_IXX_SCALE},
+    )
+    inertia_after = reader.body_inertia(name)
+    # reader.body_inertia returns the live diagonal (Ixx, Iyy, Izz) = [0], [1], [2].
+    assert OBJ_INERTIA_IXX_SCALE[0] - 1e-3 <= inertia_after[0] / inertia_before[0] <= OBJ_INERTIA_IXX_SCALE[1] + 1e-3, (
+        f"object Ixx scale out of band: {inertia_after[0] / inertia_before[0]}"
+    )
+    # Iyy/Izz were held at identity (1.0,1.0), so their live ratios must stay ~1.0 — a guard that
+    # the term scaled ONLY Ixx and did not bleed into the other principal moments (mirrors the
+    # CoM y/z guard above). Tolerance matches the Ixx band slack.
+    iyy_ratio = inertia_after[1] / inertia_before[1]
+    izz_ratio = inertia_after[2] / inertia_before[2]
+    assert abs(iyy_ratio - 1.0) < 1e-3 and abs(izz_ratio - 1.0) < 1e-3, (
+        f"object Iyy/Izz wrongly scaled: {iyy_ratio}, {izz_ratio}"
+    )
+
+    # --- object pose jitter (actor state; XY only, read directly) -------------------------------
+    st_before = env.simulator.get_actor_states([name], idx).clone()
+    O.jitter_object_pose_on_reset(env, idx, sampler=_sampler(env), xy_range=0.1, yaw_range=0.0, object_names=[name])
+    st_after = env.simulator.get_actor_states([name], idx)
+    assert (st_after[:, :2] - st_before[:, :2]).abs().max() > 1e-4, "object pose was not jittered"
+
+
+# --- distribution coverage: bands chosen so a gaussian truncates inside and a log_uniform stays
+#     positive; the signed range is invalid for log_uniform (must raise on every backend). --------
+GAUSS_BASE_MASS_ADD = {"kind": "gaussian", "low": 2.0, "high": 3.0}
+LOGU_LINK_MASS_SCALE = {"kind": "log_uniform", "low": 2.0, "high": 3.0}  # strictly positive -> valid
+SIGNED_LOGU_MASS_ADD = {"kind": "log_uniform", "low": -1.0, "high": 3.0}  # signed -> invalid (must raise)
+GAUSS_OBJ_MASS_ADD = {"kind": "gaussian", "low": 5.0, "high": 6.0}
+EXPLICIT_GAUSS_BASE_MASS = {"kind": "gaussian", "low": 2.0, "high": 3.0, "mean": 2.5, "std": 0.1}
+
+
+def _assert_damping_term_unsupported(env, idx, term, object_name: str) -> None:
+    try:
+        term(env, idx, sampler=_sampler(env), damping_range=(0.0, 0.05), object_names=[object_name])
+    except RandomizerNotSupportedError:
+        pass
+    else:
+        raise AssertionError(f"IsaacGym {term.__name__} should raise RandomizerNotSupportedError")
+
+
+def run_distribution_dr(env, reader: ModelReader) -> list[str]:
+    """Assert a non-uniform distribution leaf lands in the same band/marginal on every backend.
+
+    Covers, on the robot torso/link masses (always readable) and — where the scene has a free body —
+    object mass: (1) gaussian lands in-band on EVERY backend, including IsaacSim; (2) explicit (mean,
+    std) gaussian lands in-band; (3) log_uniform on a positive scale range works; (4) log_uniform on a
+    SIGNED range RAISES (a clean ValueError, not a silent NaN) on every backend; (5) material/friction
+    RAISES on any non-uniform distribution.
+
+    Returns the list of check labels SKIPPED on this backend (e.g. object checks on a robot-only
+    scene) so the caller's banner never claims an unverified field.
+    """
+    skipped: list[str] = []
+    idx = _env_ids(env)
+    torso = env.robot_config.torso_name
+
+    # (1) gaussian base mass (add): truncated to the band on every backend incl. IsaacSim.
+    before = reader.body_mass(torso)
+    L.randomize_mass_startup(
+        env,
+        idx,
+        sampler=_sampler(env),
+        enable_link_mass=False,
+        enable_base_mass=True,
+        added_mass_range=GAUSS_BASE_MASS_ADD,
+    )
+    after = reader.body_mass(torso)
+    lo, hi = cast("float", GAUSS_BASE_MASS_ADD["low"]), cast("float", GAUSS_BASE_MASS_ADD["high"])
+    assert lo - 1e-2 <= after - before <= hi + 1e-2, f"gaussian base mass offset out of band: {before} -> {after}"
+
+    # (2) explicit (mean, std) gaussian: also truncated to the band.
+    before = reader.body_mass(torso)
+    L.randomize_mass_startup(
+        env,
+        idx,
+        sampler=_sampler(env),
+        enable_link_mass=False,
+        enable_base_mass=True,
+        added_mass_range=EXPLICIT_GAUSS_BASE_MASS,
+    )
+    after = reader.body_mass(torso)
+    assert 2.0 - 1e-2 <= after - before <= 3.0 + 1e-2, (
+        f"explicit-(mean,std) gaussian base mass out of band: {before} -> {after}"
+    )
+
+    # (3) log_uniform link mass (scale, strictly positive): lands in the positive band.
+    link_names = list(env.robot_config.randomize_link_body_names or [])
+    assert link_names, "robot config declares no randomize_link_body_names"
+    link0 = link_names[0]
+    before = reader.body_mass(link0)
+    L.randomize_mass_startup(
+        env,
+        idx,
+        sampler=_sampler(env),
+        enable_link_mass=True,
+        link_mass_range=LOGU_LINK_MASS_SCALE,
+        enable_base_mass=False,
+    )
+    after = reader.body_mass(link0)
+    lo, hi = cast("float", LOGU_LINK_MASS_SCALE["low"]), cast("float", LOGU_LINK_MASS_SCALE["high"])
+    assert lo - 1e-3 <= after / before <= hi + 1e-3, f"log_uniform link mass scale out of band: {after / before}"
+
+    # (4) log_uniform on a SIGNED range must RAISE (clean ValueError) on every backend — no NaN.
+    try:
+        L.randomize_mass_startup(
+            env,
+            idx,
+            sampler=_sampler(env),
+            enable_link_mass=False,
+            enable_base_mass=True,
+            added_mass_range=SIGNED_LOGU_MASS_ADD,
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("log_uniform on a signed range should raise ValueError, but did not")
+
+    # (5) gaussian FRICTION lands in-band on every backend (continuous on IsaacGym/MuJoCo;
+    #     64-bucket quantile staircase on IsaacSim — both marginal-matched to the same band). Uses
+    #     GAUSS_FRICTION (disjoint from the ROBOT_FRICTION band run_robot_dr already applied) so the
+    #     "took effect" check is unambiguous even though the keyed sampler reuses the same uniform.
+    before = reader.geom_friction_for_body(torso)
+    gauss_friction = {"kind": "gaussian", "low": GAUSS_FRICTION[0], "high": GAUSS_FRICTION[1]}
+    L.randomize_friction_startup(env, idx, sampler=_sampler(env), friction_range=gauss_friction)
+    after = reader.geom_friction_for_body(torso)
+    assert GAUSS_FRICTION[0] - 1e-3 <= after <= GAUSS_FRICTION[1] + 1e-3, f"gaussian friction out of band: {after}"
+    assert abs(after - before) > 1e-3, "gaussian friction unchanged"
+
+    # log_uniform friction on a SIGNED range must still RAISE (positivity guard) on every backend.
+    try:
+        L.randomize_friction_startup(
+            env, idx, sampler=_sampler(env), friction_range={"kind": "log_uniform", "low": -0.5, "high": 0.5}
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("log_uniform friction on a signed range should raise ValueError, but did not")
+
+    # A typo'd distribution kind must still raise (fail-fast) at spec construction.
+    try:
+        L.randomize_friction_startup(
+            env, idx, sampler=_sampler(env), friction_range={"kind": "gaussain", "low": 0.5, "high": 0.7}
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unknown distribution on friction should raise ValueError, but did not")
+
+    # Object-mass gaussian (only if the scene has a free body) — proves the object path honors it too.
+    free = env.simulator.object_registry.get_names_by_type(ObjectType.INDIVIDUAL)
+    if free:
+        name = free[0]
+        before = reader.body_mass(name)
+        O.randomize_object_rigid_body_mass_startup(
+            env, idx, sampler=_sampler(env), mass_distribution_params=GAUSS_OBJ_MASS_ADD, object_names=[name]
+        )
+        after = reader.body_mass(name)
+        lo, hi = cast("float", GAUSS_OBJ_MASS_ADD["low"]), cast("float", GAUSS_OBJ_MASS_ADD["high"])
+        assert lo - 1e-2 <= after - before <= hi + 1e-2, f"gaussian object mass offset out of band: {before} -> {after}"
+    else:
+        skipped.append("object-mass gaussian (robot-only scene)")
+
+    # IsaacGym has no runtime body-damping path; assert BOTH damping terms raise rather than silently
+    # no-op (covers linear AND angular — only linear is exercised behaviorally elsewhere).
+    if free and env.simulator.get_simulator_type() == SimulatorType.ISAACGYM:
+        for term in (O.randomize_object_linear_damping_startup, O.randomize_object_angular_damping_startup):
+            _assert_damping_term_unsupported(env, idx, term, free[0])
+
+    # Robot material term (IsaacSim-only; distinct from randomize_friction_startup). Friction lands in
+    # band per the reader; restitution only asserted where the reader trusts it (gated above).
+    if env.simulator.get_simulator_type() == SimulatorType.ISAACSIM:
+        before = reader.geom_friction_for_body(torso)
+        L.randomize_robot_rigid_body_material_startup(
+            env,
+            idx,
+            sampler=_sampler(env),
+            static_friction_range=ROBOT_MATERIAL_FRICTION,
+            dynamic_friction_range=ROBOT_MATERIAL_FRICTION,
+            restitution_range=(0.0, 0.0),
+        )
+        after = reader.geom_friction_for_body(torso)
+        assert ROBOT_MATERIAL_FRICTION[0] - 1e-3 <= after <= ROBOT_MATERIAL_FRICTION[1] + 1e-3, (
+            f"robot material friction out of band: {after}"
+        )
+        assert abs(after - before) > 1e-3, "robot material friction unchanged"
+
+    return skipped

--- a/src/holosoma/tests/simulators/behavior_assert.py
+++ b/src/holosoma/tests/simulators/behavior_assert.py
@@ -1244,22 +1244,6 @@ def main() -> int:
         print(f"SKIP: scenario '{args.scenario}' needs --num-envs>={min_envs} (got {args.num_envs})")
         return SKIP_EXIT_CODE
 
-    # The dr-*-governs scenarios drive the object physics-DR terms (mass/material/damping). Those
-    # terms live in the cross-backend object-DR feature, which is a follow-up branch to scene
-    # objects; on the scene-objects branch they are absent, so these scenarios skip cleanly here
-    # and run once the object-DR branch lands. (No-op when object-DR is present.)
-    if args.scenario in ("dr-friction-governs", "dr-damping-governs"):
-        from importlib.util import find_spec
-
-        mod = find_spec("holosoma.managers.randomization.terms.objects")
-        has_object_dr = mod is not None and hasattr(
-            __import__("holosoma.managers.randomization.terms.objects", fromlist=["_"]),
-            "randomize_object_rigid_body_material_startup",
-        )
-        if not has_object_dr:
-            print(f"SKIP: scenario '{args.scenario}' needs the cross-backend object-DR feature (follow-up branch)")
-            return SKIP_EXIT_CODE
-
     # Twin scenarios spawn the one-link `onelink-box` robot (not g1) carrying a per-scenario
     # link_physics that mirrors the twin object's PhysicsConfig. A non-twin scenario keeps --robot.
     twin_link_physics = _twin_robot_link_physics()

--- a/src/holosoma/tests/simulators/dr_matrix_assert.py
+++ b/src/holosoma/tests/simulators/dr_matrix_assert.py
@@ -1,0 +1,305 @@
+"""Headless cross-backend domain-randomization (DR) assertion harness.
+
+Builds ONE real, fully-managed locomotion env for a chosen backend (real action_manager +
+randomization_manager — NO shims), then runs the full matrix of robot + object DR terms against
+it and asserts each took effect, reading the mutated physics-model values back through that
+backend's native API. Exits 0 on success, non-zero with a message on failure — so it works as a
+live integration test under each backend's launcher (MuJoCo venv, IsaacGym setup, IsaacSim
+DISPLAY/EULA), the same way scene_spawn_assert.py does for spawning.
+
+Usage:
+  python dr_matrix_assert.py --simulator mujoco                 # ClassicBackend, 1 env, cpu
+  python dr_matrix_assert.py --simulator mjwarp   --num-envs 4  # WarpBackend, cuda
+  python dr_matrix_assert.py --simulator isaacgym --num-envs 4  # IsaacGym, cuda
+  python dr_matrix_assert.py --simulator isaacsim --num-envs 4  # IsaacSim, cuda
+
+The DR term calls are shared across backends (in _dr_matrix.py); only the read-back of the
+mutated model field differs, so each backend supplies a small reader object below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from tests.simulators._dr_matrix import ModelReader
+
+# This file lives in tests/simulators/, which contains an ``isaacsim/`` subpackage. Run as a
+# script, that dir lands on sys.path[0] and shadows the real IsaacSim ``isaacsim`` package. Drop
+# it (mirrors scene_spawn_assert.py); the package is imported via PYTHONPATH=src/holosoma instead.
+# Only when run as a script — when imported (e.g. by the in-process classic test) sys.path[0] is
+# the caller's, which must not be mutated.
+if __name__ == "__main__" and sys.path and sys.path[0].endswith("tests/simulators"):
+    sys.path.pop(0)
+
+# IsaacGym MUST be imported before torch. Importing it here (best-effort) guarantees the ordering
+# for the isaacgym backend before _dr_matrix (which imports torch) is pulled in below.
+try:
+    import isaacgym  # noqa: F401
+except ImportError:
+    pass
+
+
+# ---------------------------------------------------------------------------------------------
+# Backend-specific physics-model read-back. Each exposes the ModelReader interface used by
+# _dr_matrix (body_mass / geom_friction_for_body / body_inertia / body_com), reading env 0.
+# ---------------------------------------------------------------------------------------------
+class _MujocoReader:
+    """MuJoCo classic (float64 numpy on backend.model) or Warp (per-world warp_model_bridge)."""
+
+    # MuJoCo writes CoM straight into ``body_ipos`` and reads it back from the same field, so the
+    # base-CoM band assertion reads the integrated value and is trusted.
+    COM_READBACK_TRUSTED = True
+    # MuJoCo material DR sets sliding friction only; restitution is not modelled the same way, so
+    # the restitution band assertion is gated off for this backend (see run_object_dr).
+    RESTITUTION_READBACK_TRUSTED = False
+
+    def __init__(self, sim):
+        import mujoco
+
+        self._mj = mujoco
+        self._sim = sim
+        self._m = sim.backend.model  # CPU model for name->id resolution (both backends)
+        self._warp = getattr(sim.backend, "warp_model_bridge", None)
+
+    def _bid(self, body_name: str) -> int:
+        # Robot body (possibly "robot_"-prefixed), or a registry object name whose MuJoCo body is
+        # resolved via the object helper (e.g. "free0" -> "free0_baseLink").
+        for cand in (body_name, "robot_" + body_name):
+            bid = self._mj.mj_name2id(self._m, self._mj.mjtObj.mjOBJ_BODY, cand)
+            if bid != -1:
+                return bid
+        from holosoma.managers.randomization.terms.objects import _mujoco_object_body_names
+
+        obj_bodies = _mujoco_object_body_names(self._sim, body_name)
+        assert obj_bodies, f"body '{body_name}' not found in model"
+        return self._mj.mj_name2id(self._m, self._mj.mjtObj.mjOBJ_BODY, obj_bodies[0])
+
+    def _geom0(self, body_name: str) -> int:
+        bid = self._bid(body_name)
+        geoms = [g for g in range(self._m.ngeom) if self._m.geom_bodyid[g] == bid]
+        assert geoms, f"body '{body_name}' has no geoms"
+        return geoms[0]
+
+    def body_mass(self, body_name: str) -> float:
+        bid = self._bid(body_name)
+        return float(self._warp.body_mass[0, bid]) if self._warp is not None else float(self._m.body_mass[bid])
+
+    def geom_friction_for_body(self, body_name: str) -> float:
+        g = self._geom0(body_name)
+        return (
+            float(self._warp.geom_friction[0, g, 0]) if self._warp is not None else float(self._m.geom_friction[g, 0])
+        )
+
+    def body_inertia(self, body_name: str):
+        bid = self._bid(body_name)
+        src = self._warp.body_inertia[0, bid] if self._warp is not None else self._m.body_inertia[bid]
+        return tuple(float(x) for x in src)
+
+    def body_com(self, body_name: str):
+        bid = self._bid(body_name)
+        src = self._warp.body_ipos[0, bid] if self._warp is not None else self._m.body_ipos[bid]
+        return tuple(float(x) for x in src)
+
+
+class _IsaacGymReader:
+    """IsaacGym per-actor rigid-body / rigid-shape properties (env 0)."""
+
+    def __init__(self, sim):
+        self._sim = sim
+        self._gym = sim.gym
+        self._env = sim.envs[0]
+        self._robot = sim.robot_handles[0]
+        self._body_list = sim._body_list
+
+    def _is_robot_body(self, body_name: str) -> bool:
+        return body_name in self._body_list or ("robot_" + body_name) in self._body_list
+
+    def _object_actor(self, body_name: str):
+        # Object bodies are separate actors; map the object's root-body name to its handle.
+        # _dr_matrix passes the object's first body name (e.g. "free0_baseLink"); the registry
+        # key is the object name (e.g. "free0"). Match by prefix.
+        for name, handles in self._sim.object_handles.items():
+            if body_name == name or body_name.startswith(name):
+                return handles[0]
+        raise AssertionError(f"no object actor for body '{body_name}'")
+
+    def body_mass(self, body_name: str) -> float:
+        if self._is_robot_body(body_name):
+            idx = self._body_list.index(body_name if body_name in self._body_list else "robot_" + body_name)
+            props = self._gym.get_actor_rigid_body_properties(self._env, self._robot)
+            return float(props[idx].mass)
+        # Object: additive mass DR writes EACH body, so compare the per-body[0] value.
+        props = self._gym.get_actor_rigid_body_properties(self._env, self._object_actor(body_name))
+        return float(props[0].mass)
+
+    def geom_friction_for_body(self, body_name: str) -> float:
+        actor = self._robot if self._is_robot_body(body_name) else self._object_actor(body_name)
+        props = self._gym.get_actor_rigid_shape_properties(self._env, actor)
+        return float(props[0].friction)
+
+    def body_inertia(self, body_name: str):
+        actor = self._robot if self._is_robot_body(body_name) else self._object_actor(body_name)
+        props = self._gym.get_actor_rigid_body_properties(self._env, actor)
+        inertia = props[0].inertia
+        return (float(inertia.x.x), float(inertia.y.y), float(inertia.z.z))
+
+    # IsaacGym base-CoM read-back is NOT trusted by this harness — see ``COM_READBACK_TRUSTED``.
+    COM_READBACK_TRUSTED = False
+    # IsaacGym material DR sets friction only; restitution_range is ignored (logs a warning), so
+    # the restitution band assertion is gated off for this backend (see run_object_dr).
+    RESTITUTION_READBACK_TRUSTED = False
+
+    def body_com(self, body_name: str):
+        # Read the LIVE per-actor CoM straight off the gym property struct — NO add-back of the
+        # term's recorded ``_base_com_bias`` (that previous "reader" made after-minus-before equal
+        # the exact value the term sampled, a tautology that stayed green even if the write failed).
+        #
+        # Whether ``get_actor_rigid_body_properties`` reflects a prior ``set_..._properties`` CoM
+        # write is undocumented and version-fragile in IsaacGym Preview: the SAME struct's ``.mass``
+        # field DOES read back (mass DR + scene_spawn_assert.py rely on it), but the codebase has
+        # long asserted ``.com`` does not (it may return the asset-original, and recomputeInertia
+        # interacts with it). The rigid-body STATE tensor is [.,13] = pos/rot/vel/angvel (world
+        # frame) and carries no body-frame CoM offset, so it cannot expose CoM either. We therefore
+        # do NOT claim verification for this backend (see COM_READBACK_TRUSTED) and the caller skips
+        # the band assertion.
+        idx = self._body_list.index(body_name if body_name in self._body_list else "robot_" + body_name)
+        props = self._gym.get_actor_rigid_body_properties(self._env, self._robot)
+        c = props[idx].com
+        return (float(c.x), float(c.y), float(c.z))
+
+
+class _IsaacSimReader:
+    """IsaacSim physx-view read-back via the isaaclab assets (env 0)."""
+
+    # PhysX get_coms reflects the CoM write, so the base-CoM band assertion is trusted.
+    COM_READBACK_TRUSTED = True
+    # IsaacSim is the only backend that models restitution (PhysX material slot 2), so the
+    # restitution band assertion is enabled here (see run_object_dr).
+    RESTITUTION_READBACK_TRUSTED = True
+
+    def __init__(self, sim):
+        self._sim = sim
+        self._scene = sim.scene
+
+    def _asset_and_body(self, body_name: str):
+        """Return (asset, body_index). Object names (from the registry) resolve to the matching
+        RigidObject (single-body, index 0); otherwise the name is a robot body on the 'robot'
+        articulation. Objects are checked FIRST because Articulation.find_bodies RAISES (not
+        returns empty) on a non-matching name."""
+        for name in self._scene.rigid_objects:
+            if body_name == name or body_name.startswith(name):
+                return self._scene[name], 0
+        robot = self._scene["robot"]
+        ids, _ = robot.find_bodies([body_name])
+        assert ids, f"could not resolve body '{body_name}' on the robot or any object"
+        return robot, ids[0]
+
+    @staticmethod
+    def _row(view, bidx: int):
+        """Per-body row for env 0. The robot Articulation view is [num_envs, num_bodies, k]; the
+        single-body RigidObject view is [num_envs, k] (no body axis) — handle both."""
+        return view[0, bidx] if view.ndim == 3 else view[0]
+
+    def body_mass(self, body_name: str) -> float:
+        asset, bidx = self._asset_and_body(body_name)
+        masses = asset.root_physx_view.get_masses()  # [num_envs, num_bodies] or [num_envs]
+        return float(masses[0, bidx] if masses.ndim == 2 else masses[0])
+
+    def geom_friction_for_body(self, body_name: str) -> float:
+        asset, _bidx = self._asset_and_body(body_name)
+        # [num_envs, num_shapes, 3] = (static, dynamic, restitution)
+        mats = asset.root_physx_view.get_material_properties()
+        return float(mats[0, 0, 0])
+
+    def dynamic_friction_for_body(self, body_name: str) -> float:
+        asset, _bidx = self._asset_and_body(body_name)
+        # [num_envs, num_shapes, 3] = (static, dynamic, restitution) -> dynamic friction at slot 1.
+        mats = asset.root_physx_view.get_material_properties()
+        return float(mats[0, 0, 1])
+
+    def restitution_for_body(self, body_name: str) -> float:
+        asset, _bidx = self._asset_and_body(body_name)
+        # [num_envs, num_shapes, 3] = (static, dynamic, restitution) -> restitution at slot 2.
+        mats = asset.root_physx_view.get_material_properties()
+        return float(mats[0, 0, 2])
+
+    def body_inertia(self, body_name: str):
+        asset, bidx = self._asset_and_body(body_name)
+        row = self._row(asset.root_physx_view.get_inertias(), bidx)  # 9 = row-major 3x3
+        return (float(row[0]), float(row[4]), float(row[8]))  # Ixx, Iyy, Izz
+
+    def body_com(self, body_name: str):
+        asset, bidx = self._asset_and_body(body_name)
+        row = self._row(asset.root_physx_view.get_coms(), bidx)  # [..,7] (pos+quat) or [..,3]
+        return (float(row[0]), float(row[1]), float(row[2]))
+
+
+_READERS = {
+    "mujoco": _MujocoReader,
+    "mjwarp": _MujocoReader,
+    "isaacgym": _IsaacGymReader,
+    "isaacsim": _IsaacSimReader,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cross-backend DR matrix assertion harness.")
+    parser.add_argument("--simulator", required=True, choices=list(_READERS))
+    parser.add_argument("--num-envs", type=int, default=None, help="default: 1 for mujoco, 4 otherwise")
+    parser.add_argument("--result-file", default=None, help="write 'OK' here after all checks pass")
+    args = parser.parse_args()
+
+    from holosoma.config_values import simulator as sim_values
+
+    sim_cfg = getattr(sim_values, args.simulator)
+    num_envs = args.num_envs if args.num_envs is not None else (1 if args.simulator == "mujoco" else 4)
+    device = "cpu" if args.simulator == "mujoco" else "cuda:0"
+
+    # Imported here (not at top): for isaacgym/isaacsim, build_full_env's training_context must
+    # initialize the launcher first; _dr_matrix imports torch, which must come after that init.
+    import traceback
+
+    from tests.simulators import _dr_matrix as dr
+
+    with dr.build_full_env(sim_cfg, num_envs=num_envs, device=device) as env:
+        if args.simulator == "mjwarp":
+            # Object inertia field isn't in the loco preset; expand every field the matrix touches.
+            env.simulator.prepare_randomization_fields(["body_mass", "geom_friction", "body_ipos", "body_inertia"])
+        reader = cast("ModelReader", _READERS[args.simulator](env.simulator))
+        # Run each stage inside an explicit try so a failure is LOGGED with a traceback before the
+        # with-block exits — IsaacSim's close_simulation_app (on __exit__) can hard-terminate the
+        # process and swallow a propagating exception, leaving exit 0 and no diagnostic otherwise.
+        try:
+            skipped = dr.run_robot_dr(env, reader) or []
+            dr.run_push_dr(env)
+            dr.run_object_dr(env, reader)
+            skipped += dr.run_distribution_dr(env, reader) or []
+        except BaseException:
+            print("DR MATRIX FAILED:\n" + traceback.format_exc(), flush=True)
+            return 1
+        # Emit the success sentinel HERE, INSIDE the with-block — anything printed after teardown
+        # is unreliable on IsaacSim. The result-file is the authoritative success signal; the test
+        # checks it, not the exit code.
+        #
+        # Scope the banner honestly: only claim "all verified" when nothing was skipped. Any check
+        # the backend cannot read back live (e.g. IsaacGym base CoM) is listed as NOT-verified so
+        # the banner never claims a field it did not actually integrate-check.
+        if skipped:
+            msg = (
+                f"DR MATRIX OK: {args.simulator} ({num_envs} env(s)) — robot + push + object DR "
+                f"verified, EXCEPT not-verified on this backend: {', '.join(skipped)}"
+            )
+        else:
+            msg = f"DR MATRIX OK: {args.simulator} ({num_envs} env(s)) — robot + push + object DR all verified"
+        print(msg, flush=True)
+        if args.result_file:
+            with open(args.result_file, "w") as f:
+                f.write("OK\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/isaacgym/test_dr_matrix_isaacgym.py
+++ b/src/holosoma/tests/simulators/isaacgym/test_dr_matrix_isaacgym.py
@@ -1,0 +1,45 @@
+"""Full cross-backend DR matrix on IsaacGym (GPU, multi-env), one sim per subprocess.
+
+Runs the dr_matrix_assert.py harness under IsaacGym in its own process (IsaacGym segfaults on a
+second gymapi sim per process): it builds ONE real, fully-managed locomotion env (real
+action_manager + randomization_manager, no shims) and asserts every robot + object DR term took
+effect, reading back the native gym actor rigid-body / rigid-shape properties (mass, friction,
+inertia Mat33, com). The MuJoCo columns are under ../mujoco/; IsaacSim under ../isaacsim/.
+
+Unmarked (conftest's directory rule applies ``isaacgym``; the CI job selects ``-m isaacgym``)
+collects it and it skips cleanly elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("isaacgym")
+from holosoma.utils.safe_torch_import import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("IsaacGym requires a CUDA device", allow_module_level=True)
+
+from tests.simulators._run_harness import run_harness
+
+_HARNESS = Path(__file__).resolve().parents[1] / "dr_matrix_assert.py"
+
+
+def test_dr_matrix_isaacgym(tmp_path):
+    # Trust the result-file the harness writes after all checks pass (uniform with the other
+    # backends, whose teardown can mask the exit code), not just the subprocess return code.
+    result_file = tmp_path / "dr_matrix_result.txt"
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--num-envs",
+        "4",
+        "--result-file",
+        str(result_file),
+        label="isaacgym DR matrix",
+        timeout=900,
+        result_file=result_file,
+    )

--- a/src/holosoma/tests/simulators/isaacgym/test_scene_spawn_isaacgym.py
+++ b/src/holosoma/tests/simulators/isaacgym/test_scene_spawn_isaacgym.py
@@ -89,3 +89,24 @@ def test_scene_spawn_multi_env(scene):
         label=f"isaacgym/{scene} (num_envs=4)",
         timeout=600,
     )
+
+
+# Live object physics-DR on IsaacGym: `--object-dr` runs the mass + material DR terms after
+# prepare_sim and asserts, against the real gym actor API, that mass increased by the configured
+# additive band on every (object, env) and that an object_names subset narrows targeting.
+# `free-and-static` gives two free bodies (per-env addressing + subset isolation) plus a fixed
+# pillar (must be excluded).
+@pytest.mark.parametrize("num_envs", ["1", "4"])
+def test_object_dr_dispatch(num_envs):
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--scene",
+        "free-and-static",
+        "--num-envs",
+        num_envs,
+        "--object-dr",
+        label=f"isaacgym object-DR (num_envs={num_envs})",
+        timeout=600,
+    )

--- a/src/holosoma/tests/simulators/isaacsim/test_dr_matrix_isaacsim.py
+++ b/src/holosoma/tests/simulators/isaacsim/test_dr_matrix_isaacsim.py
@@ -1,0 +1,47 @@
+"""Full cross-backend DR matrix on IsaacSim (GPU, multi-env), one sim per subprocess.
+
+Runs the dr_matrix_assert.py harness under IsaacSim in its own process (IsaacSim's
+SimulationContext is a process singleton — one sim per process): it builds ONE real,
+fully-managed locomotion env (real action_manager + randomization_manager, no shims) and asserts
+every robot + object DR term took effect, reading back the isaaclab physx-view properties
+(``get_masses`` / ``get_material_properties`` / ``get_inertias`` / ``get_coms``). The MuJoCo
+columns are under ../mujoco/; IsaacGym under ../isaacgym/.
+
+Marked ``isaacsim`` so only the IsaacSim CI job (``-m isaacsim``) collects it.
+``importorskip("isaaclab")``/CUDA-gated otherwise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.isaacsim
+
+pytest.importorskip("isaaclab")
+torch = pytest.importorskip("torch")
+if not torch.cuda.is_available():
+    pytest.skip("IsaacSim requires a CUDA device", allow_module_level=True)
+
+from tests.simulators._run_harness import run_harness  # noqa: E402
+
+_HARNESS = Path(__file__).resolve().parents[1] / "dr_matrix_assert.py"
+
+
+def test_dr_matrix_isaacsim(tmp_path):
+    # IsaacSim's app teardown can hard-terminate the process (masking the exit code and swallowing
+    # late stdout), so trust the result-file the harness writes AFTER all checks pass, not rc.
+    result_file = tmp_path / "dr_matrix_result.txt"
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--num-envs",
+        "4",
+        "--result-file",
+        str(result_file),
+        label="isaacsim DR matrix",
+        timeout=900,
+        result_file=result_file,
+    )

--- a/src/holosoma/tests/simulators/mujoco/test_dr_matrix_classic.py
+++ b/src/holosoma/tests/simulators/mujoco/test_dr_matrix_classic.py
@@ -1,0 +1,34 @@
+"""Full cross-backend DR matrix on the MuJoCo ClassicBackend (CPU, single-env).
+
+Builds ONE real, fully-managed locomotion env (real action_manager + randomization_manager, no
+shims) and runs every robot + object DR term against it via the shared ``_dr_matrix`` checks,
+reading mutated fields back through the ``dr_matrix_assert`` MuJoCo reader. This is the
+classic-CPU column of the matrix; the GPU columns (mjwarp / isaacgym / isaacsim) run the SAME
+``dr_matrix_assert`` harness in a subprocess under their own launcher.
+
+The MuJoCo ClassicBackend is safe to build in-process, so this runs the harness pieces directly
+(no subprocess) and needs no CUDA — it executes in the MuJoCo (hsmujoco) CPU env.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("mujoco")
+
+# MuJoCo ClassicBackend (CPU) only.
+pytestmark = pytest.mark.mujoco_classic
+
+from holosoma.config_values import simulator as sim_values  # noqa: E402
+from tests.simulators import _dr_matrix as dr  # noqa: E402
+from tests.simulators.dr_matrix_assert import _MujocoReader  # noqa: E402
+
+
+def test_dr_matrix_classic_cpu():
+    with dr.build_full_env(sim_values.mujoco, num_envs=1, device="cpu") as env:
+        reader = _MujocoReader(env.simulator)
+        dr.run_robot_dr(env, reader)
+        dr.run_push_dr(env)
+        dr.run_object_dr(env, reader)
+        dr.run_distribution_dr(env, reader)

--- a/src/holosoma/tests/simulators/mujoco/test_dr_matrix_warp.py
+++ b/src/holosoma/tests/simulators/mujoco/test_dr_matrix_warp.py
@@ -1,0 +1,47 @@
+"""Full cross-backend DR matrix on the MuJoCo WarpBackend (GPU, multi-env), one sim per process.
+
+Runs the dr_matrix_assert.py harness under the MuJoCo-Warp backend in its own process: it builds
+ONE real, fully-managed locomotion env (real action_manager + randomization_manager, no shims)
+and asserts every robot + object DR term took effect, reading back the per-world
+``warp_model_bridge``. The classic-CPU column runs the same harness in-process
+(test_dr_matrix_classic.py); the Isaac columns live under ../isaacgym/ and ../isaacsim/.
+
+Skipped without CUDA / the MuJoCo-Warp stack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("mujoco")
+
+# MuJoCo WarpBackend (CUDA) only.
+pytestmark = pytest.mark.mujoco_warp
+
+if not torch.cuda.is_available():
+    pytest.skip("WarpBackend multi-env tests require a CUDA device", allow_module_level=True)
+
+from tests.simulators._run_harness import run_harness  # noqa: E402
+
+_HARNESS = Path(__file__).resolve().parents[1] / "dr_matrix_assert.py"
+
+
+def test_dr_matrix_warp(tmp_path):
+    # Trust the result-file the harness writes after all checks pass (uniform with the other
+    # backends, whose teardown can mask the exit code), not just the subprocess return code.
+    result_file = tmp_path / "dr_matrix_result.txt"
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--num-envs",
+        "4",
+        "--result-file",
+        str(result_file),
+        label="mjwarp DR matrix",
+        timeout=900,
+        result_file=result_file,
+    )

--- a/src/holosoma/tests/simulators/mujoco/test_object_dr_classic_cpu.py
+++ b/src/holosoma/tests/simulators/mujoco/test_object_dr_classic_cpu.py
@@ -1,0 +1,192 @@
+"""Live CPU (ClassicBackend, single-env) tests for cross-backend object physics DR.
+
+The object DR terms (``randomize_object_rigid_body_{mass,material,inertia}_startup``) route
+all MuJoCo work through the shared ``randomize_field`` chokepoint. These tests prove the
+ClassicBackend branch of that path mutates the live single-env ``mujoco.MjModel`` fields
+(``body_mass`` / ``geom_friction`` / ``body_inertia``) in place — one sample, but real — so
+classic CPU is usable for sim2sim robustness checks, reproducing a randomized instance, and
+CPU-only CI. The GPU/multi-env analogue lives in test_object_dr_warp.py.
+
+Unlike the Warp path, the ClassicBackend needs NO field expansion: it writes the one CPU
+model field directly (the ``@mujoco_required_field`` attribute still names the field for the
+term, but ``randomize_field`` skips expansion/validation when not on the Warp backend).
+
+Runs in the MuJoCo (hsmujoco) CPU env — no CUDA required; mirrors the builder in
+test_object_observations_live.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("mujoco")
+
+# MuJoCo ClassicBackend (CPU) only.
+pytestmark = pytest.mark.mujoco_classic
+
+from holosoma.config_types.scene import RigidObjectConfig, SceneConfig  # noqa: E402
+from holosoma.managers.randomization.terms.objects import (  # noqa: E402
+    _mujoco_object_geom_ids,
+    randomize_object_rigid_body_inertia_startup,
+    randomize_object_rigid_body_mass_startup,
+    randomize_object_rigid_body_material_startup,
+)
+from tests.simulators._dr_matrix import _sampler  # noqa: E402
+from tests.simulators.mujoco._build import build_classic_sim, env_shell, object_body_id  # noqa: E402
+
+SMALL_BOX = "holosoma/data/scene_objects/boxes/small_box.urdf"
+_IDENTITY_OFF_DIAG = {"Ixy": (1.0, 1.0), "Iyz": (1.0, 1.0), "Ixz": (1.0, 1.0)}
+
+
+def test_object_mass_randomized_classic_cpu():
+    sim = build_classic_sim(
+        SceneConfig(rigid_objects={"box": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.0, 0.6])})
+    )
+    bid = object_body_id(sim, "box")
+    before = float(sim.backend.model.body_mass[bid])
+
+    env = env_shell(sim, 1)
+    randomize_object_rigid_body_mass_startup(
+        env, torch.tensor([0]), sampler=_sampler(env), mass_distribution_params=(5.0, 6.0)
+    )
+
+    after = float(sim.backend.model.body_mass[bid])
+    # operation="add": the live model mass picked up an offset inside the configured band
+    # (a no-op / wrong-backend write would leave it at the URDF default).
+    assert 5.0 - 1e-3 <= after - before <= 6.0 + 1e-3, f"mass offset out of band: {before} -> {after}"
+
+
+def test_object_friction_randomized_classic_cpu():
+    sim = build_classic_sim(
+        SceneConfig(rigid_objects={"box": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.0, 0.6])})
+    )
+    geom_ids = _mujoco_object_geom_ids(sim, "box")
+    assert geom_ids, "object 'box' resolved to no geoms (unnamed-geom resolution failure)"
+    g0 = geom_ids[0]
+    before = float(sim.backend.model.geom_friction[g0, 0])
+
+    env = env_shell(sim, 1)
+    randomize_object_rigid_body_material_startup(
+        env,
+        torch.tensor([0]),
+        sampler=_sampler(env),
+        material={"mujoco": {"sliding_friction": (0.2, 0.3)}},
+    )
+
+    after = float(sim.backend.model.geom_friction[g0, 0])
+    # operation="abs": the live model now sits inside the requested band, changed from default.
+    assert 0.2 - 1e-4 <= after <= 0.3 + 1e-4, f"friction out of band: {after}"
+    assert abs(after - before) > 1e-3, "friction unchanged"
+
+
+def test_object_inertia_randomized_classic_cpu():
+    sim = build_classic_sim(
+        SceneConfig(rigid_objects={"box": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.0, 0.6])})
+    )
+    bid = object_body_id(sim, "box")
+    before = sim.backend.model.body_inertia[bid].copy()  # [Ixx, Iyy, Izz] principal moments
+
+    env = env_shell(sim, 1)
+    randomize_object_rigid_body_inertia_startup(
+        env,
+        torch.tensor([0]),
+        sampler=_sampler(env),
+        inertia_distribution_params_dict={
+            "Ixx": (2.0, 3.0),
+            "Iyy": (1.0, 1.0),
+            "Izz": (1.0, 1.0),
+            **_IDENTITY_OFF_DIAG,
+        },
+    )
+
+    after = sim.backend.model.body_inertia[bid]
+    # operation="scale": Ixx scaled into [2, 3]x; Iyy/Izz left at 1.0x (unchanged).
+    assert 2.0 - 1e-4 <= after[0] / before[0] <= 3.0 + 1e-4, f"Ixx scale out of band: {after[0] / before[0]}"
+    assert abs(after[1] - before[1]) < 1e-9 and abs(after[2] - before[2]) < 1e-9, "Iyy/Izz wrongly scaled"
+
+
+def test_object_mass_dr_multi_object_isolation_classic_cpu():
+    """Randomizing one object's mass must not touch the other object's mass (single env)."""
+    sim = build_classic_sim(
+        SceneConfig(
+            rigid_objects={
+                "box_a": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.0, 0.6]),
+                "box_b": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.3, 0.6]),
+            }
+        )
+    )
+    bid_a, bid_b = object_body_id(sim, "box_a"), object_body_id(sim, "box_b")
+    before_a = float(sim.backend.model.body_mass[bid_a])
+    before_b = float(sim.backend.model.body_mass[bid_b])
+
+    env = env_shell(sim, 1)
+    randomize_object_rigid_body_mass_startup(
+        env, torch.tensor([0]), sampler=_sampler(env), mass_distribution_params=(5.0, 6.0), object_names=["box_a"]
+    )
+
+    assert abs(float(sim.backend.model.body_mass[bid_a]) - before_a) > 1e-3, "box_a mass should have changed"
+    assert abs(float(sim.backend.model.body_mass[bid_b]) - before_b) < 1e-9, (
+        "box_b mass leaked — per-object targeting broken"
+    )
+
+
+def test_object_inertia_off_diagonal_warns_classic_cpu():
+    """A non-identity off-diagonal range is ignored (MuJoCo stores diagonal moments) but warns.
+
+    The term logs via loguru (not stdlib logging), so capture it with a temporary sink.
+    """
+    from loguru import logger
+
+    sim = build_classic_sim(
+        SceneConfig(rigid_objects={"box": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.0, 0.6])})
+    )
+    env = env_shell(sim, 1)
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(m), level="WARNING")
+    try:
+        randomize_object_rigid_body_inertia_startup(
+            env,
+            torch.tensor([0]),
+            sampler=_sampler(env),
+            inertia_distribution_params_dict={
+                "Ixx": (1.0, 1.0),
+                "Iyy": (1.0, 1.0),
+                "Izz": (1.0, 1.0),
+                "Ixy": (1.5, 2.0),
+                "Iyz": (1.0, 1.0),
+                "Ixz": (1.0, 1.0),
+            },
+        )
+    finally:
+        logger.remove(sink_id)
+    assert any("off-diagonal" in m.lower() and "Ixy" in m for m in messages), (
+        "expected a one-time off-diagonal-ignored warning"
+    )
+
+
+def test_object_dr_robot_only_scene_noop_classic_cpu():
+    """A robot-only scene resolves to no free bodies -> the terms no-op without error."""
+    sim = build_classic_sim(SceneConfig())
+    env = env_shell(sim, 1)
+    # None of these should raise (RandomizerNotSupportedError or otherwise).
+    randomize_object_rigid_body_mass_startup(
+        env, torch.tensor([0]), sampler=_sampler(env), mass_distribution_params=(5.0, 6.0)
+    )
+    randomize_object_rigid_body_material_startup(
+        env,
+        torch.tensor([0]),
+        sampler=_sampler(env),
+        material={"mujoco": {"sliding_friction": (0.2, 0.3)}},
+    )
+    randomize_object_rigid_body_inertia_startup(
+        env,
+        torch.tensor([0]),
+        sampler=_sampler(env),
+        inertia_distribution_params_dict={
+            "Ixx": (2.0, 3.0),
+            "Iyy": (1.0, 1.0),
+            "Izz": (1.0, 1.0),
+            **_IDENTITY_OFF_DIAG,
+        },
+    )

--- a/src/holosoma/tests/simulators/mujoco/test_object_dr_warp.py
+++ b/src/holosoma/tests/simulators/mujoco/test_object_dr_warp.py
@@ -1,0 +1,139 @@
+"""GPU (WarpBackend, multi-env) tests for cross-backend object physics DR.
+
+These prove the object DR terms (``randomize_object_rigid_body_mass_startup`` /
+``..._material_startup``) mutate the live per-env MuJoCo Warp model fields (``body_mass`` /
+``geom_friction``) for a registered free body, per env and per object. Skipped without
+CUDA / the MuJoCo-Warp stack.
+
+The terms rely on ``@mujoco_required_field`` field expansion, which in production is driven
+by ``prepare_manager_fields`` scanning the RandomizationManager. The bare test sim has no
+manager, so we expand the fields manually via ``prepare_fields`` (the same primitive the
+manager path delegates to) before calling the term — exactly what a real run does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("mujoco")
+
+# MuJoCo WarpBackend (CUDA) only.
+pytestmark = pytest.mark.mujoco_warp
+
+if not torch.cuda.is_available():
+    pytest.skip("WarpBackend multi-env tests require a CUDA device", allow_module_level=True)
+
+from holosoma.config_types.scene import RigidObjectConfig, SceneConfig  # noqa: E402
+from holosoma.managers.randomization.terms.objects import (  # noqa: E402
+    _mujoco_object_geom_ids,
+    randomize_object_rigid_body_mass_startup,
+    randomize_object_rigid_body_material_startup,
+)
+from tests.simulators._dr_matrix import _sampler  # noqa: E402
+from tests.simulators.mujoco._build import build_warp_sim, env_shell, object_body_id  # noqa: E402
+
+SMALL_BOX = "holosoma/data/scene_objects/boxes/small_box.urdf"
+NUM_ENVS = 4
+
+
+def test_object_mass_randomized_warp():
+    sim = build_warp_sim(
+        SceneConfig(rigid_objects={"box": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.0, 0.6])}),
+        seed=7,
+    )
+    # Expand the field the term needs (manager path does this via prepare_manager_fields).
+    sim.prepare_randomization_fields(["body_mass"])
+
+    bid = object_body_id(sim, "box")
+    before = sim.backend.warp_model_bridge.body_mass[:, bid].clone()
+
+    env = env_shell(sim, NUM_ENVS)
+    randomize_object_rigid_body_mass_startup(
+        env, torch.arange(NUM_ENVS, device=sim.sim_device), sampler=_sampler(env), mass_distribution_params=(5.0, 6.0)
+    )
+
+    after = sim.backend.warp_model_bridge.body_mass[:, bid]
+    # Mass changed in every env (a CPU-only / no-op write would leave it at the URDF 0.1 kg).
+    assert torch.all((after - before).abs() > 1e-3), f"mass unchanged: before={before.cpu()} after={after.cpu()}"
+    # Additive offset within the configured band (per env).
+    assert torch.all(after - before >= 5.0 - 1e-3) and torch.all(after - before <= 6.0 + 1e-3)
+    # Per-env distinct (guards against a broadcast-one-value bug).
+    assert len({round(float(v), 4) for v in after.cpu().tolist()}) > 1
+
+
+def test_object_friction_randomized_warp():
+    sim = build_warp_sim(
+        SceneConfig(rigid_objects={"box": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.0, 0.6])}),
+        seed=7,
+    )
+    sim.prepare_randomization_fields(["geom_friction"])
+
+    geom_ids = _mujoco_object_geom_ids(sim, "box")
+    assert geom_ids, "object 'box' resolved to no geoms (unnamed-geom resolution failure)"
+    g0 = geom_ids[0]
+    before = sim.backend.warp_model_bridge.geom_friction[:, g0, 0].clone()
+
+    env = env_shell(sim, NUM_ENVS)
+    randomize_object_rigid_body_material_startup(
+        env,
+        torch.arange(NUM_ENVS, device=sim.sim_device),
+        sampler=_sampler(env),
+        material={"mujoco": {"sliding_friction": (0.2, 0.3)}},
+    )
+
+    after = sim.backend.warp_model_bridge.geom_friction[:, g0, 0]
+    # operation="abs": every env now sits inside the requested band.
+    assert torch.all(after >= 0.2 - 1e-4) and torch.all(after <= 0.3 + 1e-4), f"friction out of band: {after.cpu()}"
+    # And it actually changed from the default (1.0) and is per-env distinct.
+    assert torch.all((after - before).abs() > 1e-3)
+    assert len({round(float(v), 4) for v in after.cpu().tolist()}) > 1
+
+
+def test_object_mass_dr_multi_object_isolation_warp():
+    """Randomizing one object's mass must not touch the other object's mass."""
+    sim = build_warp_sim(
+        SceneConfig(
+            rigid_objects={
+                "box_a": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.0, 0.6]),
+                "box_b": RigidObjectConfig(urdf_file=SMALL_BOX, position=[0.4, 0.3, 0.6]),
+            }
+        ),
+        seed=7,
+    )
+    sim.prepare_randomization_fields(["body_mass"])
+
+    bid_a, bid_b = object_body_id(sim, "box_a"), object_body_id(sim, "box_b")
+    before_a = sim.backend.warp_model_bridge.body_mass[:, bid_a].clone()
+    before_b = sim.backend.warp_model_bridge.body_mass[:, bid_b].clone()
+
+    env = env_shell(sim, NUM_ENVS)
+    randomize_object_rigid_body_mass_startup(
+        env,
+        torch.arange(NUM_ENVS, device=sim.sim_device),
+        sampler=_sampler(env),
+        mass_distribution_params=(5.0, 6.0),
+        object_names=["box_a"],
+    )
+
+    after_a = sim.backend.warp_model_bridge.body_mass[:, bid_a]
+    after_b = sim.backend.warp_model_bridge.body_mass[:, bid_b]
+    assert torch.all((after_a - before_a).abs() > 1e-3), "box_a mass should have changed"
+    assert torch.allclose(after_b, before_b), "box_b mass leaked — per-object targeting broken"
+
+
+def test_object_dr_robot_only_scene_noop_warp():
+    """A robot-only scene resolves to no free bodies -> the terms no-op without error."""
+    sim = build_warp_sim(SceneConfig(), seed=7)
+    sim.prepare_randomization_fields(["body_mass", "geom_friction"])
+    env = env_shell(sim, NUM_ENVS)
+    # Should not raise (RandomizerNotSupportedError or otherwise) and should change nothing.
+    randomize_object_rigid_body_mass_startup(
+        env, torch.arange(NUM_ENVS, device=sim.sim_device), sampler=_sampler(env), mass_distribution_params=(5.0, 6.0)
+    )
+    randomize_object_rigid_body_material_startup(
+        env,
+        torch.arange(NUM_ENVS, device=sim.sim_device),
+        sampler=_sampler(env),
+        material={"mujoco": {"sliding_friction": (0.2, 0.3)}},
+    )

--- a/src/holosoma/tests/simulators/mujoco/test_object_managers_demo.py
+++ b/src/holosoma/tests/simulators/mujoco/test_object_managers_demo.py
@@ -1,0 +1,34 @@
+"""Regression test: the object-managers example runs end-to-end.
+
+Runs ``holosoma.examples.object_managers_demo`` on the MuJoCo backends and asserts it exits 0,
+so the worked example (scene spawn + object observations + reset/velocity-restore + pose
+jitter + cross-backend physics DR, all in one scenario) stays runnable as the code evolves.
+The example itself does the per-feature assertions and returns a nonzero code on any failure;
+this test just guards that the whole thing still executes.
+
+CPU/ClassicBackend always runs (single env). The Warp GPU path (multi-env) runs only when a
+CUDA device is present.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("mujoco")
+
+from holosoma.examples.object_managers_demo import run_demo  # noqa: E402
+
+
+@pytest.mark.mujoco_classic
+def test_object_managers_demo_mujoco_cpu():
+    """The example runs to completion on the MuJoCo classic (CPU) backend, single env."""
+    assert run_demo("mujoco", num_envs=1, headless=True) == 0
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="mjwarp multi-env demo requires a CUDA device")
+def test_object_managers_demo_mjwarp_multi_env():
+    """The example runs to completion on the MuJoCo Warp (GPU) backend with multiple envs —
+    the path where per-env placement, jitter, and DR are actually distinct per environment."""
+    assert run_demo("mjwarp", num_envs=4, headless=True) == 0

--- a/src/holosoma/tests/simulators/scene_spawn_assert.py
+++ b/src/holosoma/tests/simulators/scene_spawn_assert.py
@@ -136,6 +136,111 @@ def _object_sliding_friction(sim, name, env_id):
     return None
 
 
+def _run_object_dr_checks(sim, free_names, env_ids) -> bool:
+    """Run object mass+material DR on the live backend and verify it took effect.
+
+    Asserts (a) mass increased by the configured additive band on every (object, env), (b) the
+    object_names subset narrows targeting (only the named body changes). Currently verifies
+    read-back on IsaacGym (native rigid-body-property API); other backends just exercise the
+    dispatch without crashing (their DR effect is verified in the per-backend DR unit tests).
+    """
+    import types
+
+    from holosoma.managers.randomization.terms.objects import (
+        randomize_object_rigid_body_mass_startup,
+        randomize_object_rigid_body_material_startup,
+    )
+    from holosoma.utils.simulator_config import SimulatorType
+    from tests.simulators._dr_matrix import _sampler
+
+    env_shell = types.SimpleNamespace(simulator=sim, num_envs=sim.num_envs, device=sim.sim_device)
+    sampler = _sampler(env_shell)  # shell has no dr_base_seed -> _sampler falls back to fixed seed 0
+    is_isaacgym = sim.get_simulator_type() == SimulatorType.ISAACGYM
+
+    mass_lo, mass_hi = 5.0, 6.0
+    fric_lo, fric_hi = 0.2, 0.3
+    if is_isaacgym:
+        before = {(nm, e): _isaacgym_object_mass(sim, nm, e) for nm in free_names for e in range(sim.num_envs)}
+        # Snapshot sliding friction per (object, env) BEFORE the material DR so we can assert it
+        # actually moved (a no-op write must fail), not merely that it lands in band.
+        fric_before = {(nm, e): _object_sliding_friction(sim, nm, e) for nm in free_names for e in range(sim.num_envs)}
+
+    randomize_object_rigid_body_mass_startup(
+        env_shell, env_ids, sampler=sampler, mass_distribution_params=[mass_lo, mass_hi]
+    )
+    randomize_object_rigid_body_material_startup(
+        env_shell,
+        env_ids,
+        sampler=sampler,
+        material={
+            "isaacgym": {"friction": [fric_lo, fric_hi]},
+            "isaacsim": {"static_friction": [fric_lo, fric_hi], "dynamic_friction": [fric_lo, fric_hi]},
+            "mujoco": {"sliding_friction": [fric_lo, fric_hi]},
+        },
+    )
+
+    if is_isaacgym:
+        nbody = {
+            nm: len(sim.gym.get_actor_rigid_body_properties(sim.envs[0], sim.object_handles[nm][0]))
+            for nm in free_names
+        }
+        for nm in free_names:
+            for e in range(sim.num_envs):
+                delta = _isaacgym_object_mass(sim, nm, e) - before[(nm, e)]
+                # Additive offset applied to EACH body of the object => band scales by body count.
+                lo, hi = mass_lo * nbody[nm], mass_hi * nbody[nm]
+                if not (lo - 1e-3 <= delta <= hi + 1e-3):
+                    print(f"FAIL: object-DR mass delta {delta:.3f} for {nm} env{e} outside [{lo},{hi}]")
+                    return False
+        print(f"OBJECT-DR mass band [{mass_lo},{mass_hi}]/body applied to {free_names} across {sim.num_envs} envs OK")
+
+        # Friction read-back: the material DR set sliding friction in [fric_lo, fric_hi] on every
+        # named shape. Mirror the mass check — read the LIVE shape friction back per (object, env)
+        # and assert it (a) CHANGED from the pre-DR baseline and (b) lands in band. The DR samples
+        # one friction value per env (from a bucket) applied to all named objects in that env, so
+        # this also confirms it reached each object. Reads the same shape-property field the DR
+        # wrote (and that the per-object physics check reads), so it can never be a config echo.
+        for nm in free_names:
+            for e in range(sim.num_envs):
+                got = _object_sliding_friction(sim, nm, e)
+                if got is None:
+                    print(f"FAIL: object-DR friction read-back returned None for {nm} env{e} on IsaacGym")
+                    return False
+                base = fric_before[(nm, e)]
+                if base is not None and abs(got - base) <= 1e-6:
+                    print(f"FAIL: object-DR friction for {nm} env{e} did not change from baseline {base:.4f}")
+                    return False
+                if not (fric_lo - 1e-3 <= got <= fric_hi + 1e-3):
+                    print(f"FAIL: object-DR friction {got:.4f} for {nm} env{e} outside [{fric_lo},{fric_hi}]")
+                    return False
+        print(f"OBJECT-DR friction band [{fric_lo},{fric_hi}] applied to {free_names} across {sim.num_envs} envs OK")
+
+        # object_names subset: randomize only the first free body further; others must not change.
+        if len(free_names) >= 2:
+            target, other = free_names[0], free_names[1]
+            mass_other = {e: _isaacgym_object_mass(sim, other, e) for e in range(sim.num_envs)}
+            randomize_object_rigid_body_mass_startup(
+                env_shell, env_ids, sampler=sampler, mass_distribution_params=[mass_lo, mass_hi], object_names=[target]
+            )
+            for e in range(sim.num_envs):
+                if abs(_isaacgym_object_mass(sim, other, e) - mass_other[e]) > 1e-4:
+                    print(f"FAIL: object-DR subset leaked onto '{other}' env{e}")
+                    return False
+            print(f"OBJECT-DR object_names subset isolation OK ('{target}' only, '{other}' untouched)")
+        return True
+
+    # Non-IsaacGym backends have no live read-back here yet. The DR terms dispatched above, but we
+    # have NOT verified the effect landed — returning True now would be a vacuous green that lets a
+    # future `--object-dr` wiring of IsaacSim/Warp pass without ever checking the result. Fail loud
+    # instead so read-back must be implemented before this branch can report success. (Do not
+    # implement IsaacSim/Warp read-back here — just prevent the silent pass.)
+    raise NotImplementedError(
+        f"--object-dr read-back is not implemented for {sim.get_simulator_type()}; "
+        f"mass+material DR dispatched on {free_names} but the effect was not verified. "
+        "Implement a live read-back for this backend before wiring it through --object-dr."
+    )
+
+
 def main() -> int:
     # Register the test-only scene presets into scene.DEFAULTS so `scene:<testkey>` resolves through
     # the normal tyro path inside this (sub)process. Core never imports these; tests register them.
@@ -156,6 +261,10 @@ def main() -> int:
     # --headless false opens a real window (needs a display) and drives the headful render;
     # --headless true drives the headless render (viewer is None — must not crash).
     parser.add_argument("--headless", choices=["true", "false"], default="true")
+    # Run the object physics-DR terms (mass + friction) after prepare_sim and assert they took
+    # effect on the live backend (read mass/friction back per object/env). Works on any
+    # DR-supporting backend (IsaacGym / IsaacSim / Warp).
+    parser.add_argument("--object-dr", action="store_true")
     # Save a movie of the run to this directory (records every episode, headless or headful).
     # Uses the backend's own video recorder, so it works on every backend.
     parser.add_argument("--record", default=None, metavar="DIR", help="save a video of the run to DIR")
@@ -222,6 +331,10 @@ def main() -> int:
 
     # Object physics DR (opt-in): run mass + material DR on the free bodies and verify the
     # effect landed on the live backend.
+    if args.object_dr:
+        if not _run_object_dr_checks(sim, free_names, env_ids):
+            return 1
+
     # All snapshots keep the full env dimension; per-env checks below index every row.
     z0 = {nm: sim.get_actor_states([nm], env_ids)[:, 2].clone() for nm in free_names + static_names}
     p0 = {nm: sim.get_actor_states([nm], env_ids)[:, :3].clone() for nm in free_names}


### PR DESCRIPTION
# PR 04 — Cross-backend object physics domain randomization

## Summary

Domain-randomize scene objects across all four backends, on top of the reproducible keyed sampler
(PR 02) and the scene-object registry (PR 03). Adds startup randomizers for object **mass**,
**material** (friction/restitution), **inertia**, and **freejoint damping** — each drawn through the
keyed `TermSampler`, so a `(term, env, episode)` draw is reproducible and per-env independent — plus
the typed per-backend config surface to drive them. Re-wires object DR into the shipped `wbt/g1`
`w_object` preset, which PR 03 had temporarily stripped.

The bulk of the PR is genuinely additive. **But it is NOT purely additive** — it also unifies the
granularity of the pre-existing *robot* friction term, which changes dynamics and per-seed results
for the `loco/g1` and `loco/t1` presets (see the callout below).

---

## ⚠️ Not result-preserving — `loco/g1` and `loco/t1` need re-baselining

**Robot friction DR (`randomize_friction_startup`) changed granularity on IsaacSim and MuJoCo**
— this is a *robot* term, unrelated to objects, that rides along in this PR.

- `terms/locomotion.py:967` now passes `per_env=True` (IsaacSim) and `terms/locomotion.py:985` now
  passes `shared_across_entities=True` (MuJoCo) into the friction draw. Before (03 base): the
  IsaacSim branch drew friction **per shape** and the MuJoCo branch **per geom**, independently.
  After: **one friction value per env**, broadcast across all of the robot's shapes/geoms.
- Impact: (1) realized contact dynamics differ — every robot geom now shares one coefficient instead
  of varying per link; (2) per-seed values differ even for shape 0, because the sampler draw drops
  the shape coordinate (`coords=(k,)` vs `(k, shape_ids)`; bucket pick `coords=(3,)` vs
  `(3, shape_ids)`).
- **Who is hit:** the shipped, enabled presets `loco/g1` (`friction_range=[0.5,1.25]`) and `loco/t1`
  (`friction_range=[0.1,1.0]`). Both preset files are byte-identical 03→04; the change is entirely in
  the term body. IsaacGym was already per-env (from PR 02) and is unchanged. There is **no opt-out**.
- Not masked: this is a `setup_terms` (startup) term, robot foot friction is never overwritten at
  reset. **Re-baseline `loco/g1` and `loco/t1`; do not expect a seed to reproduce a 03 run.**

Everything else in the PR is additive (new capability or new config surface); no *other* existing
preset's dynamics or reproducibility changes.

---

## Behavior changes, grouped by user impact

### Different dynamics (existing tasks)

- **Robot friction granularity** — see the callout. `terms/locomotion.py:967,985`;
  presets `loco/g1`, `loco/t1`.
- **`wbt/g1` `w_object` now randomizes the object again.** `object_state_dr_at_setup`
  (`config_values/wbt/g1/randomization.py:39`) is merged back into
  `g1_29dof_wbt_randomization_w_object.setup_terms` (`:141`). The 03 base had **no** object DR on
  this preset (setup was base-only). So the existing `g1_29dof_wbt_w_object` and
  `g1_29dof_wbt_fast_sac_w_object` experiments now randomize the spawned box's mass (`+[1.0,4.0]`),
  material friction (`[0.1,0.6]`), and inertia (`Ixx` scale `[0.5,1.5]`) at startup where 03 did not.
  On **IsaacSim** these ranges and the draw path are identical to pre-stack main (mass/inertia
  writers are byte-identical; `num_buckets=64`), so this is a *restoration* vs main — but still a
  dynamics change vs the 03 base. Not masked: the WBT command term overwrites only object pose/velocity
  from motion data, never mass/friction/inertia.

### Newly supported

- **Object mass / material / inertia DR is now cross-backend** (`terms/objects.py:157, 316, 502`).
  Each term has three real backend branches — IsaacGym (native
  `get/set_actor_rigid_{shape,body}_properties`), IsaacSim (project `events.py` writers), MuJoCo
  Warp+Classic (`randomize_field`, plus `scale_inertia_by_mass_ratio` for mass) — and raises
  `RandomizerNotSupportedError` on anything else. On pre-stack main these lived in `terms.locomotion`
  and were **IsaacSim-only** (raised on every other backend). Targets resolve via
  `_resolve_object_names` → registry `INDIVIDUAL` free bodies, defaulting to all of them, so a term
  no-ops cleanly on a robot-only scene.
- **Object freejoint-damping DR** (`randomize_object_{linear,angular}_damping_startup`,
  `terms/objects.py:757, 796`) — new terms supporting MuJoCo (Classic+Warp, via freejoint
  `dof_damping`) and IsaacSim (live-USD `PhysxRigidBodyAPI.{linear,angular}Damping`). See "latent"
  below — **no shipped preset wires them yet.**
- **MuJoCo mass DR now rescales object inertia by the mass ratio** and clamps mass to `1e-6`,
  matching the Isaac paths (`terms/objects.py` MuJoCo branch → `scale_inertia_by_mass_ratio`,
  `clamp(min=1e-6)`). This only reaches a user via the newly-wired `w_object` object DR above.

### Removed / fail-loud

- **Object damping on IsaacGym raises `RandomizerNotSupportedError`** (`terms/objects.py:727`,
  `_DAMPING_ISAACGYM_MSG`): IsaacGym has no runtime free-body-damping path (damping is import-time on
  `AssetOptions` only). Latent today (no preset wires damping), so no shipped IsaacGym run breaks; but
  a user who wires object damping and runs IsaacGym gets a hard, explanatory error. The message
  directs them to set damping via `PhysXPhysicsConfig` at spawn.

---

## Migration guide (breaking config/API surface — object-DR authors only)

Config-driven users who don't randomize objects and don't subclass DR terms see **no** API break
here (the friction-granularity change needs no config edit). For object-DR authors:

**1. Object-DR func paths and the inertia param type.** (Only relevant if you wired object DR against
*pre-stack main*; the 03 base had no object DR to migrate from.)

```python
# BEFORE (pre-stack main) — IsaacSim-only, in terms.locomotion
func="...terms.locomotion:randomize_object_rigid_body_mass_startup"
params={"mass_distribution_params": [1.0, 4.0]}
func="...terms.locomotion:randomize_object_rigid_body_inertia_startup"
params={"inertia_distribution_params_dict": {"Ixx": [0.5, 1.5]}}   # plain dict

# AFTER — cross-backend, in terms.objects
func="...terms.objects:randomize_object_rigid_body_mass_startup"
params={"mass_distribution_params": [1.0, 4.0]}
func="...terms.objects:randomize_object_rigid_body_inertia_startup"
params={"inertia_distribution_params_dict": InertiaScale(Ixx=[0.5, 1.5])}   # typed
```
`InertiaScale` / `MaterialRandomizationConfig` import from `holosoma.config_types.randomization`.
**Not a hard break:** `_coerce_inertia_params` still accepts a plain `{Ixx: ...}` dict and
`_coerce_material_cfg` still accepts a nested dict, so the typed classes are the preferred-but-optional
surface.

**2. Material DR is a new term with a typed, per-backend config** (no prior form). Each backend
sub-block names only the channels that backend honors — no silent cross-backend drop; MuJoCo has no
scalar restitution (it exposes `solref`/`solimp` instead):

```python
func="...terms.objects:randomize_object_rigid_body_material_startup"
params={"material": MaterialRandomizationConfig(
    isaacgym=IsaacGymMaterialDR(friction=[0.1, 0.6], restitution=[0.0, 1.0]),
    isaacsim=IsaacSimMaterialDR(static_friction=[0.1, 0.6], dynamic_friction=[0.1, 0.6], restitution=[0.0, 1.0]),
    mujoco=MujocoMaterialDR(sliding_friction=[0.1, 0.6]))}
```

**3. Internal writer signatures gained backward-compatible params (non-breaking).**
`isaacsim/events.py:randomize_rigid_body_material` gained `per_env: bool = False`;
`mujoco/backends/randomization.py:randomize_field` gained `shared_across_entities: bool = False`.
Both defaults preserve the old per-shape/per-entity behavior; only callers passing `True` (the robot
friction term, and the new object terms) change results. Custom callers need no change.

---

