### PR TITLE
Hook system for simulation callbacks

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,6 +17,12 @@ warn_unused_ignores = True
 disallow_untyped_defs = True
 disallow_any_generics = True
 
+# The arity-guard tests carry ``type: ignore[call-overload]`` on registrations that HookRegistry.add's
+# typed overloads must reject. warn_unused_ignores makes those ignores load-bearing: if the overloads
+# regress and stop flagging the mismatch, the now-unused ignore fails mypy in CI.
+[mypy-holosoma.simulator.base_simulator.tests.test_hooks]
+warn_unused_ignores = True
+
 # Please keep them alphabetically sorted
 
 [mypy-booster_robotics_sdk.*]

--- a/src/holosoma/holosoma/envs/base_task/base_task.py
+++ b/src/holosoma/holosoma/envs/base_task/base_task.py
@@ -14,6 +14,7 @@ from holosoma.managers.reward import RewardManager
 from holosoma.managers.termination import TerminationManager
 from holosoma.managers.terrain import TerrainManager
 from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+from holosoma.simulator.base_simulator.hooks import Phase
 from holosoma.simulator.shared.object_registry import ObjectType
 from holosoma.utils.helpers import get_class
 from holosoma.utils.safe_torch_import import torch
@@ -243,8 +244,7 @@ class BaseTask:
 
         # Call episode end for environments that are being reset
         for env_id in env_ids:
-            if hasattr(self.simulator, "on_episode_end"):
-                self.simulator.on_episode_end(env_id.item())
+            self.simulator.hooks.emit(Phase.EPISODE_END, env_id.item())
 
         # Reset observation history BEFORE state changes (must happen first to clear history buffers)
         self.observation_manager.reset(env_ids)
@@ -279,8 +279,7 @@ class BaseTask:
 
         # Call episode start for environments that have been reset
         for env_id in env_ids:
-            if hasattr(self.simulator, "on_episode_start"):
-                self.simulator.on_episode_start(env_id.item())
+            self.simulator.hooks.emit(Phase.EPISODE_START, env_id.item())
 
     def _reset_envs_idx_impl(self, env_ids, target_states=None, target_buf=None):
         """Template implementation of environment reset.
@@ -450,10 +449,13 @@ class BaseTask:
             self.action_manager.process_actions(actions)
 
     def _physics_step(self):
+        self.simulator.hooks.emit(Phase.FRAME_BEGIN)
         self.render()
         for _ in range(self.simulator.simulator_config.sim.control_decimation_steps):
             self._apply_force_in_physics_step()
+            self.simulator.hooks.emit(Phase.PRE_STEP)
             self.simulator.simulate_at_each_physics_step()
+            self.simulator.hooks.emit(Phase.POST_STEP)
 
     def _apply_force_in_physics_step(self):
         if self.action_manager is not None:
@@ -461,6 +463,7 @@ class BaseTask:
 
     def _post_physics_step(self):
         self._refresh_sim_tensors()
+        self.simulator.hooks.emit(Phase.FRAME_END)
         self.episode_length_buf += 1
         self._update_counters_each_step()
 

--- a/src/holosoma/holosoma/simulator/base_simulator/base_simulator.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/base_simulator.py
@@ -12,6 +12,7 @@ from holosoma.config_types.robot import RobotConfig
 from holosoma.config_types.scene import SceneConfig
 from holosoma.config_types.simulator import SimulatorInitConfig
 from holosoma.managers.terrain import TerrainManager
+from holosoma.simulator.base_simulator.hooks import HookRegistry, Phase
 from holosoma.simulator.shared.object_registry import ObjectRegistry, ObjectType
 from holosoma.simulator.shared.scene_types import SceneInterface
 from holosoma.simulator.types import ActorIndices, ActorNames, ActorPoses, ActorStates, EnvIds
@@ -173,6 +174,8 @@ class BaseSimulator:
         self.headless = False
         self.debug_viz_enabled = self.simulator_config.debug_viz
         self.object_registry = ObjectRegistry(device)
+        self.hooks = HookRegistry(base_rates=self._hook_base_rates())
+        self._closed = False
 
         # Virtual gantry system
         self.virtual_gantry: VirtualGantry | None = None
@@ -563,70 +566,33 @@ class BaseSimulator:
             from holosoma.simulator.shared.simulator_bridge import SimulatorBridge
 
             self.bridge = SimulatorBridge(self, self.simulator_config.bridge)
+            self.bridge.register_hooks(self.hooks)
             logger.info("Bridge system initialized successfully")
         except Exception as e:
             logger.error(f"Failed to initialize bridge system: {e}")
             raise
 
-    def _step_bridge(self) -> None:
-        """Step bridge system if enabled.
+    def _hook_base_rates(self) -> dict[Phase, float]:
+        """Base tick rate (Hz) of each periodic phase, so hooks can request a rate via ``every="30Hz"``.
 
-        Should be called by subclasses during each physics step,
-        typically before physics simulation. Handles bridge state
-        publishing and command processing.
+        Per-substep phases tick at ``fps``; per-frame phases at the control rate ``fps / control_decimation``.
         """
-        if self.bridge is not None:
-            self.bridge.step()
+        sim = self.simulator_config.sim
+        fps = float(sim.fps)
+        control_hz = fps / sim.control_decimation_steps
+        return {
+            Phase.PRE_STEP: fps,
+            Phase.POST_STEP: fps,
+            Phase.FRAME_BEGIN: control_hz,
+            Phase.FRAME_END: control_hz,
+        }
 
-    # ----- Video Recording Interface -----
-    def on_episode_start(self, env_id: int = 0) -> None:
-        """Called when an episode starts.
-
-        This method provides a hook for video recording and other episode-based
-        functionality. Subclasses can override this method to add additional
-        episode start logic while calling super() to maintain video recording.
-
-        Parameters
-        ----------
-        env_id : int, default=0
-            The environment ID where the episode is starting.
-        """
-        if self.virtual_gantry is not None and env_id == 0:
-            # Follow robot on start (may want this configurable later)
-            self.virtual_gantry.set_position_to_robot()
-
-        if self.video_recorder is not None:
-            self.video_recorder.on_episode_start(env_id)
-
-    def on_episode_end(self, env_id: int = 0) -> None:
-        """Called when an episode ends.
-
-        This method provides a hook for video recording and other episode-based
-        functionality. Subclasses can override this method to add additional
-        episode end logic while calling super() to maintain video recording.
-
-        Parameters
-        ----------
-        env_id : int, default=0
-            The environment ID where the episode is ending.
-        """
-        if self.video_recorder is not None:
-            self.video_recorder.on_episode_end(env_id)
-
-    def capture_video_frame(self, env_id: int = 0) -> None:
-        """Capture a video frame during simulation.
-
-        This method should be called during each simulation step when video
-        recording is active. It delegates to the video recorder if one is
-        configured and currently recording.
-
-        Parameters
-        ----------
-        env_id : int, default=0
-            The environment ID where the frame is being captured.
-        """
-        if self.video_recorder is not None:
-            self.video_recorder.capture_frame(env_id)
+    def close(self) -> None:
+        """Tear down simulator-owned runtime participants."""
+        if self._closed:
+            return
+        self._closed = True
+        self.hooks.emit(Phase.CLOSE)
 
     # ----- Actor/Object Access Interface -----
     # These methods provide unified access to objects registered with ObjectType enum

--- a/src/holosoma/holosoma/simulator/base_simulator/hooks.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/hooks.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Mapping
+
+from typing_extensions import Self
+
+from holosoma.config_types.frequency import DecimationLike, is_frequency_string, resolve_decimation
+
+
+class Phase(str, Enum):
+    """Lifecycle points emitted by the active simulator loop.
+
+    ``payload`` names the positional args ``emit`` forwards to callbacks. ``periodic`` marks phases
+    that fire on a fixed clock (per-substep or per-frame ticks) — only these accept a frequency-string
+    rate (``"30Hz"``) for :meth:`HookRegistry.add`'s ``every``; event phases (episode/close) accept an
+    int decimation ("every Nth event") but reject frequency strings, which have no clock to resolve
+    against.
+
+    ``FRAME_*`` bracket the outer tick (once per frame); ``*_STEP`` bracket each physics substep. The
+    names are engine-agnostic — they don't assume what drives the outer tick (a policy, a bridge, ...).
+    """
+
+    payload: tuple[str, ...]
+    periodic: bool
+
+    FRAME_BEGIN = ("frame_begin", (), True)
+    PRE_STEP = ("pre_step", (), True)
+    POST_STEP = ("post_step", (), True)
+    FRAME_END = ("frame_end", (), True)
+    EPISODE_END = ("episode_end", ("env_id",), False)
+    EPISODE_START = ("episode_start", ("env_id",), False)
+    CLOSE = ("close", (), False)
+
+    def __new__(cls, value: str, payload: tuple[str, ...], periodic: bool) -> Self:
+        obj = str.__new__(cls, value)
+        obj._value_ = value
+        obj.payload = payload
+        obj.periodic = periodic
+        return obj
+
+
+class HookRegistryError(RuntimeError):
+    """Raised when the hook registry is misused."""
+
+
+class HookCloseError(RuntimeError):
+    """Raised after close hooks run if one or more hooks failed."""
+
+    def __init__(self, failures: list[tuple[str, Exception]]) -> None:
+        self.failures = failures
+        details = ", ".join(f"{name}: {exc!r}" for name, exc in failures)
+        super().__init__(f"{len(failures)} close hook(s) failed: {details}")
+
+
+@dataclass
+class _HookRecord:
+    phase: Phase
+    callback: Callable[..., Any]
+    name: str
+    every: int = 1
+    """Resolved emission decimation: the callback runs once per ``every`` emissions of its phase."""
+    _counter: int = 0
+    """Emissions counted toward the next fire; only advances while enabled (disabled hooks leave the snapshot)."""
+    enabled: bool = True
+    removed: bool = False
+
+    def due(self) -> bool:
+        """Advance the per-hook counter and report whether this emission should fire the callback."""
+        self._counter += 1
+        if self._counter >= self.every:
+            self._counter = 0
+            return True
+        return False
+
+
+class HookHandle:
+    """Identity handle returned by hook registration."""
+
+    def __init__(self, registry: HookRegistry, record: _HookRecord) -> None:
+        self._registry = registry
+        self._record = record
+
+    @property
+    def name(self) -> str:
+        return self._record.name
+
+    @property
+    def phase(self) -> Phase:
+        return self._record.phase
+
+    @property
+    def enabled(self) -> bool:
+        return self._record.enabled and not self._record.removed
+
+    @property
+    def every(self) -> int:
+        """Current resolved emission decimation (see :meth:`set_every`)."""
+        return self._record.every
+
+    def enable(self) -> None:
+        self._registry._enable(self._record)
+
+    def disable(self) -> None:
+        self._registry._disable(self._record)
+
+    def set_every(self, every: DecimationLike) -> None:
+        """Change this hook's cadence live (int decimation or frequency string), resetting its counter.
+
+        Same rules as ``every`` at registration. Safe to call while other phases emit, but not from
+        inside this hook's own phase (mutating a phase mid-emit raises)."""
+        self._registry._set_every(self._record, every)
+
+    def remove(self) -> None:
+        self._registry._remove(self._record)
+
+
+class HookRegistry:
+    """Small lifecycle hook registry with deterministic registration order."""
+
+    def __init__(self, base_rates: Mapping[Phase, float] | None = None) -> None:
+        self._records: dict[Phase, list[_HookRecord]] = {phase: [] for phase in Phase}
+        self._snapshots: dict[Phase, tuple[_HookRecord, ...]] = dict.fromkeys(Phase, ())
+        self._emitting: set[Phase] = set()
+        self._closed = False
+        self._base_rates: dict[Phase, float] = dict(base_rates or {})
+
+    def add(
+        self,
+        phase: Phase,
+        callback: Callable[..., Any],
+        *,
+        name: str | None = None,
+        every: DecimationLike = 1,
+    ) -> HookHandle:
+        """Register a hook callback for a lifecycle phase.
+
+        ``every`` sub-samples emissions: an int decimation runs the callback once per ``every``
+        emissions; a frequency string (``"30Hz"``, ``">30Hz"``, ``"<30Hz"``) is resolved against the
+        phase's base tick rate into that decimation. Frequency strings require a periodic phase and a
+        known base rate; event phases (episode/close) accept only int decimations. Default ``1`` fires
+        every emission.
+        """
+        self._assert_mutable(phase)
+        record = _HookRecord(
+            phase=phase,
+            callback=callback,
+            name=name or self._default_name(callback),
+            every=self._resolve_every(phase, every, name),
+        )
+        self._records[phase].append(record)
+        self._rebuild(phase)
+        return HookHandle(self, record)
+
+    def _resolve_every(self, phase: Phase, every: DecimationLike, name: str | None) -> int:
+        """Turn a hook's ``every`` into an int decimation, resolving frequency strings vs the base rate."""
+        field = f"hook {name or '<callback>'!r} on phase {phase.value!r} 'every'"
+        if phase is Phase.CLOSE and every != 1:
+            raise HookRegistryError(f"{field}: CLOSE fires once at teardown; decimating it would skip cleanup.")
+        if is_frequency_string(every):
+            if not phase.periodic:
+                raise HookRegistryError(
+                    f"{field}: phase {phase.value!r} is not periodic; use an int decimation, not {every!r}."
+                )
+            base_hz = self._base_rates.get(phase)
+            if base_hz is None:
+                raise HookRegistryError(
+                    f"{field}: no base rate registered for periodic phase {phase.value!r}; "
+                    f"cannot resolve frequency {every!r}. Pass base_rates to HookRegistry, or use an int."
+                )
+            return resolve_decimation(every, base_hz, field=field, log=True)
+        return resolve_decimation(every, base_hz=1.0, field=field)
+
+    def emit(self, phase: Phase, *args: Any) -> None:
+        """Run each enabled hook due this emission, in registration order (CLOSE runs once, reversed)."""
+        self._validate_payload(phase, args)
+
+        if phase is Phase.CLOSE:
+            if self._closed:
+                return
+
+            if phase in self._emitting:
+                raise HookRegistryError("Recursive close hook emission is not supported")
+
+            self._closed = True
+            failures: list[tuple[str, Exception]] = []
+            self._emitting.add(phase)
+            try:
+                for record in reversed(self._snapshots[phase]):
+                    try:
+                        record.callback()
+                    except Exception as exc:  # noqa: PERF203
+                        failures.append((record.name, exc))
+            finally:
+                self._emitting.remove(phase)
+
+            if failures:
+                raise HookCloseError(failures)
+            return
+
+        if phase in self._emitting:
+            raise HookRegistryError(f"Recursive hook emission is not supported for phase {phase.value!r}")
+
+        self._emitting.add(phase)
+        try:
+            for record in self._snapshots[phase]:
+                if record.due():
+                    record.callback(*args)
+        finally:
+            self._emitting.remove(phase)
+
+    @staticmethod
+    def _validate_payload(phase: Phase, args: tuple[Any, ...]) -> None:
+        expected = phase.payload
+        if len(args) == len(expected):
+            return
+        expected_text = ", ".join(expected) or "no arguments"
+        raise HookRegistryError(f"Phase {phase.value!r} expects {expected_text}")
+
+    def _enable(self, record: _HookRecord) -> None:
+        if record.removed or record.enabled:
+            return
+        self._assert_mutable(record.phase)
+        record.enabled = True
+        self._rebuild(record.phase)
+
+    def _disable(self, record: _HookRecord) -> None:
+        if record.removed or not record.enabled:
+            return
+        self._assert_mutable(record.phase)
+        record.enabled = False
+        self._rebuild(record.phase)
+
+    def _set_every(self, record: _HookRecord, every: DecimationLike) -> None:
+        if record.removed:
+            raise HookRegistryError(f"Cannot set cadence on removed hook {record.name!r}.")
+        self._assert_mutable(record.phase)
+        record.every = self._resolve_every(record.phase, every, record.name)
+        record._counter = 0
+
+    def _remove(self, record: _HookRecord) -> None:
+        if record.removed:
+            return
+        self._assert_mutable(record.phase)
+        record.enabled = False
+        record.removed = True
+        self._rebuild(record.phase)
+
+    def _rebuild(self, phase: Phase) -> None:
+        self._snapshots[phase] = tuple(
+            record for record in self._records[phase] if record.enabled and not record.removed
+        )
+
+    def _assert_mutable(self, phase: Phase) -> None:
+        if phase in self._emitting:
+            raise HookRegistryError(f"Cannot mutate hooks while emitting phase {phase.value!r}")
+
+    @staticmethod
+    def _default_name(callback: Callable[..., Any]) -> str:
+        return getattr(callback, "__qualname__", repr(callback))

--- a/src/holosoma/holosoma/simulator/base_simulator/hooks.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/hooks.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, overload
 
-from typing_extensions import Self
+from typing_extensions import Literal, Self
 
 from holosoma.config_types.frequency import DecimationLike, is_frequency_string, resolve_decimation
 
@@ -39,6 +40,18 @@ class Phase(str, Enum):
         obj.payload = payload
         obj.periodic = periodic
         return obj
+
+
+# Callback shapes keyed to each phase's payload, so :meth:`HookRegistry.add`'s typed overloads
+# reject an arity mismatch (e.g. a one-arg callback on a zero-payload phase) at type-check time.
+# A callback with only-defaulted params still satisfies the zero-arg alias, matching the runtime
+# ``inspect``-based check in ``add``.
+FrameCallback = Callable[[], Any]
+"""Callback for a zero-payload periodic phase (``FRAME_BEGIN``/``PRE_STEP``/``POST_STEP``/``FRAME_END``)."""
+EpisodeCallback = Callable[[int], Any]
+"""Callback for an episode phase (``EPISODE_START``/``EPISODE_END``); receives ``env_id``."""
+CloseCallback = Callable[[], Any]
+"""Callback for ``CLOSE`` (zero payload, fires once at teardown)."""
 
 
 class HookRegistryError(RuntimeError):
@@ -126,6 +139,36 @@ class HookRegistry:
         self._closed = False
         self._base_rates: dict[Phase, float] = dict(base_rates or {})
 
+    @overload
+    def add(
+        self,
+        phase: Literal[Phase.FRAME_BEGIN, Phase.PRE_STEP, Phase.POST_STEP, Phase.FRAME_END],
+        callback: FrameCallback,
+        *,
+        name: str | None = None,
+        every: DecimationLike = 1,
+    ) -> HookHandle: ...
+
+    @overload
+    def add(
+        self,
+        phase: Literal[Phase.EPISODE_END, Phase.EPISODE_START],
+        callback: EpisodeCallback,
+        *,
+        name: str | None = None,
+        every: DecimationLike = 1,
+    ) -> HookHandle: ...
+
+    @overload
+    def add(
+        self,
+        phase: Literal[Phase.CLOSE],
+        callback: CloseCallback,
+        *,
+        name: str | None = None,
+        every: DecimationLike = 1,
+    ) -> HookHandle: ...
+
     def add(
         self,
         phase: Phase,
@@ -136,6 +179,13 @@ class HookRegistry:
     ) -> HookHandle:
         """Register a hook callback for a lifecycle phase.
 
+        The callback's signature must accept the phase's payload (see :class:`Phase`): zero args for
+        the periodic ``FRAME_*``/``*_STEP`` phases and ``CLOSE``, one ``env_id`` for the episode
+        phases. The typed overloads reject a mismatch at type-check time; :meth:`_check_arity` also
+        checks it at registration, so a wrong-arity callback fails loudly at ``add`` rather than with a
+        ``TypeError`` on the first ``emit``. A parameter with a default still satisfies a phase that
+        passes fewer args (e.g. ``capture_frame(env_id: int = 0)`` on the zero-payload ``FRAME_END``).
+
         ``every`` sub-samples emissions: an int decimation runs the callback once per ``every``
         emissions; a frequency string (``"30Hz"``, ``">30Hz"``, ``"<30Hz"``) is resolved against the
         phase's base tick rate into that decimation. Frequency strings require a periodic phase and a
@@ -143,15 +193,50 @@ class HookRegistry:
         every emission.
         """
         self._assert_mutable(phase)
+        resolved_name = name or self._default_name(callback)
+        self._check_arity(phase, callback, resolved_name)
         record = _HookRecord(
             phase=phase,
             callback=callback,
-            name=name or self._default_name(callback),
+            name=resolved_name,
             every=self._resolve_every(phase, every, name),
         )
         self._records[phase].append(record)
         self._rebuild(phase)
         return HookHandle(self, record)
+
+    @staticmethod
+    def _check_arity(phase: Phase, callback: Callable[..., Any], name: str) -> None:
+        """Fail at registration if ``callback`` can't take the args ``emit`` will pass for ``phase``.
+
+        ``emit`` calls ``callback(*payload)`` with ``len(phase.payload)`` positional args. A callback is
+        compatible when it requires no more than that many positional params (extras must have defaults)
+        and can accept that many (via fixed params or ``*args``). Built-ins and C callables whose
+        signature ``inspect`` can't read are left to runtime.
+        """
+        try:
+            params = list(inspect.signature(callback).parameters.values())
+        except (TypeError, ValueError):
+            return  # Signature not introspectable (e.g. some C callables); defer to runtime.
+
+        n = len(phase.payload)
+        positional = [p for p in params if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)]
+        required = sum(1 for p in positional if p.default is p.empty)
+        has_varargs = any(p.kind is p.VAR_POSITIONAL for p in params)
+        max_positional = len(positional)
+
+        if required > n:
+            raise HookRegistryError(
+                f"hook {name!r} on phase {phase.value!r}: callback requires {required} positional "
+                f"arg(s) but the phase emits {n} ({', '.join(phase.payload) or 'none'}). "
+                f"Give the extra param(s) a default or drop them."
+            )
+        if not has_varargs and n > max_positional:
+            raise HookRegistryError(
+                f"hook {name!r} on phase {phase.value!r}: phase emits {n} arg(s) "
+                f"({', '.join(phase.payload)}) but the callback accepts at most {max_positional}. "
+                f"Accept the payload (add the param or *args)."
+            )
 
     def _resolve_every(self, phase: Phase, every: DecimationLike, name: str | None) -> int:
         """Turn a hook's ``every`` into an int decimation, resolving frequency strings vs the base rate."""

--- a/src/holosoma/holosoma/simulator/base_simulator/tests/test_hooks.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/tests/test_hooks.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import pytest
+
+from holosoma.simulator.base_simulator.hooks import HookCloseError, HookRegistry, HookRegistryError, Phase
+
+pytestmark = pytest.mark.no_sim
+
+
+def test_emit_uses_registration_order() -> None:
+    calls: list[str] = []
+    hooks = HookRegistry()
+
+    hooks.add(Phase.FRAME_END, lambda: calls.append("a"), name="a")
+    hooks.add(Phase.FRAME_END, lambda: calls.append("b"), name="b")
+
+    hooks.emit(Phase.FRAME_END)
+
+    assert calls == ["a", "b"]
+
+
+def test_handle_disable_enable_remove() -> None:
+    calls: list[str] = []
+    hooks = HookRegistry()
+    handle = hooks.add(Phase.FRAME_END, lambda: calls.append("a"), name="a")
+
+    handle.disable()
+    hooks.emit(Phase.FRAME_END)
+    handle.enable()
+    hooks.emit(Phase.FRAME_END)
+    handle.remove()
+    hooks.emit(Phase.FRAME_END)
+    handle.remove()
+
+    assert calls == ["a"]
+
+
+def test_mutating_current_phase_during_emit_raises() -> None:
+    hooks = HookRegistry()
+    handle = hooks.add(Phase.FRAME_END, lambda: None, name="a")
+    hooks.add(Phase.FRAME_END, handle.remove, name="remove")
+
+    with pytest.raises(HookRegistryError, match="Cannot mutate hooks"):
+        hooks.emit(Phase.FRAME_END)
+
+
+def test_close_runs_reverse_order_once_and_reports_failures() -> None:
+    calls: list[str] = []
+    hooks = HookRegistry()
+
+    hooks.add(Phase.CLOSE, lambda: calls.append("first"), name="first")
+
+    def fail() -> None:
+        calls.append("second")
+        raise RuntimeError("boom")
+
+    hooks.add(Phase.CLOSE, fail, name="second")
+
+    with pytest.raises(HookCloseError) as exc_info:
+        hooks.emit(Phase.CLOSE)
+
+    hooks.emit(Phase.CLOSE)
+
+    assert calls == ["second", "first"]
+    assert exc_info.value.failures[0][0] == "second"
+
+
+def test_close_phase_rejects_payload() -> None:
+    hooks = HookRegistry()
+
+    with pytest.raises(HookRegistryError, match="expects no arguments"):
+        hooks.emit(Phase.CLOSE, object())
+
+
+def test_phase_payloads_have_fixed_signatures() -> None:
+    hooks = HookRegistry()
+    calls: list[int] = []
+
+    def record_episode_start(env_id: int) -> None:
+        calls.append(env_id)
+
+    hooks.add(Phase.EPISODE_START, record_episode_start, name="episode_start")
+
+    hooks.emit(Phase.EPISODE_START, 7)
+
+    with pytest.raises(HookRegistryError, match="expects env_id"):
+        hooks.emit(Phase.EPISODE_START)
+    with pytest.raises(HookRegistryError, match="expects no arguments"):
+        hooks.emit(Phase.FRAME_END, 1)
+    assert calls == [7]
+
+
+def test_every_int_decimates_emissions() -> None:
+    calls: list[int] = []
+    hooks = HookRegistry()
+    hooks.add(Phase.POST_STEP, lambda: calls.append(1), name="third", every=3)
+
+    for _ in range(7):
+        hooks.emit(Phase.POST_STEP)
+
+    # fires on the 3rd, 6th emission (counter resets after each fire)
+    assert len(calls) == 2
+
+
+def test_every_default_fires_every_emission() -> None:
+    calls: list[int] = []
+    hooks = HookRegistry()
+    hooks.add(Phase.POST_STEP, lambda: calls.append(1), name="always")
+
+    for _ in range(5):
+        hooks.emit(Phase.POST_STEP)
+
+    assert len(calls) == 5
+
+
+def test_every_frequency_string_resolves_against_base_rate() -> None:
+    calls: list[int] = []
+    # base 200Hz physics tick; "50Hz" -> decimation 4.
+    hooks = HookRegistry(base_rates={Phase.POST_STEP: 200.0})
+    hooks.add(Phase.POST_STEP, lambda: calls.append(1), name="rate", every="50Hz")
+
+    for _ in range(8):
+        hooks.emit(Phase.POST_STEP)
+
+    assert len(calls) == 2  # fired on the 4th and 8th
+
+
+def test_every_frequency_string_needs_periodic_phase() -> None:
+    hooks = HookRegistry()
+    with pytest.raises(HookRegistryError, match="not periodic"):
+        hooks.add(Phase.EPISODE_START, lambda _env_id: None, name="bad", every="10Hz")
+
+
+def test_every_frequency_string_needs_base_rate() -> None:
+    hooks = HookRegistry()  # no base rates registered
+    with pytest.raises(HookRegistryError, match="no base rate"):
+        hooks.add(Phase.POST_STEP, lambda: None, name="bad", every="50Hz")
+
+
+def test_every_int_on_event_phase_is_allowed() -> None:
+    calls: list[int] = []
+    hooks = HookRegistry()
+    hooks.add(Phase.EPISODE_START, lambda env_id: calls.append(env_id), name="every_other", every=2)
+
+    for i in range(4):
+        hooks.emit(Phase.EPISODE_START, i)
+
+    assert calls == [1, 3]
+
+
+def test_close_rejects_decimation() -> None:
+    hooks = HookRegistry()
+    with pytest.raises(HookRegistryError, match="CLOSE fires once"):
+        hooks.add(Phase.CLOSE, lambda: None, name="bad", every=2)
+
+
+def test_invalid_every_raises() -> None:
+    hooks = HookRegistry()
+    with pytest.raises(ValueError, match="must be >= 1"):
+        hooks.add(Phase.POST_STEP, lambda: None, name="bad", every=0)
+
+
+def test_set_every_live_changes_cadence_and_resets_counter() -> None:
+    calls: list[int] = []
+    hooks = HookRegistry()
+    handle = hooks.add(Phase.POST_STEP, lambda: calls.append(1), name="rate")
+
+    hooks.emit(Phase.POST_STEP)  # every=1 -> fires
+    assert len(calls) == 1
+
+    handle.set_every(3)
+    assert handle.every == 3
+    for _ in range(5):
+        hooks.emit(Phase.POST_STEP)
+    # counter reset by set_every; fires on the 3rd of the 5 emissions
+    assert len(calls) == 2
+
+
+def test_set_every_accepts_frequency_string() -> None:
+    calls: list[int] = []
+    hooks = HookRegistry(base_rates={Phase.POST_STEP: 100.0})
+    handle = hooks.add(Phase.POST_STEP, lambda: calls.append(1), name="rate")
+
+    handle.set_every("25Hz")  # 100 / 25 -> 4
+    assert handle.every == 4
+    for _ in range(8):
+        hooks.emit(Phase.POST_STEP)
+    assert len(calls) == 2
+
+
+def test_set_every_during_own_phase_emit_raises() -> None:
+    hooks = HookRegistry()
+    handle = hooks.add(Phase.POST_STEP, lambda: None, name="a")
+    hooks.add(Phase.POST_STEP, lambda: handle.set_every(2), name="mutator")
+
+    with pytest.raises(HookRegistryError, match="Cannot mutate hooks"):
+        hooks.emit(Phase.POST_STEP)
+
+
+def test_set_every_on_removed_hook_raises() -> None:
+    hooks = HookRegistry()
+    handle = hooks.add(Phase.POST_STEP, lambda: None, name="a")
+    handle.remove()
+    with pytest.raises(HookRegistryError, match="removed hook"):
+        handle.set_every(2)

--- a/src/holosoma/holosoma/simulator/base_simulator/tests/test_hooks.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/tests/test_hooks.py
@@ -203,3 +203,72 @@ def test_set_every_on_removed_hook_raises() -> None:
     handle.remove()
     with pytest.raises(HookRegistryError, match="removed hook"):
         handle.set_every(2)
+
+
+# ----- callback-arity guard (add() rejects a signature that can't take the phase payload) -----
+
+
+def test_add_rejects_required_arg_on_zero_payload_phase() -> None:
+    hooks = HookRegistry()
+
+    def needs_env(env_id: int) -> None: ...
+
+    # POST_STEP emits no args, so a required positional param can never be filled.
+    # The ``type: ignore[call-overload]`` is load-bearing: mypy also rejects this mismatch via
+    # add()'s typed overloads, so if the overloads regress this ignore goes unused and CI notices.
+    with pytest.raises(HookRegistryError, match="requires 1 positional arg"):
+        hooks.add(Phase.POST_STEP, needs_env, name="bad")  # type: ignore[call-overload]
+
+
+def test_add_rejects_zero_arg_callback_on_episode_phase() -> None:
+    hooks = HookRegistry()
+
+    def takes_nothing() -> None: ...
+
+    # EPISODE_START emits env_id, but the callback accepts no positional args.
+    # ``type: ignore[call-overload]`` load-bearing (see test above): the overloads reject this too.
+    with pytest.raises(HookRegistryError, match="accepts at most 0"):
+        hooks.add(Phase.EPISODE_START, takes_nothing, name="bad")  # type: ignore[call-overload]
+
+
+def test_add_accepts_defaulted_arg_on_zero_payload_phase() -> None:
+    # The video recorder's ``capture_frame(env_id: int = 0)`` shape: the default covers the
+    # zero-arg FRAME/STEP emit, so it is a valid registration (not a mismatch).
+    hooks = HookRegistry()
+    calls: list[int] = []
+
+    def capture_frame(env_id: int = 0) -> None:
+        calls.append(env_id)
+
+    hooks.add(Phase.POST_STEP, capture_frame, name="video.capture_frame")
+    hooks.emit(Phase.POST_STEP)
+    assert calls == [0]  # default supplied, no crash
+
+
+def test_add_accepts_varargs_on_any_phase() -> None:
+    hooks = HookRegistry()
+
+    def anything(*args: object) -> None: ...
+
+    hooks.add(Phase.POST_STEP, anything, name="a")
+    hooks.add(Phase.EPISODE_END, anything, name="b")  # *args absorbs env_id too
+
+
+def test_add_arity_guard_ignores_self_on_bound_method() -> None:
+    # inspect.signature on a bound method excludes ``self``, so a one-arg method matches an
+    # episode phase and a defaulted-arg method matches a zero-payload phase.
+    hooks = HookRegistry()
+
+    class Participant:
+        def on_episode_start(self, env_id: int) -> None: ...
+        def capture_frame(self, env_id: int = 0) -> None: ...
+
+    p = Participant()
+    hooks.add(Phase.EPISODE_START, p.on_episode_start, name="ep")
+    hooks.add(Phase.FRAME_END, p.capture_frame, name="frame")
+
+
+def test_add_arity_guard_tolerates_uninspectable_callback() -> None:
+    # Some C-level callables reject inspect.signature; the guard must not block them.
+    hooks = HookRegistry()
+    hooks.add(Phase.EPISODE_END, print, name="builtin")  # print(*args) — accepts env_id

--- a/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
+++ b/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
@@ -371,12 +371,14 @@ class IsaacGym(BaseSimulator):
             attachment_body_names=gantry_cfg.attachment_body_names,
             cfg=gantry_cfg,
         )
+        self.virtual_gantry.register_hooks(self.hooks)
 
         # Initialize bridge system using base class helper
         self._init_bridge()
 
         if self.video_recorder:
             self.video_recorder.setup_recording()
+            self.video_recorder.register_hooks(self.hooks)
 
         # Initialize command system for keyboard controls
         # Command tensor format: [vx, vy, vz, yaw_rate, walk_stand, waist_yaw, ..., height, ...]
@@ -731,22 +733,10 @@ class IsaacGym(BaseSimulator):
         if not hasattr(self, "step_counter"):
             self.step_counter = 0
 
-        # Apply virtual gantry forces BEFORE physics step to ensure proper constraint behavior
-        # (forces must be part of the current step, not applied reactively after)
-        if self.virtual_gantry:
-            self.virtual_gantry.step()
-
-        # Step bridge for updated torques before physics step using base class helper
-        self._step_bridge()
-
         self.gym.simulate(self.sim)
 
         if self.sim_device == "cpu":
             self.gym.fetch_results(self.sim, True)
-
-        # Call video recorder capture frame if recording is active
-        if self.video_recorder:
-            self.capture_video_frame()
 
         self.gym.refresh_dof_state_tensor(self.sim)
 

--- a/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
@@ -839,6 +839,7 @@ class IsaacSim(BaseSimulator):
             attachment_body_names=gantry_cfg.attachment_body_names,
             cfg=gantry_cfg,
         )
+        self.virtual_gantry.register_hooks(self.hooks)
 
         # Initialize bridge system using base class helper
         self._init_bridge()
@@ -846,6 +847,7 @@ class IsaacSim(BaseSimulator):
         # Setup video recording after scene is ready
         if self.video_recorder:
             self.video_recorder.setup_recording()
+            self.video_recorder.register_hooks(self.hooks)
 
         # Initialize robot tensors
         self.refresh_sim_tensors()
@@ -920,13 +922,6 @@ class IsaacSim(BaseSimulator):
         has_video_recording = self.video_recorder is not None and self.video_recorder.is_recording
         is_rendering = self.sim.has_gui() or self.sim.has_rtx_sensors() or has_video_recording
 
-        # Apply virtual gantry forces before physics step
-        if self.virtual_gantry:
-            self.virtual_gantry.step()
-
-        # Step bridge for updated torques before physics step using base class helper
-        self._step_bridge()
-
         self.scene.write_data_to_sim()
 
         # simulate
@@ -955,10 +950,6 @@ class IsaacSim(BaseSimulator):
             current_base_vel = self.robot_root_states[:, 7:10]
             self.base_linear_acc = (current_base_vel - self.prev_base_lin_vel) / self.sim_dt
             self.prev_base_lin_vel = current_base_vel.clone()
-
-        # Call video recorder capture frame if recording is active
-        if self.video_recorder:
-            self.capture_video_frame()
 
     def setup_viewer(self):
         self.viewer = self.viewport_camera_controller

--- a/src/holosoma/holosoma/simulator/mujoco/mujoco.py
+++ b/src/holosoma/holosoma/simulator/mujoco/mujoco.py
@@ -354,6 +354,7 @@ class MuJoCo(BaseSimulator):
             attachment_body_names=gantry_cfg.attachment_body_names,
             cfg=gantry_cfg,
         )
+        self.virtual_gantry.register_hooks(self.hooks)
 
         # Initialize bridge system using base class helper
         self._init_bridge()
@@ -361,6 +362,7 @@ class MuJoCo(BaseSimulator):
         if self.video_config.enabled:
             self.video_recorder = MuJoCoVideoRecorder(self.video_config, self)
             self.video_recorder.setup_recording()
+            self.video_recorder.register_hooks(self.hooks)
 
         # For debugging
         self.print_mujoco_model_tree()
@@ -1071,19 +1073,8 @@ class MuJoCo(BaseSimulator):
     def simulate_at_each_physics_step(self) -> None:
         """Advance simulation by one step."""
 
-        if self.virtual_gantry:
-            # Apply virtual gantry forces before step
-            self.virtual_gantry.step()
-
-        # Step bridge for updated torques before step using base class helper
-        self._step_bridge()
-
         # Delegate simulation step to backend
         self.backend.step()
-
-        # Call video recorder capture frame if recording is active
-        if self.video_recorder and self.video_recorder.is_recording:
-            self.capture_video_frame()
 
     def _actor_freejoint_addrs(self, obj_name: str) -> tuple[int, int]:
         """Return (qpos_addr, qvel_addr) for an actor's freejoint, or raise if unknown."""

--- a/src/holosoma/holosoma/simulator/shared/simulator_bridge.py
+++ b/src/holosoma/holosoma/simulator/shared/simulator_bridge.py
@@ -14,11 +14,13 @@ from loguru import logger
 
 from holosoma.bridge import BasicSdk2Bridge, create_sdk2py_bridge
 from holosoma.config_types.simulator import BridgeConfig
+from holosoma.simulator.base_simulator.hooks import Phase
 from holosoma.utils.clock import ClockPub
 from holosoma.utils.safe_torch_import import torch
 
 if TYPE_CHECKING:
     from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+    from holosoma.simulator.base_simulator.hooks import HookRegistry
 
 
 class SimulatorBridge:
@@ -68,6 +70,19 @@ class SimulatorBridge:
         else:
             # We don't support runtime toggling on/off
             logger.info("Robot bridge disabled")
+
+    def register_hooks(self, hooks: HookRegistry) -> None:
+        """Register bridge lifecycle hooks with the simulator loop.
+
+        step() is PRE_STEP: it applies SDK-computed torques, which must land before the substep
+        integrates them.
+        """
+        hooks.add(Phase.PRE_STEP, self.step, name="bridge.step")
+        hooks.add(Phase.CLOSE, self.close, name="bridge.close")
+
+    def close(self) -> None:
+        """Tear down bridge-owned resources (clock publisher ZMQ socket)."""
+        self.clock_pub.close()
 
     def _init_robot_bridge(self):
         """Initialize the robot bridge using the copied factory function."""

--- a/src/holosoma/holosoma/simulator/shared/video_recorder.py
+++ b/src/holosoma/holosoma/simulator/shared/video_recorder.py
@@ -20,12 +20,14 @@ import numpy as np
 import numpy.typing as npt
 from loguru import logger
 
+from holosoma.simulator.base_simulator.hooks import Phase
 from holosoma.simulator.shared.camera_controller import CameraController, CameraParameters
 from holosoma.utils.video_utils import create_video, format_command_labels, overlay_text_on_image
 
 if TYPE_CHECKING:
     from holosoma.config_types.video import VideoConfig
     from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+    from holosoma.simulator.base_simulator.hooks import HookRegistry
 
 
 class VideoRecorderInterface(ABC):
@@ -84,9 +86,6 @@ class VideoRecorderInterface(ABC):
         # Camera controller for unified camera positioning
         self.camera_controller = CameraController(config.camera, simulator)
 
-        # Frame decimation counter for capturing at control frequency
-        self._frame_counter: int = 0
-
         # Performance timing statistics
         self._frame_times: list[float] = []
 
@@ -97,6 +96,18 @@ class VideoRecorderInterface(ABC):
 
         if config.use_recording_thread:
             self._setup_threaded_recording()
+
+    def register_hooks(self, hooks: HookRegistry) -> None:
+        """Register video lifecycle hooks with the simulator loop.
+
+        Frames are captured on FRAME_END, which fires once per frame (after the last physics substep +
+        tensor refresh) — the control rate the recorder wants — so no manual decimation against
+        control_decimation is needed.
+        """
+        hooks.add(Phase.EPISODE_START, self.on_episode_start, name="video.on_episode_start")
+        hooks.add(Phase.EPISODE_END, self.on_episode_end, name="video.on_episode_end")
+        hooks.add(Phase.FRAME_END, self.capture_frame, name="video.capture_frame")
+        hooks.add(Phase.CLOSE, self.cleanup, name="video.cleanup")
 
     def _setup_threaded_recording(self) -> None:
         """Shared threading setup logic."""
@@ -174,12 +185,8 @@ class VideoRecorderInterface(ABC):
     def capture_frame(self, env_id: int = 0) -> None:
         """Shared frame capture dispatch logic.
 
-        This method is called during each simulation step and handles the logic
-        for determining whether to actually capture a frame based on recording
-        state, environment filtering, and control decimation.
-
-        Frames are captured at control frequency (not physics frequency) by
-        only capturing on every Nth physics step, where N = control_decimation.
+        Registered on FRAME_END, which fires once per frame, so this captures at control frequency
+        without tracking physics steps. Filters on recording state and record_env_id.
 
         Parameters
         ----------
@@ -188,14 +195,6 @@ class VideoRecorderInterface(ABC):
         """
         # Only capture frames when recording is active and from the correct environment
         if not self._is_recording or env_id != self.config.record_env_id:
-            return
-
-        # Increment frame counter for decimation tracking
-        self._frame_counter += 1
-
-        # Only capture frame at control frequency (every control_decimation physics steps)
-        control_decimation = self.simulator.simulator_config.sim.control_decimation_steps
-        if self._frame_counter % control_decimation != 0:
             return
 
         if self.config.use_recording_thread:
@@ -517,9 +516,6 @@ class VideoRecorderInterface(ABC):
         """
         # Initialize frame buffer for new episode
         self._clear_frame_buffer()
-
-        # Reset frame counter for decimation tracking
-        self._frame_counter = 0
 
         # Reset camera controller to start from current robot position
         self.camera_controller.reset()

--- a/src/holosoma/holosoma/simulator/shared/virtual_gantry.py
+++ b/src/holosoma/holosoma/simulator/shared/virtual_gantry.py
@@ -7,15 +7,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
 from loguru import logger
 
 from holosoma.config_types.simulator import VirtualGantryCfg
+from holosoma.simulator.base_simulator.hooks import Phase
 from holosoma.utils.safe_torch_import import torch
 from holosoma.utils.simulator_config import SimulatorType, get_simulator_type
+
+if TYPE_CHECKING:
+    from holosoma.simulator.base_simulator.hooks import HookRegistry
 
 
 class GantryCommand(Enum):
@@ -108,6 +112,15 @@ class VirtualGantry:
         self._enabled: bool = enable
         self.set_enable(enable)
 
+    def register_hooks(self, hooks: HookRegistry) -> None:
+        """Register virtual gantry lifecycle hooks with the simulator loop.
+
+        step() is PRE_STEP: gantry forces must be applied before the substep so they act within it,
+        not reactively after.
+        """
+        hooks.add(Phase.PRE_STEP, self.step, name="virtual_gantry.step")
+        hooks.add(Phase.EPISODE_START, self.on_episode_start, name="virtual_gantry.on_episode_start")
+
     def _setup_force_application(self) -> None:
         """Set up simulator-specific force application and clearing methods.
 
@@ -188,6 +201,11 @@ class VirtualGantry:
         x, y = self.sim.robot_root_states[env_id, :3].detach().cpu().numpy()[:2]
         self.point = np.array([x, y, self.height])
         logger.debug(f"Virtual gantry position reset to '{self.point}'")
+
+    def on_episode_start(self, env_id: int) -> None:
+        """Reset the gantry anchor when the tracked environment starts."""
+        if env_id == 0:
+            self.set_position_to_robot()
 
     def handle_command(self, command_data: GantryCommandData | GantryCommand) -> bool:
         """Handle gantry commands with optional parameters.

--- a/src/holosoma/holosoma/train_agent.py
+++ b/src/holosoma/holosoma/train_agent.py
@@ -160,6 +160,7 @@ def train(tyro_config: ExperimentConfig, training_context: TrainingContext | Non
         simulation_app = init_sim_imports(tyro_config)
         auto_close = True
 
+    env = None
     try:
         # have to import torch after isaacgym
         import torch  # noqa: F401
@@ -310,6 +311,16 @@ def train(tyro_config: ExperimentConfig, training_context: TrainingContext | Non
         logger.error(f"Exception occurred during training: {e}\n{tb_str}")
         sys.exit(1)  # manually set exit code, not possible via isaacsim app.close()
     finally:
+        # Fire the simulator CLOSE phase (bridge/video teardown). Prefer env.close() if the env
+        # wrapper defines one; else reach the simulator directly.
+        if env is not None:
+            try:
+                if hasattr(env, "close"):
+                    env.close()
+                elif hasattr(env, "simulator") and hasattr(env.simulator, "close"):
+                    env.simulator.close()
+            except Exception as e:
+                logger.warning(f"Environment close failed: {e}")
         if auto_close:
             close_simulation_app(simulation_app)
 

--- a/src/holosoma/holosoma/utils/sim_utils.py
+++ b/src/holosoma/holosoma/utils/sim_utils.py
@@ -22,6 +22,7 @@ from holosoma.config_types.experiment import ExperimentConfig
 from holosoma.config_types.full_sim import FullSimConfig
 from holosoma.config_types.run_sim import RunSimConfig
 from holosoma.managers.terrain.manager import TerrainManager
+from holosoma.simulator.base_simulator.hooks import Phase
 from holosoma.utils.common import seeding
 from holosoma.utils.helpers import get_class
 from holosoma.utils.rate import RateLimiter
@@ -433,9 +434,9 @@ class DirectSimulation:
         self.simulator.prepare_sim()
         logger.debug("simulator.prepare_sim() completed")
 
-        # Step 5.5: Initialize episode (positions virtual gantry, etc.)
-        self.simulator.on_episode_start(env_id=0)
-        logger.debug("simulator.on_episode_start() completed")
+        # Step 5.5: Initialize episode (positions virtual gantry, starts lifecycle participants, etc.)
+        self.simulator.hooks.emit(Phase.EPISODE_START, 0)
+        logger.debug("simulator episode-start hooks completed")
 
         # Step 6: Setup viewer if not headless
         if not self.config.training.headless:
@@ -458,6 +459,7 @@ class DirectSimulation:
         """
         # Setup rate limiting
         sim_frequency = self.config.simulator.config.sim.fps
+        control_decimation = self.config.simulator.config.sim.control_decimation_steps
         rate_limiter = RateLimiter(sim_frequency)
 
         # Calculate viewer sync frequency
@@ -488,8 +490,15 @@ class DirectSimulation:
                 # Refresh tensors if needed (no-op for MuJoCo)
                 pre_step_refresh()
 
-                # Direct simulator step - this triggers bridge.step() inside simulate_at_each_physics_step()
+                # Direct simulator step with the same physics hooks used by BaseTask.
+                if step_count % control_decimation == 0:
+                    self.simulator.hooks.emit(Phase.FRAME_BEGIN)
+                self.simulator.hooks.emit(Phase.PRE_STEP)
                 self.simulator.simulate_at_each_physics_step()
+                self.simulator.hooks.emit(Phase.POST_STEP)
+
+                if step_count % control_decimation == 0:
+                    self.simulator.hooks.emit(Phase.FRAME_END)
 
                 # Update viewer at display rate
                 if step_count % viewer_steps == 0:
@@ -518,12 +527,11 @@ class DirectSimulation:
 
     def cleanup(self) -> None:
         """Handle simulation cleanup."""
-        # Cleanup environment
+        # Fire the simulator CLOSE phase (bridge/video teardown), via env.close() if defined else direct.
         if hasattr(self.env, "close"):
             self.env.close()
-
-        if self.simulator.video_recorder:
-            self.simulator.video_recorder.cleanup()
+        else:
+            self.simulator.close()
 
         # Cleanup simulation app
         if self.simulation_app:


### PR DESCRIPTION
## Summary

Replaces the hard-coded step-loop side effects scattered across the simulator backends with a single lifecycle **hook registry**. Instead of each backend hand-calling `virtual_gantry.step()`, `_step_bridge()`, and `capture_video_frame()` inside its `simulate_at_each_physics_step`, and overriding `on_episode_start/end`, the runtime participants now register callbacks against typed `Phase` events that `BaseTask` (and the `run_sim` `DirectSimulation` loop) emit.

1. **`hooks.py` — new `HookRegistry` + `Phase` enum.** Seven lifecycle phases: `FRAME_BEGIN` / `FRAME_END` bracket the outer control-rate tick, `PRE_STEP` / `POST_STEP` bracket each physics substep, plus `EPISODE_START`, `EPISODE_END`, `CLOSE`. Deterministic registration-order dispatch, per-phase payload-arity validation, `enable/disable/remove` handles, mutation-during-emit guards, and a reverse-order `CLOSE` that runs every hook exactly once and aggregates failures into one `HookCloseError`. Covered by `tests/test_hooks.py` (`no_sim`).
2. **Per-hook cadence — `every`.** `hooks.add(phase, fn, every=4)` runs a callback once per N emissions of its phase. On periodic phases (`FRAME_*`, `*_STEP`), `every` also accepts a frequency string (`"30Hz"`, `">30Hz"`, `"<30Hz"`) resolved against the phase's base tick rate, which `BaseSimulator._hook_base_rates()` supplies from the sim config: `fps` for the substep phases, `fps / control_decimation_steps` for the frame phases. `HookHandle.set_every()` retunes a live hook (counter resets). Event phases (episode) accept int decimation only; `CLOSE` rejects any decimation.
3. **Participants self-register.** `SimulatorBridge`, `VirtualGantry`, and the video recorder each gain a `register_hooks()` that wires their existing methods to phases. The backends call `participant.register_hooks(self.hooks)` at setup; their step methods lose the inline calls.
4. **Deterministic teardown.** New `BaseSimulator.close()` (idempotent) emits `Phase.CLOSE`; `train_agent.py` closes the env in a `finally`, and `DirectSimulation.cleanup()` routes through `env.close()` / `simulator.close()`. Adds `SimulatorBridge.close()` (closes the clock-publisher socket) — **it did not previously exist**, and registering it for `CLOSE` is what surfaced the bug below.

Behavior-preserving for every shipped run: the same callbacks fire at the same rate, in the same order.

## Behavior changes by user impact

### Newly present (opt-in / internal; no shipped run affected)
- **`Phase.CLOSE` teardown path.** `BaseSimulator.close()` now emits `CLOSE`, running `bridge.close` (clock socket) and `video.cleanup` in reverse registration order, idempotently. Previously teardown was ad-hoc: `DirectSimulation.cleanup` only called `video_recorder.cleanup()`, and the bridge's clock socket was never explicitly closed. Both `train_agent.py` (new `finally`) and `DirectSimulation` now go through `close()`.
- **`HookRegistry` public surface on `BaseSimulator.hooks`.** New extension point — downstream code can register per-phase callbacks (with an optional cadence) without subclassing a backend or overriding `on_episode_*`.
- **`run_sim` loop emits the same phases as training.** `DirectSimulation.run()` emits `PRE_STEP`/`POST_STEP` every physics step and `FRAME_BEGIN`/`FRAME_END` every `control_decimation_steps`, so hooks behave identically under `run_sim` and `BaseTask`.

### Removed (internal API surface)
- **`BaseSimulator.on_episode_start` / `on_episode_end` / `capture_video_frame` / `_step_bridge` deleted.** These were the override seams for episode/video/bridge behavior. Callers now emit phases: `base_task.py` emits `EPISODE_START` / `EPISODE_END` (replacing the `hasattr(simulator, "on_episode_*")` guards) and the frame/step phases; `sim_utils.py` emits `EPISODE_START` at init. Any out-of-tree subclass that overrode `on_episode_start/end` to hook episode boundaries must migrate to `simulator.hooks.add(Phase.EPISODE_START, ...)`. All in-tree callers migrated.
- **Video recorder's manual decimation counter deleted.** `capture_frame` no longer tracks `_frame_counter % control_decimation`; it registers on `FRAME_END`, which already fires once per frame at control rate.

### Result-preserving (verified)
- **Per-step callback timing unchanged.** `bridge.step` and `virtual_gantry.step` register on `PRE_STEP` (fires every physics substep, before `simulate_at_each_physics_step`, as before — SDK torques and gantry forces must land before the substep integrates them). Registration order — gantry before bridge (gantry registered ahead of `_init_bridge` in every backend) — matches the old inline call order.
- **Video capture rate unchanged.** `video.capture_frame` registers on `FRAME_END`: once per frame, at control frequency — the same rate the old per-substep counter decimated to. The capture point moves from "after the Nth physics substep" to "after `_refresh_sim_tensors` at frame end".
- **Episode-start order unchanged.** Gantry's `set_position_to_robot` (now `VirtualGantry.on_episode_start`, `env_id == 0` guarded) registers before the video recorder's `on_episode_start`, matching the old `BaseSimulator.on_episode_start` body.

## Migration guide (out-of-tree only)

**Episode / video / bridge hooks — register instead of override**
```python
# BEFORE (subclass override)                 # AFTER (register a callback)
class MySim(MuJoCo):                          sim.hooks.add(Phase.EPISODE_START, my_fn)   # my_fn(env_id)
    def on_episode_start(self, env_id=0):     sim.hooks.add(Phase.POST_STEP, my_capture)
        super().on_episode_start(env_id)      sim.hooks.add(Phase.FRAME_END, my_log, every="10Hz")
        my_fn(env_id)                         # deregister later via the returned handle:
                                              handle = sim.hooks.add(Phase.CLOSE, my_cleanup); handle.remove()
```
`simulator.capture_video_frame()` / `_step_bridge()` are gone — the video recorder and bridge register themselves; there is nothing to call. Payload arity is validated at emit: `EPISODE_START`/`EPISODE_END` pass `env_id`; all other phases pass no args.
