### PR TITLE
feat: terrain hide_visual, frequency-string rate model, backend-aware run_sim device

### DIFF
--- a/src/holosoma/holosoma/agents/callbacks/recording.py
+++ b/src/holosoma/holosoma/agents/callbacks/recording.py
@@ -73,7 +73,7 @@ class EvalRecordingCallback(RLEvalCallback):
         self._metadata["fps"] = round(1.0 / float(env.dt))
         self._metadata["sim_dt"] = float(env.sim_dt)
         self._metadata["sim_fps"] = round(1.0 / float(env.sim_dt))
-        self._metadata["control_decimation"] = env.simulator.simulator_config.sim.control_decimation
+        self._metadata["control_decimation"] = env.simulator.simulator_config.sim.control_decimation_steps
         self._metadata["env_id"] = self.env_id
         if hasattr(sim, "dof_names"):
             self._metadata["dof_names"] = list(sim.dof_names)

--- a/src/holosoma/holosoma/config_types/frequency.py
+++ b/src/holosoma/holosoma/config_types/frequency.py
@@ -1,0 +1,97 @@
+"""Resolve rate fields written as frequency strings ("20Hz") into decimations.
+
+A decimation is "act every Nth tick of a base clock" running at ``base_hz``. A rate field is either a
+decimation int (every Nth tick) or a target frequency string resolved against a base rate.
+
+Grammar (case-insensitive, surrounding whitespace ignored)::
+
+    "20Hz"     require an exact decimation (base/20 must be a whole number); error otherwise
+    ">20Hz"    round to achieve a rate >= target (floor(base/20))
+    "<20Hz"    round to achieve a rate <= target (ceil(base/20))
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Union
+
+from loguru import logger
+
+DecimationLike = Union[int, str]
+"""A rate field: a decimation int (every Nth base tick), or a frequency string resolved against a base
+rate via :func:`resolve_decimation`. Form-checked by :func:`validate_decimation_like`."""
+
+# an optional comparison prefix (< or >), a positive number (int or float), then a Hz unit.
+_FREQ_RE = re.compile(r"^\s*([<>]?)\s*([0-9]*\.?[0-9]+)\s*[Hh][Zz]\s*$")
+
+
+def is_frequency_string(value: DecimationLike) -> bool:
+    """Whether ``value`` is a frequency string (vs an already-numeric decimation)."""
+    return isinstance(value, str)
+
+
+def validate_decimation_like(value: DecimationLike, *, field: str) -> None:
+    """Validate form only (int >= 1, or a well-formed freq string), without a base rate.
+
+    Resolution to an int happens later against the base rate. Raises ValueError on a bad form.
+    """
+    if isinstance(value, bool):  # bool is an int subclass; reject explicitly
+        raise ValueError(f"{field}: expected a decimation int or frequency string, got bool {value!r}.")
+    if isinstance(value, int):
+        if value < 1:
+            raise ValueError(f"{field}: decimation must be >= 1, got {value}.")
+        return
+    if not isinstance(value, str) or _FREQ_RE.match(value) is None:
+        raise ValueError(f"{field}: invalid {value!r}; expected an int >= 1 or e.g. '20Hz', '>20Hz', '<20Hz'.")
+
+
+def resolve_decimation(value: DecimationLike, base_hz: float, *, field: str, log: bool = False) -> int:
+    """Resolve ``value`` to an integer decimation >= 1 against a ``base_hz`` clock.
+
+    An int passes through unchanged (>= 1 enforced). A bare frequency string ("20Hz") requires an
+    exact decimation (``base/target`` must be a whole number) and raises otherwise. A ">"-prefixed
+    string (">20Hz") floors ``base/target`` so the achieved rate is >= target; a "<"-prefixed string
+    ("<20Hz") ceils it so the achieved rate is <= target. A target faster than ``base_hz`` clamps to
+    1 (warned when ``log``). ``log`` is passed once at config validation; resolved-property reads stay
+    silent (they re-resolve on every access, which would spam per-step logs).
+    """
+    if isinstance(value, bool):  # bool is an int subclass; reject explicitly
+        raise ValueError(f"{field}: expected a decimation int or frequency string, got bool {value!r}.")
+    if isinstance(value, int):
+        if value < 1:
+            raise ValueError(f"{field}: decimation must be >= 1, got {value}.")
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field}: expected a decimation int or frequency string, got {value!r}.")
+
+    m = _FREQ_RE.match(value)
+    if m is None:
+        raise ValueError(f"{field}: invalid frequency {value!r}; expected e.g. '20Hz', '>20Hz', '<20Hz'.")
+    prefix = m.group(1)
+    hz = float(m.group(2))
+    if hz <= 0.0:
+        raise ValueError(f"{field}: frequency must be positive, got {value!r}.")
+
+    ratio = base_hz / hz
+    if prefix == ">":
+        dec = math.floor(ratio)  # floor so achieved rate >= target
+    elif prefix == "<":
+        dec = math.ceil(ratio)  # ceil so achieved rate <= target
+    else:
+        # Bare "20Hz": require an exact decimation, else the achieved rate would silently differ.
+        dec = round(ratio)
+        if not math.isclose(ratio, dec, rel_tol=1e-9, abs_tol=1e-9):
+            raise ValueError(
+                f"{field}: {value} is not exactly achievable from base {base_hz:g}Hz "
+                f"(base/target = {ratio:g}). Use '>{hz:g}Hz' (achieve >= target) or "
+                f"'<{hz:g}Hz' (achieve <= target) to allow rounding."
+            )
+
+    if dec < 1:
+        if log:
+            logger.warning(f"{field}: requested {value} but base clock is {base_hz:g}Hz; capping at decimation=1.")
+        dec = 1
+    if log:
+        logger.info(f"{field}: {value} @ base {base_hz:g}Hz -> decimation={dec} (achieved {base_hz / dec:g}Hz).")
+    return dec

--- a/src/holosoma/holosoma/config_types/run_sim.py
+++ b/src/holosoma/holosoma/config_types/run_sim.py
@@ -85,6 +85,8 @@ class RunSimConfig:
     Only used by run_sim.py for real-time display synchronization.
     """
 
-    device: str | None = "cpu"
-    """Device to use for simulation. None auto-detects based on the simulator type.
+    device: str | None = None
+    """Device to use for simulation. None (the default) auto-detects based on the simulator
+    backend: cuda:0 for MuJoCo Warp, cuda:0 for IsaacSim/IsaacGym when CUDA is available (else
+    cpu), and cpu for classic MuJoCo. Pass an explicit value (e.g. "cpu" or "cuda:1") to override.
     """

--- a/src/holosoma/holosoma/config_types/simulator.py
+++ b/src/holosoma/holosoma/config_types/simulator.py
@@ -4,8 +4,10 @@ from dataclasses import field
 from enum import Enum
 from typing import Any
 
+from pydantic import model_validator
 from pydantic.dataclasses import dataclass
 
+from holosoma.config_types.frequency import DecimationLike, resolve_decimation
 from holosoma.config_types.viewer import ViewerConfig
 
 
@@ -115,13 +117,22 @@ class SimEngineConfig:
     """Top-level simulation engine settings."""
 
     fps: int
-    """Target simulation frames per second."""
+    """Physics rate in Hz: the sim integrates one physics step every ``1/fps`` seconds (the engine
+    timestep ``dt``). The base frequency every other rate here is derived from."""
 
-    control_decimation: int
-    """Number of physics steps between agent control updates."""
+    control_decimation: DecimationLike
+    """Physics steps per control step: sets the CONTROL (policy) rate to ``fps / control_decimation``
+    Hz. Each control step the policy emits one action that is HELD while the sim runs this many
+    physics steps, then the next observation/action is taken. Higher = cheaper, lower-frequency
+    control. Int (every Nth physics step), or a frequency string expressed against ``fps``: a bare
+    "50Hz" requires an exact decimation (e.g. fps=200 -> 4) and errors if not exactly achievable,
+    while ">50Hz"/"<50Hz" round to the nearest rate at or above/below the target. Holds the value AS
+    WRITTEN; read the resolved integer step count via :attr:`control_decimation_steps`."""
 
     substeps: int
-    """Number of substeps per physics frame."""
+    """Solver substeps WITHIN each physics step — subdivides the ``1/fps`` step for finer/stabler
+    integration (contacts, stiff dynamics). Does NOT change ``fps`` or any rate; purely solver
+    accuracy vs. cost per step."""
 
     physx: PhysxConfig
     """PhysX solver configuration."""
@@ -129,11 +140,36 @@ class SimEngineConfig:
     render_mode: str = "human"
     """Rendering mode requested from the simulator."""
 
-    render_interval: int = 1
-    """Number of physics frames between rendered frames."""
+    render_interval: DecimationLike = 1
+    """Physics steps per rendered frame: render rate = ``fps / render_interval`` Hz.
+    Decouples rendering from physics so the sim can step faster than it draws; 1 = render every
+    step. Int, or a frequency string vs ``fps``. Holds the value AS WRITTEN; read the resolved
+    integer step count via :attr:`render_interval_steps`."""
 
     max_episode_length_s: float = 20.0
     """Maximum episode length in seconds."""
+
+    @model_validator(mode="after")
+    def _validate_rates(self) -> SimEngineConfig:
+        """Validate (do NOT mutate) the rate fields: both must resolve to a valid step count against
+        ``fps``. The fields keep what the user wrote; the resolved ints are exposed as the
+        ``*_steps`` properties below, computed against ``fps`` on access (always consistent if ``fps``
+        changes, and the input config is never rewritten)."""
+        resolve_decimation(self.control_decimation, self.fps, field="control_decimation", log=True)
+        resolve_decimation(self.render_interval, self.fps, field="render_interval", log=True)
+        return self
+
+    @property
+    def control_decimation_steps(self) -> int:
+        """Resolved physics-steps-per-control-step (int >= 1) — ``control_decimation`` evaluated
+        against ``fps`` (a frequency string becomes ``fps/target``; an int passes through)."""
+        return resolve_decimation(self.control_decimation, self.fps, field="control_decimation")
+
+    @property
+    def render_interval_steps(self) -> int:
+        """Resolved physics-steps-per-rendered-frame (int >= 1) — ``render_interval`` evaluated
+        against ``fps`` (frequency string -> ``fps/target``; int passes through)."""
+        return resolve_decimation(self.render_interval, self.fps, field="render_interval")
 
 
 @dataclass(frozen=True)

--- a/src/holosoma/holosoma/config_types/terrain.py
+++ b/src/holosoma/holosoma/config_types/terrain.py
@@ -136,6 +136,10 @@ class TerrainTermCfg:
     - "fake": Mock terrain for testing
     """
 
+    hide_visual: bool = False
+    """Render the terrain invisible while keeping its collider (default ``False``). Set ``True`` when
+    a scene supplies its own visible floor; the robot still collides with the terrain."""
+
     horizontal_scale: float = 0.1
     """Horizontal resolution of terrain grid in meters."""
 

--- a/src/holosoma/holosoma/config_types/tests/test_frequency.py
+++ b/src/holosoma/holosoma/config_types/tests/test_frequency.py
@@ -1,0 +1,120 @@
+"""Unit tests for frequency-string -> decimation resolution (pure; no simulator)."""
+
+from __future__ import annotations
+
+import pydantic
+import pytest
+
+from holosoma.config_types.frequency import resolve_decimation
+from holosoma.config_types.simulator import PhysxConfig, SimEngineConfig
+
+pytestmark = pytest.mark.no_sim
+
+
+# ----- resolve_decimation -----
+
+
+def test_int_passthrough():
+    assert resolve_decimation(4, 200, field="x") == 4
+    assert resolve_decimation(1, 200, field="x") == 1
+
+
+def test_int_below_one_rejected():
+    with pytest.raises(ValueError, match="must be >= 1"):
+        resolve_decimation(0, 200, field="x")
+
+
+def test_bool_rejected():
+    # bool is an int subclass; must not pass through as a decimation.
+    with pytest.raises(ValueError, match="bool"):
+        resolve_decimation(True, 200, field="x")
+
+
+def test_frequency_string_exact_divisor():
+    assert resolve_decimation("50Hz", 200, field="x") == 4
+
+
+def test_bare_frequency_requires_exact_divisor():
+    # 200/60 = 3.33 is not a whole decimation; a bare frequency must be exactly achievable.
+    with pytest.raises(ValueError, match="not exactly achievable"):
+        resolve_decimation("60Hz", 200, field="x")
+
+
+def test_greater_than_floors_to_faster_rate():
+    # 200/60 = 3.33 -> floor 3, so the achieved rate (66.7Hz) is >= the 60Hz target.
+    assert resolve_decimation(">60Hz", 200, field="x") == 3
+
+
+def test_less_than_ceils_to_slower_rate():
+    # 200/60 = 3.33 -> ceil 4, so the achieved rate (50Hz) is <= the 60Hz target.
+    assert resolve_decimation("<60Hz", 200, field="x") == 4
+
+
+def test_comparison_prefixes_on_exact_divisor():
+    # An exact divisor resolves identically regardless of prefix.
+    assert resolve_decimation("50Hz", 200, field="x") == 4
+    assert resolve_decimation(">50Hz", 200, field="x") == 4
+    assert resolve_decimation("<50Hz", 200, field="x") == 4
+
+
+def test_comparison_prefix_whitespace():
+    assert resolve_decimation("  > 60 hz ", 200, field="x") == 3
+    assert resolve_decimation(" <60Hz ", 200, field="x") == 4
+
+
+def test_frequency_string_case_whitespace_and_float():
+    assert resolve_decimation("  50 hz ", 200, field="x") == 4
+    assert resolve_decimation("0.5Hz", 1, field="x") == 2
+
+
+def test_frequency_faster_than_base_clamps_to_one():
+    # floor(200/400) = 0 -> clamped to 1. A bare "400Hz" would instead error (not exact).
+    assert resolve_decimation(">400Hz", 200, field="x") == 1
+    assert resolve_decimation("<400Hz", 200, field="x") == 1
+    with pytest.raises(ValueError, match="not exactly achievable"):
+        resolve_decimation("400Hz", 200, field="x")
+
+
+def test_malformed_strings_rejected():
+    for bad in ("50", "Hz", "50khz", "-50Hz", "fastHz"):
+        with pytest.raises(ValueError, match="invalid"):
+            resolve_decimation(bad, 200, field="x")
+
+
+def test_zero_frequency_rejected():
+    with pytest.raises(ValueError, match="positive"):
+        resolve_decimation("0Hz", 200, field="x")
+
+
+# ----- SimEngineConfig integration -----
+
+
+def _sim(control_decimation, render_interval=1, fps=200) -> SimEngineConfig:
+    return SimEngineConfig(
+        fps=fps,
+        control_decimation=control_decimation,
+        substeps=1,
+        physx=PhysxConfig(solver_type=1, num_position_iterations=4, num_velocity_iterations=0),
+        render_interval=render_interval,
+    )
+
+
+def test_sim_config_keeps_value_as_written_and_resolves_steps():
+    cfg = _sim("50Hz", render_interval="100Hz")
+    assert cfg.control_decimation == "50Hz"  # field holds what the user wrote
+    assert cfg.control_decimation_steps == 4
+    assert cfg.render_interval == "100Hz"
+    assert cfg.render_interval_steps == 2
+
+
+def test_sim_config_int_fields_resolve_identity():
+    cfg = _sim(4, render_interval=2)
+    assert cfg.control_decimation_steps == 4
+    assert cfg.render_interval_steps == 2
+
+
+def test_sim_config_rejects_bad_rate_at_construction():
+    with pytest.raises(pydantic.ValidationError):
+        _sim("banana")
+    with pytest.raises(pydantic.ValidationError):
+        _sim(0)

--- a/src/holosoma/holosoma/envs/base_task/base_task.py
+++ b/src/holosoma/holosoma/envs/base_task/base_task.py
@@ -118,7 +118,7 @@ class BaseTask:
         self.simulator.setup()
         self.sim_dt = self.simulator.sim_dt
 
-        self.dt = simulator_config.config.sim.control_decimation * self.sim_dt
+        self.dt = simulator_config.config.sim.control_decimation_steps * self.sim_dt
         self.max_episode_length_s = simulator_config.config.sim.max_episode_length_s
         self.max_episode_length = np.ceil(self.max_episode_length_s / self.dt)
 
@@ -451,7 +451,7 @@ class BaseTask:
 
     def _physics_step(self):
         self.render()
-        for _ in range(self.simulator.simulator_config.sim.control_decimation):
+        for _ in range(self.simulator.simulator_config.sim.control_decimation_steps):
             self._apply_force_in_physics_step()
             self.simulator.simulate_at_each_physics_step()
 

--- a/src/holosoma/holosoma/managers/action/terms/joint_control.py
+++ b/src/holosoma/holosoma/managers/action/terms/joint_control.py
@@ -89,7 +89,7 @@ class JointPositionActionTerm(ActionTermBase):
             self.action_queue = torch.zeros(self.env.num_envs, max_delay + 1, self._action_dim, device=self.env.device)
 
         # Allocate sub-step torque history buffer
-        decimation = self.env.simulator.simulator_config.sim.control_decimation
+        decimation = self.env.simulator.simulator_config.sim.control_decimation_steps
         self.torques_substep = torch.zeros(self.env.num_envs, decimation, self._action_dim, device=self.env.device)
         self.dof_pos_substep = torch.zeros(self.env.num_envs, decimation, self._action_dim, device=self.env.device)
         self.dof_vel_substep = torch.zeros(self.env.num_envs, decimation, self._action_dim, device=self.env.device)

--- a/src/holosoma/holosoma/managers/terrain/base.py
+++ b/src/holosoma/holosoma/managers/terrain/base.py
@@ -98,3 +98,7 @@ class TerrainTermBase(ABC):
     @property
     def restitution(self) -> float:
         return self._cfg.restitution
+
+    @property
+    def hide_visual(self) -> bool:
+        return self._cfg.hide_visual

--- a/src/holosoma/holosoma/run_sim.py
+++ b/src/holosoma/holosoma/run_sim.py
@@ -30,17 +30,36 @@ def run_simulation(config: RunSimConfig):
     config : RunSimConfig
         Configuration containing all simulation settings.
     """
-    # Auto-set device for GPU-accelerated backends if still on default CPU
-    if config.device == "cpu":
-        # Check if using Warp backend (requires CUDA)
-        if hasattr(config.simulator.config, "mujoco_backend"):
-            from holosoma.config_types.simulator import MujocoBackend
+    # Resolve the simulation device from the backend when the user did not set one (device=None).
+    # An explicit --device (including "cpu") is always honored.
+    if config.device is None:
+        from holosoma.config_types.simulator import MujocoBackend
+        from holosoma.utils.safe_torch_import import torch
 
-            if config.simulator.config.mujoco_backend == MujocoBackend.WARP:
-                logger.info("Auto-detected MuJoCo Warp backend - setting device to cuda:0")
-                config = dataclasses.replace(config, device="cuda:0")
+        sim_name = config.simulator.config.name
+        is_warp = (
+            hasattr(config.simulator.config, "mujoco_backend")
+            and config.simulator.config.mujoco_backend == MujocoBackend.WARP
+        )
+        if is_warp:
+            # MuJoCo Warp only runs on CUDA, so cpu is never a valid choice for it.
+            resolved_device = "cuda:0"
+            logger.info("Auto-detected MuJoCo Warp backend - setting device to cuda:0")
+        elif sim_name in ("isaacsim", "isaacgym"):
+            # Isaac backends are GPU-first; prefer cuda:0 when it is actually available,
+            # otherwise fall back to cpu (IsaacSim can run PhysX on CPU).
+            if torch.cuda.is_available():
+                resolved_device = "cuda:0"
+                logger.info(f"Auto-detected {sim_name} backend with CUDA available - setting device to cuda:0")
+            else:
+                resolved_device = "cpu"
+                logger.warning(f"{sim_name} backend selected but CUDA is unavailable - defaulting to cpu")
+        else:
+            # Classic MuJoCo (CPU physics engine).
+            resolved_device = "cpu"
+            logger.info(f"Auto-detected {sim_name} backend - setting device to cpu")
 
-    config = dataclasses.replace(config, device=config.device)
+        config = dataclasses.replace(config, device=resolved_device)
 
     logger.info("Starting Holosoma Direct Simulation...")
     logger.info(f"Robot: {config.robot.asset.robot_type}")

--- a/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
+++ b/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
@@ -198,11 +198,20 @@ class IsaacGym(BaseSimulator):
         return ["urdf"]
 
     def setup_terrain(self):
-        mesh_type = self.terrain_manager.get_state("locomotion_terrain").mesh_type
+        terrain_state = self.terrain_manager.get_state("locomotion_terrain")
+        mesh_type = terrain_state.mesh_type
+        # IsaacGym's ground has no separable visual, so hide_visual is satisfied only where it is
+        # already met (headless draws nothing) and warned otherwise. set_headless runs before this,
+        # so self.headless is reliable.
+        if terrain_state.hide_visual and not self.headless:
+            logger.warning(
+                "terrain hide_visual=True is not supported on IsaacGym in headful mode (its ground "
+                "geometry has no separable visual); run headless or use MuJoCo/IsaacSim."
+            )
         if mesh_type == "plane":
             self._create_ground_plane()
         elif mesh_type in ["trimesh", "load_obj"]:
-            terrain = self.terrain_manager.get_state("locomotion_terrain").terrain
+            terrain = terrain_state.terrain
             self._create_trimesh(terrain)
         else:
             raise ValueError(f"Unsupported terrain mesh type: {mesh_type}")

--- a/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
@@ -101,7 +101,7 @@ class IsaacSim(BaseSimulator):
 
         sim_config: SimulationCfg = SimulationCfg(
             dt=1.0 / self.simulator_config.sim.fps,
-            render_interval=self.simulator_config.sim.render_interval,
+            render_interval=self.simulator_config.sim.render_interval_steps,
             device=self.sim_device,
             physx=PhysxCfg(
                 bounce_threshold_velocity=self.simulator_config.sim.physx.bounce_threshold_velocity,
@@ -137,10 +137,10 @@ class IsaacSim(BaseSimulator):
             f"\tRendering step-size   : {1.0 / self.simulator_config.sim.fps * self.simulator_config.sim.substeps}"
         )
 
-        if self.simulator_config.sim.render_interval < self.simulator_config.sim.control_decimation:
+        if self.simulator_config.sim.render_interval_steps < self.simulator_config.sim.control_decimation_steps:
             msg = (
-                f"The render interval ({self.simulator_config.sim.render_interval}) is smaller than the decimation "
-                f"({self.simulator_config.sim.control_decimation}). Multiple render calls will happen for each "
+                f"The render interval ({self.simulator_config.sim.render_interval_steps}) is smaller than the decimation "
+                f"({self.simulator_config.sim.control_decimation_steps}). Multiple render calls will happen for each "
                 "environment step. If this is not intended, set the render interval to be equal to the decimation."
             )
             logger.warning(msg)
@@ -890,7 +890,7 @@ class IsaacSim(BaseSimulator):
 
         # Issue: data.net_forces_w_history is not cleared after a reset.
         # Solution: We only read the most recent decimation_factor steps.
-        control_decimation = self.simulator_config.sim.control_decimation
+        control_decimation = self.simulator_config.sim.control_decimation_steps
         effective_history_length = min(control_decimation, self.simulator_config.contact_sensor_history_length)
         self.contact_forces_history[:, :effective_history_length, :, :] = self.contact_sensor.data.net_forces_w_history[
             :, :effective_history_length, self._contact_to_robot_body_ids
@@ -935,7 +935,7 @@ class IsaacSim(BaseSimulator):
         # Render between steps only IF the GUI or sensor need it
         # note: we assume the render interval to be the shortest accepted rendering interval.
         #    If a camera needs rendering at a faster frequency, this will lead to unexpected behavior.
-        if self._sim_step_counter % self.simulator_config.sim.render_interval == 0 and is_rendering:
+        if self._sim_step_counter % self.simulator_config.sim.render_interval_steps == 0 and is_rendering:
             self.render()
 
         # update buffers at sim

--- a/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
@@ -16,7 +16,7 @@ import isaaclab.terrains as terrain_gen
 import isaacsim.core.utils.stage as stage_utils
 import omni.log
 import torch
-from pxr import Usd
+from pxr import Usd, UsdGeom
 from isaaclab.actuators import IdealPDActuatorCfg
 from isaaclab.assets import Articulation, ArticulationCfg
 from isaaclab.envs import ViewerCfg, mdp
@@ -68,6 +68,22 @@ from holosoma.simulator.shared.virtual_gantry import (
 )
 
 from holosoma.simulator.types import ActorNames, ActorIndices, EnvIds, ActorStates, ActorPoses
+
+
+def _hide_prim_subtree(stage: "Usd.Stage", prim_path: str) -> None:
+    """Make the geometry under ``prim_path`` invisible (rendering only; physics untouched).
+
+    Authors ``visibility = invisible`` on every Imageable prim in the subtree. The terrain root
+    (e.g. ``/World/ground``) is typeless, so setting visibility only there is a no-op; the visible
+    meshes are on Imageable descendants. Colliders are unaffected, so the body stays collidable.
+    """
+    root = stage.GetPrimAtPath(prim_path)
+    if not root.IsValid():
+        return
+    for prim in Usd.PrimRange(root):
+        imageable = UsdGeom.Imageable(prim)
+        if imageable:
+            imageable.MakeInvisible()
 
 
 class IsaacSim(BaseSimulator):
@@ -438,6 +454,10 @@ class IsaacSim(BaseSimulator):
             terrain_config.env_spacing = self.scene.cfg.env_spacing
             terrain_config.class_type(terrain_config)
             global_collision_prims.append(terrain_config.prim_path)
+            # Hide the ground plane's visual while keeping its collider; avoids z-fighting a scene
+            # USD's own floor. Applied to the whole /World/ground subtree.
+            if terrain_state.hide_visual:
+                _hide_prim_subtree(stage_utils.get_current_stage(), terrain_prim_path)
         elif terrain_state.mesh_type in ["trimesh", "load_obj"]:
             self.terrain = self.terrain_manager.get_state("locomotion_terrain").terrain
             visual_material = sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.0, 0.0))

--- a/src/holosoma/holosoma/simulator/mujoco/scene_manager.py
+++ b/src/holosoma/holosoma/simulator/mujoco/scene_manager.py
@@ -216,6 +216,12 @@ class MujocoSceneManager:
             # Only collide with robot (class 1)
             terrain_state.geom.conaffinity = 1  # type: ignore[attr-defined]
 
+            # Hide the terrain visual while keeping its collider: zero-alpha rgba stops the geom from
+            # drawing but leaves contype/conaffinity untouched. The geom's rgba overrides any
+            # material/default color.
+            if terrain_state.hide_visual:
+                terrain_state.geom.rgba = [0.0, 0.0, 0.0, 0.0]  # type: ignore[attr-defined]
+
     def _create_ground_plane(self, terrain_state: TerrainTermBase) -> mujoco.MjSpec.Geom:
         """Create a ground plane terrain geometry.
 

--- a/src/holosoma/holosoma/simulator/shared/video_recorder.py
+++ b/src/holosoma/holosoma/simulator/shared/video_recorder.py
@@ -194,7 +194,7 @@ class VideoRecorderInterface(ABC):
         self._frame_counter += 1
 
         # Only capture frame at control frequency (every control_decimation physics steps)
-        control_decimation = self.simulator.simulator_config.sim.control_decimation
+        control_decimation = self.simulator.simulator_config.sim.control_decimation_steps
         if self._frame_counter % control_decimation != 0:
             return
 
@@ -431,7 +431,7 @@ class VideoRecorderInterface(ABC):
             # Frames are captured at control_frequency = sim_fps / control_decimation
             # To achieve desired playback rate: actual_fps = control_frequency * playback_rate
             sim_config = self.simulator.simulator_config.sim
-            control_frequency = sim_config.fps / sim_config.control_decimation
+            control_frequency = sim_config.fps / sim_config.control_decimation_steps
             display_fps = control_frequency * self.config.playback_rate
 
             # Get save directory


### PR DESCRIPTION
## Summary

Three leaf features pulled out of the mega scene-objects branch into their own PR:
1. **terrain `hide_visual`** — render terrain invisible while keeping its collider (additive, opt-in config field).
2. **frequency-string rate model** — `control_decimation` / `render_interval` accept an int OR a target frequency string (`"50Hz"`, `">50Hz"`, `"<50Hz"`) resolved against `fps`; callers read the resolved integer via new `control_decimation_steps` / `render_interval_steps` properties. Result-preserving for every shipped preset.
3. **run_sim backend-aware default device** — `RunSimConfig.device` default `"cpu"` → `None`, resolved per backend. **This changes the resolved device for IsaacSim/IsaacGym.**

## ⚠️ Not result-preserving — re-baseline affected runs

**`run_sim` on IsaacSim/IsaacGym with no `--device`, on a CUDA-capable box, now runs on `cuda:0` where it previously ran on `cpu`.** The old logic only upgraded the `"cpu"` default to `cuda:0` for the MuJoCo-Warp backend; IsaacSim/IsaacGym (which default `mujoco_backend=CLASSIC`) stayed on `cpu`. The new logic resolves `device=None` to `cuda:0` for those backends when `torch.cuda.is_available()`. GPU vs CPU PhysX are different solver pipelines, so dynamics/repro differ for anyone who relied on the old unset-`--device` default. Trigger is narrow: `run_sim` entrypoint only, GPU box, no explicit `--device`. `run_sim.py:35-64`, `run_sim.py:71` → `sim_utils.py:262-263` → `base_simulator.py:172` → `isaacgym.py:128-139` / `isaacsim.py:102-105`.

## Behavior changes

### Different dynamics / reproducibility
- **IsaacSim/IsaacGym default device `cpu` → `cuda:0`** (GPU box, unset `--device`, `run_sim`). See callout above. `config_types/run_sim.py:88`, `run_sim.py:35-64`.

### Newly supported (opt-in; no-op default — no existing task/env affected)
- **terrain `hide_visual: bool = False`** — hides terrain visual while keeping its collider. No path touches collision (`contype`/`conaffinity`/colliders untouched). `config_types/terrain.py` (default `False`), `managers/terrain/base.py` (property).
  - **MuJoCo:** honored for **all** mesh types — zero-alpha `geom.rgba=[0,0,0,0]` in the shared post-dispatch block. `simulator/mujoco/scene_manager.py:219-221`.
  - **IsaacSim:** honored for **`plane` terrain only** — `_hide_prim_subtree` authors `visibility=invisible` on the `/World/ground` subtree. **`trimesh`/`load_obj` terrain silently ignores `hide_visual`** (the mesh branch never calls it — no warning, no effect). `simulator/isaacsim/isaacsim.py:73-86, 457-460`.
  - **IsaacGym:** **never actually hides.** Headless is a trivial no-op (nothing drawn); headful logs an "unsupported" warning and leaves the ground visible. `simulator/isaacgym/isaacgym.py:201-210`.

### Removed / fail-loud (config surface)
- **`control_decimation` / `render_interval` retyped `int` → `DecimationLike` (`int | str`)** with a new `SimEngineConfig` `model_validator` (`_validate_rates`). The base had **no** validation on these fields; now a malformed rate raises `pydantic.ValidationError` **at config construction**: `int < 1` (e.g. `0`, `-3` — previously accepted) and unparseable / non-exact-divisor strings (`"banana"`, bare `"60Hz"` at `fps=200`). `config_types/simulator.py:123,143,152-160`, `config_types/frequency.py`.
- **Resolved-int read path moved to `*_steps` properties.** Any code that read the raw `control_decimation` / `render_interval` as an int must switch to `control_decimation_steps` / `render_interval_steps` (the field now holds the value as written, which may be a string). All in-tree callers already migrated. `config_types/simulator.py:163-172`.

### Latent edge-case (no shipped preset triggers it)
- **`run_sim` explicit `--device cpu` + mjwarp:** old logic force-upgraded any `"cpu"` to `cuda:0` for WARP; new logic honors an explicit `cpu`. Only reachable by explicitly passing `--device cpu` to a Warp run, which is not a valid config (Warp is CUDA-only). `run_sim.py:35-47`.

_Note: the IsaacSim `link_physics.isaacsim` NameError fix that previously rode along in this PR's imports has been moved to its origin, **PR 03** (`fix(isaacsim): import stage_utils and Usd for link_physics material bind`) — that's where `_bind_robot_link_material` and its unimported use were introduced. PR 05 now only adds `UsdGeom` (needed by its own `_hide_prim_subtree`); `stage_utils`/`Usd` arrive via PR 03. This PR's final tree is unchanged by the move._

## Migration guide (API/config surface)

**Rate fields — read the resolved `*_steps` property**
```python
# BEFORE                                      # AFTER
for _ in range(sim.control_decimation):       for _ in range(sim.control_decimation_steps):
sim_fps / sim.control_decimation              sim_fps / sim.control_decimation_steps
render_interval < control_decimation          render_interval_steps < control_decimation_steps
```
Fields now accept a frequency string resolved against `fps`: `"50Hz"` requires an exact decimation (errors if `fps/target` isn't whole), `">50Hz"` floors (achieved rate ≥ target), `"<50Hz"` ceils (achieved rate ≤ target). Ints ≥ 1 pass through unchanged. `int < 1` and malformed strings now raise `ValidationError` at construction.

**run_sim device default (currently undocumented in the migration guide — add it)**
```python
# BEFORE                                      # AFTER
RunSimConfig.device: str | None = "cpu"       RunSimConfig.device: str | None = None
# unset --device:                             # unset --device resolves per backend:
#   mjwarp            -> cuda:0                #   mjwarp             -> cuda:0        (unchanged)
#   isaacsim/isaacgym -> cpu                   #   isaacsim/isaacgym  -> cuda:0 if CUDA else cpu  (CHANGED)
#   classic mujoco    -> cpu                   #   classic mujoco     -> cpu          (unchanged)
```
Pass an explicit `--device cpu` (or `--device cuda:1`) to pin the old behavior. IsaacSim/IsaacGym users who want the previous CPU default **must** now pass `--device cpu`.

**terrain `hide_visual`** — additive field, default `False`; no migration required. If you set it `True`, note the per-backend support matrix above (MuJoCo: all; IsaacSim: plane only; IsaacGym: unsupported/warns).
