### PR TITLE
Plugin config family (PLUGIN_REGISTRY) + ROS2 clock/gantry/odometry plugins

### DIFF
--- a/docs/writing-extensions.md
+++ b/docs/writing-extensions.md
@@ -136,7 +136,7 @@ A plugin's hooks attach to lifecycle phases via `add(phase, callback, *, name=No
 
 `every` sub-samples a phase: an int runs the callback every Nth emission; a frequency string (`"100Hz"`, `">100Hz"`, `"<100Hz"`) is resolved against the phase's base rate (`fps` for the per-substep `*_STEP` phases, `fps/control_decimation` for the per-frame `FRAME_*` phases). Frequency strings are periodic-phases only; `CLOSE` always fires once. The registry sub-samples natively — hooks never write their own counters.
 
-Built-ins to copy: the dependency-free `none` no-op in `holosoma/simulator/shared/builtin_plugins.py`; `clock_publish` / `gantry_control` (ROS2, `rclpy` imported lazily so core stays ROS-free) in `ros2_plugins.py`. Select `plugin.<key>:none` to disable a slot.
+Built-ins to copy: the dependency-free `none` no-op in `holosoma/simulator/shared/builtin_plugins.py`; `clock_publish` / `gantry_control` / `odometry` (ROS2, `rclpy` imported lazily so core stays ROS-free) in `ros2_plugins.py`. Select `plugin.<key>:none` to disable a slot.
 
 ## Don't
 

--- a/docs/writing-extensions.md
+++ b/docs/writing-extensions.md
@@ -75,11 +75,68 @@ Register hyphen-case (`go2-12dof`). The CLI token is `<field>:<key>` and accepts
 
 Publish an entry point under the group whose config type matches your preset. Training and inference share some group names on purpose — the type check routes each preset to the right registry.
 
-**Training (`holosoma`)** — `robot` `RobotConfig` · `simulator` `SimulatorConfig` · `run_sim` `SimulatorConfig` · `terrain` `TerrainManagerCfg` · `scene` `SceneConfig` · `algo` `PPOAlgoConfig`/`FastSACAlgoConfig` · `observation` `ObservationManagerCfg` · `action` `ActionManagerCfg` · `reward` `RewardManagerCfg` · `termination` `TerminationManagerCfg` · `randomization` `RandomizationManagerCfg` · `command` `CommandManagerCfg` · `curriculum` `CurriculumManagerCfg` · `logger` `DisabledLoggerConfig`/`WandbLoggerConfig` · `experiment` `ExperimentConfig` (top-level `exp:`)
+**Training (`holosoma`)** — `robot` `RobotConfig` · `simulator` `SimulatorConfig` · `run_sim` `SimulatorConfig` · `terrain` `TerrainManagerCfg` · `scene` `SceneConfig` · `algo` `PPOAlgoConfig`/`FastSACAlgoConfig` · `observation` `ObservationManagerCfg` · `action` `ActionManagerCfg` · `reward` `RewardManagerCfg` · `termination` `TerminationManagerCfg` · `randomization` `RandomizationManagerCfg` · `command` `CommandManagerCfg` · `curriculum` `CurriculumManagerCfg` · `logger` `DisabledLoggerConfig`/`WandbLoggerConfig` · `plugin` `PluginConfig` · `experiment` `ExperimentConfig` (top-level `exp:`)
+
+The `plugin` family runs custom per-step behavior — see [Plugins](#plugins) below.
 
 **Inference (`holosoma_inference`)** — `robot` `RobotConfig` · `observation` `ObservationConfig` · `task` `TaskConfig` · `inference` `InferenceConfig` (top-level `inference:`)
 
 Group string is `holosoma.config.<family>`, registry var is `<FAMILY>_REGISTRY` (e.g. `holosoma.config.reward` → `REWARD_REGISTRY`).
+
+## Plugins — custom per-step behavior
+
+A **plugin** is a bundle of behavior — a set of lifecycle hooks plus whatever state they need — that runs your code at points in the simulator loop, without subclassing a backend. It's built on the hook system (`simulator.hooks`, `Phase`) and can depend on other simulator contracts (the virtual gantry, the clock, …). Write a class taking `(cfg, simulator)` that registers hooks in `__init__`, and pair it with a `PluginConfig` (its CLI-visible knobs). There is no base class to inherit.
+
+```python
+# my_plugins.py — log the robot's height, sampled at a fixed rate
+from dataclasses import dataclass
+from loguru import logger
+from holosoma.config_types.plugin import PluginConfig
+from holosoma.config_values.plugin import PLUGIN_REGISTRY
+from holosoma.simulator.base_simulator.hooks import Phase
+
+@dataclass(frozen=True)
+class LogHeightPluginConfig(PluginConfig):
+    every: str = "2Hz"                       # int decimation or frequency string
+    def get_cls(self):
+        return LogHeightPlugin               # import lazily here if the impl is heavy
+
+class LogHeightPlugin:
+    def __init__(self, cfg: LogHeightPluginConfig, simulator):
+        self.cfg, self.simulator = cfg, simulator
+        # register one hook per phase you care about:
+        simulator.hooks.add(Phase.FRAME_END, self.log, name="log_height", every=cfg.every)
+
+    def log(self):                           # signature = the phase's payload (below)
+        logger.info(f"height = {self.simulator.robot_root_states[0, 2]:.3f}")
+
+PLUGIN_REGISTRY.add("log_height", LogHeightPluginConfig())
+```
+
+```bash
+python -m holosoma.run_sim --import-file my_plugins.py plugin.h:log_height --plugin.h.every=5Hz
+```
+
+Select plugins as the dynamic-dict `plugin.<key>:<preset>` (per-key leaf overrides via `--plugin.<key>.<field>=…`); each is constructed once in `BaseSimulator.__init__`. Ship them packaged via the `holosoma.config.plugin` entry-point group like any other preset.
+
+### Phases
+
+A plugin's hooks attach to lifecycle phases via `add(phase, callback, *, name=None, every=1)`. Per control frame the loop emits, in order:
+
+| Phase | When | Callback args | Cadence |
+|---|---|---|---|
+| `FRAME_BEGIN` | before the physics substeps (push commands to the sim here) | — | control rate |
+| `PRE_STEP` | before each physics substep | — | physics `fps` |
+| `POST_STEP` | after each physics substep (freshest sim time) | — | physics `fps` |
+| `FRAME_END` | after the substeps + state-tensor refresh (read state here) | — | control rate |
+| `EPISODE_START` / `EPISODE_END` | on reset boundaries | `env_id` | per event |
+| `CLOSE` | teardown (release resources); runs in reverse registration order | — | once |
+
+### Cadence
+
+`every` sub-samples a phase: an int runs the callback every Nth emission; a frequency string (`"100Hz"`, `">100Hz"`, `"<100Hz"`) is resolved against the phase's base rate (`fps` for the per-substep `*_STEP` phases, `fps/control_decimation` for the per-frame `FRAME_*` phases). Frequency strings are periodic-phases only; `CLOSE` always fires once. The registry sub-samples natively — hooks never write their own counters.
+
+Built-ins to copy: the dependency-free `none` no-op in `holosoma/simulator/shared/builtin_plugins.py`; `clock_publish` / `gantry_control` (ROS2, `rclpy` imported lazily so core stays ROS-free) in `ros2_plugins.py`. Select `plugin.<key>:none` to disable a slot.
 
 ## Don't
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -107,6 +107,12 @@ ignore_missing_imports = True
 [mypy-rosgraph_msgs.*]
 ignore_missing_imports = True
 
+[mypy-nav_msgs.*]
+ignore_missing_imports = True
+
+[mypy-builtin_interfaces.*]
+ignore_missing_imports = True
+
 [mypy-scipy.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -104,6 +104,9 @@ ignore_missing_imports = True
 [mypy-rclpy.*]
 ignore_missing_imports = True
 
+[mypy-rosgraph_msgs.*]
+ignore_missing_imports = True
+
 [mypy-scipy.*]
 ignore_missing_imports = True
 

--- a/src/holosoma/holosoma/config_types/env.py
+++ b/src/holosoma/holosoma/config_types/env.py
@@ -8,6 +8,7 @@ from holosoma.config_types.curriculum import CurriculumManagerCfg
 from holosoma.config_types.experiment import ExperimentConfig, TrainingConfig
 from holosoma.config_types.logger import LoggerConfig
 from holosoma.config_types.observation import ObservationManagerCfg
+from holosoma.config_types.plugin import PluginConfig
 from holosoma.config_types.randomization import RandomizationManagerCfg
 from holosoma.config_types.reward import RewardManagerCfg
 from holosoma.config_types.robot import RobotConfig
@@ -36,6 +37,9 @@ class EnvConfig:
     robot: RobotConfig
     training: TrainingConfig
     logger: LoggerConfig
+    plugin: dict[str, PluginConfig]
+    """Plugins to install on the simulator (key -> resolved PluginConfig). Threaded into
+    FullSimConfig; installed in ``BaseSimulator.__init__``."""
 
 
 def get_tyro_env_config(tyro_config: ExperimentConfig) -> EnvConfig:
@@ -66,4 +70,5 @@ def get_tyro_env_config(tyro_config: ExperimentConfig) -> EnvConfig:
         curriculum=tyro_config.curriculum,
         robot=tyro_config.robot,
         logger=tyro_config.logger,
+        plugin=dict(tyro_config.plugin),
     )

--- a/src/holosoma/holosoma/config_types/experiment.py
+++ b/src/holosoma/holosoma/config_types/experiment.py
@@ -15,6 +15,7 @@ import holosoma.config_values.command
 import holosoma.config_values.curriculum
 import holosoma.config_values.logger
 import holosoma.config_values.observation
+import holosoma.config_values.plugin
 import holosoma.config_values.randomization
 import holosoma.config_values.reward
 import holosoma.config_values.robot
@@ -28,6 +29,7 @@ from holosoma.config_types.command import CommandManagerCfg
 from holosoma.config_types.curriculum import CurriculumManagerCfg
 from holosoma.config_types.logger import LoggerConfig
 from holosoma.config_types.observation import ObservationManagerCfg
+from holosoma.config_types.plugin import PluginConfig
 from holosoma.config_types.randomization import RandomizationManagerCfg
 from holosoma.config_types.reward import RewardManagerCfg
 from holosoma.config_types.robot import RobotConfig
@@ -118,6 +120,12 @@ class ExperimentConfig:
     )
     scene: Annotated[SceneConfig, UseRegistry(holosoma.config_values.scene.SCENE_REGISTRY)] = (
         holosoma.config_values.scene.empty
+    )
+    # Plugins, declared per-key as ``plugin.<key>:<variant>`` (resolved from PLUGIN_REGISTRY),
+    # optionally with per-key field overrides. Installed in ``BaseSimulator.__init__``. Threaded into
+    # FullSimConfig so plugins work in the training path (run_sim already exposes the same field).
+    plugin: dict[str, Annotated[PluginConfig, UseRegistry(holosoma.config_values.plugin.PLUGIN_REGISTRY)]] = (
+        dataclasses.field(default_factory=dict)
     )
     observation: Annotated[
         ObservationManagerCfg | None, UseRegistry(holosoma.config_values.observation.OBSERVATION_REGISTRY)

--- a/src/holosoma/holosoma/config_types/full_sim.py
+++ b/src/holosoma/holosoma/config_types/full_sim.py
@@ -6,6 +6,7 @@ from pydantic.dataclasses import dataclass
 
 from holosoma.config_types.experiment import TrainingConfig
 from holosoma.config_types.logger import LoggerConfig
+from holosoma.config_types.plugin import PluginConfig
 from holosoma.config_types.robot import RobotConfig
 from holosoma.config_types.scene import SceneConfig
 from holosoma.config_types.simulator import SimulatorInitConfig
@@ -23,6 +24,10 @@ class FullSimConfig:
 
     scene: SceneConfig = field(default_factory=SceneConfig)
     """Scene composition (rigid objects, scene files)."""
+
+    plugin: dict[str, PluginConfig] = field(default_factory=dict)
+    """Plugins (key -> config). Each is instantiated against the live simulator in
+    ``BaseSimulator.__init__`` via ``cfg.get_cls()(cfg, self)``."""
 
     experiment_dir: str | None = None
     """Experiment directory path (computed from logger config in base_task)."""

--- a/src/holosoma/holosoma/config_types/plugin.py
+++ b/src/holosoma/holosoma/config_types/plugin.py
@@ -1,0 +1,115 @@
+"""Config types for simulator plugins.
+
+A *plugin* is a bundle of behavior — a set of lifecycle hooks plus whatever state and
+side effects they need — that an extension attaches to a running simulator without
+subclassing a backend. Plugins are built on the lifecycle hook system (``simulator.hooks``,
+:class:`~holosoma.simulator.base_simulator.hooks.Phase`) and may depend on other simulator
+contracts (the virtual gantry, the clock, etc.). Each plugin pairs:
+
+- a ``PluginConfig`` subclass (the CLI-visible, serializable knobs), registered under a
+  name in ``holosoma.config_values.plugin.PLUGIN_REGISTRY``, and
+- a runtime plugin class, returned by the config's :meth:`PluginConfig.get_cls`. There is
+  no base class to inherit: any class constructed as ``cls(cfg, simulator)`` that
+  registers its hooks on ``simulator.hooks`` works (duck-typed).
+
+The config is resolved on the CLI as a dynamic-dict field (see ``RunSimConfig.plugin``);
+``BaseSimulator.__init__`` then instantiates each ``get_cls()`` against itself.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from holosoma.config_types.frequency import DecimationLike, validate_decimation_like
+
+
+@dataclass(frozen=True)
+class PluginConfig(abc.ABC):
+    """Base config for a simulator plugin.
+
+    Subclass with the plugin's parameters as dataclass fields and implement
+    :meth:`get_cls` to point at the runtime plugin class. Register an instance in
+    ``PLUGIN_REGISTRY`` so it is selectable as ``plugin.<key>:<variant>`` on the CLI.
+    """
+
+    @abc.abstractmethod
+    def get_cls(self) -> Callable[..., Any]:
+        """Return the runtime plugin class this config configures.
+
+        The class is constructed as ``cls(cfg, simulator)`` and is expected to register
+        its hooks on ``simulator.hooks`` in ``__init__`` — no base class required.
+        Import it lazily inside this method so that registering the config preset does
+        not pull the (possibly heavy) runtime module at import time.
+        """
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class NoOpPluginConfig(PluginConfig):
+    """A plugin that does nothing, registered as the ``none`` preset.
+
+    Selecting ``plugin.<key>:none`` disables that slot: its runtime class registers no
+    hooks, so it is a genuine no-op.
+    """
+
+    def get_cls(self) -> Callable[..., Any]:
+        from holosoma.simulator.shared.builtin_plugins import NoOpPlugin
+
+        return NoOpPlugin
+
+
+@dataclass(frozen=True)
+class ClockPublishPluginConfig(PluginConfig):
+    """Publish sim time as a ROS2 ``rosgraph_msgs/msg/Clock`` topic.
+
+    A ROS2 example plugin. rclpy is an optional dependency (``holosoma[ros2]``); this
+    config stays import-safe without ROS because :meth:`get_cls` defers the impl import.
+    """
+
+    topic: str = "/clock"
+    """Topic to publish the clock on (ROS2 ``use_sim_time`` consumers expect ``/clock``)."""
+
+    node_name: str = "holosoma_clock"
+    """ROS2 node name for the publisher."""
+
+    publish_every: DecimationLike = 1
+    """How often to publish, on the PHYSICS rate (the clock is read right after each physics
+    step). Either a decimation int (publish every Nth physics step) or a frequency string
+    (``"100Hz"``, ``">100Hz"``, ``"<100Hz"``) resolved at install time against ``fps``."""
+
+    def __post_init__(self) -> None:
+        validate_decimation_like(self.publish_every, field="publish_every")
+
+    def get_cls(self) -> Callable[..., Any]:
+        from holosoma.simulator.shared.ros2_plugins import ClockPublishPlugin
+
+        return ClockPublishPlugin
+
+
+@dataclass(frozen=True)
+class GantryControlPluginConfig(PluginConfig):
+    """Control the virtual gantry over ROS2 via three independent standard-message topics.
+
+    Each of position / length / enabled is its own subscription, so publishing to one
+    topic changes only that property (the others are left untouched). A ROS2 example
+    plugin; rclpy is optional (``holosoma[ros2]``), imported lazily via :meth:`get_cls`.
+    """
+
+    position_topic: str = "/gantry/position"
+    """``geometry_msgs/msg/Point`` — new gantry anchor point ``(x, y, z)`` in world frame."""
+
+    length_topic: str = "/gantry/length"
+    """``std_msgs/msg/Float64`` — new elastic-band rest length."""
+
+    enabled_topic: str = "/gantry/enabled"
+    """``std_msgs/msg/Bool`` — enable (True) or disable (False) the gantry."""
+
+    node_name: str = "holosoma_gantry_control"
+    """ROS2 node name for the subscriber."""
+
+    def get_cls(self) -> Callable[..., Any]:
+        from holosoma.simulator.shared.ros2_plugins import GantryControlPlugin
+
+        return GantryControlPlugin

--- a/src/holosoma/holosoma/config_types/plugin.py
+++ b/src/holosoma/holosoma/config_types/plugin.py
@@ -113,3 +113,52 @@ class GantryControlPluginConfig(PluginConfig):
         from holosoma.simulator.shared.ros2_plugins import GantryControlPlugin
 
         return GantryControlPlugin
+
+
+@dataclass(frozen=True)
+class ROS2OdometryPluginConfig(PluginConfig):
+    """Publish the robot base pose/velocity as ``nav_msgs/Odometry`` over ROS2.
+
+    A self-sourced (non-camera) egress plugin: it reads base pose/velocity straight off
+    ``simulator.robot_root_states`` each control step (the sim analog of the robot's onboard
+    sport/odom estimate) — so it uses no camera base class, just registers a ``FRAME_END`` publish
+    like :class:`ClockPublishPluginConfig`. rclpy is optional (``holosoma[ros2]``), imported lazily
+    via :meth:`get_cls`.
+    """
+
+    node_name: str = "sim_odometry"
+    """ROS2 node name created for this sink."""
+
+    topic: str = "/odom"
+    """Topic to publish the ``nav_msgs/Odometry`` on."""
+
+    frame_id: str = "odom"
+    """``header.frame_id``: the fixed frame the pose is expressed in (odometry origin)."""
+
+    child_frame_id: str = "base_link"
+    """``child_frame_id``: the moving body frame the twist is expressed in."""
+
+    qos: str = "best_effort"
+    """QoS profile: ``best_effort`` (default) or ``reliable``."""
+
+    env_id: int = 0
+    """Which environment's base state to publish. Default 0 (the single real-time robot)."""
+
+    publish_every: DecimationLike = 1
+    """How often to publish, on the CONTROL rate (base state is fresh after each frame's tensor
+    refresh). Either a decimation int (publish every Nth control step) or a frequency string
+    (``"50Hz"``, ``">50Hz"``, ``"<50Hz"``) resolved at install time against the control rate."""
+
+    def __post_init__(self) -> None:
+        validate_decimation_like(self.publish_every, field="publish_every")
+        if self.qos not in ("best_effort", "reliable"):
+            raise ValueError(f"ROS2OdometryPluginConfig.qos must be 'best_effort' or 'reliable', got '{self.qos}'.")
+        if not self.topic:
+            raise ValueError("ROS2OdometryPluginConfig.topic must be a non-empty topic.")
+        if self.env_id < 0:
+            raise ValueError(f"ROS2OdometryPluginConfig.env_id must be >= 0, got {self.env_id}.")
+
+    def get_cls(self) -> Callable[..., Any]:
+        from holosoma.simulator.shared.ros2_plugins import ROS2OdometryPlugin
+
+        return ROS2OdometryPlugin

--- a/src/holosoma/holosoma/config_types/run_sim.py
+++ b/src/holosoma/holosoma/config_types/run_sim.py
@@ -12,12 +12,14 @@ from dataclasses import dataclass, field
 
 from typing_extensions import Annotated
 
+import holosoma.config_values.plugin
 import holosoma.config_values.robot
 import holosoma.config_values.run_sim
 import holosoma.config_values.scene
 import holosoma.config_values.terrain
 from holosoma.config_types.experiment import TrainingConfig
 from holosoma.config_types.logger import DisabledLoggerConfig, LoggerConfig
+from holosoma.config_types.plugin import PluginConfig
 from holosoma.config_types.robot import RobotConfig
 from holosoma.config_types.scene import SceneConfig
 from holosoma.config_types.simulator import SimulatorConfig
@@ -63,6 +65,14 @@ class RunSimConfig:
 
     scene: Annotated[SceneConfig, UseRegistry(holosoma.config_values.scene.SCENE_REGISTRY)] = (
         holosoma.config_values.scene.empty
+    )
+
+    # Plugins: declare on the CLI as ``plugin.<key>:<variant>`` (resolved from
+    # PLUGIN_REGISTRY), optionally with per-key leaf overrides
+    # (e.g. ``--plugin.<key>.<field>=<value>``). Passed through to ``FullSimConfig.plugin`` and
+    # instantiated against the live simulator in ``BaseSimulator.__init__``. Empty by default.
+    plugin: dict[str, Annotated[PluginConfig, UseRegistry(holosoma.config_values.plugin.PLUGIN_REGISTRY)]] = field(
+        default_factory=dict
     )
 
     # Minimal configs needed for FullSimConfig

--- a/src/holosoma/holosoma/config_values/plugin.py
+++ b/src/holosoma/holosoma/config_values/plugin.py
@@ -5,6 +5,7 @@ from holosoma.config_types.plugin import (
     GantryControlPluginConfig,
     NoOpPluginConfig,
     PluginConfig,
+    ROS2OdometryPluginConfig,
 )
 from holosoma.utils.config_registry import ConfigRegistry, deprecated_defaults_alias
 
@@ -20,5 +21,10 @@ none = PLUGIN_REGISTRY.add("none", NoOpPluginConfig())
 # configs stay rclpy-free, so registering them here does not require ROS.
 clock_publish = PLUGIN_REGISTRY.add("clock_publish", ClockPublishPluginConfig())
 gantry_control = PLUGIN_REGISTRY.add("gantry_control", GantryControlPluginConfig())
+
+# Robot base pose/velocity as nav_msgs/Odometry — a self-sourced (non-camera) egress plugin that
+# reads robot_root_states each control step. Rides the same in-process rclpy transport as the image
+# egress (no CycloneDDS entanglement with the Unitree SDK bridge).
+odometry = PLUGIN_REGISTRY.add("odometry", ROS2OdometryPluginConfig())
 
 __getattr__ = deprecated_defaults_alias(__name__, PLUGIN_REGISTRY)

--- a/src/holosoma/holosoma/config_values/plugin.py
+++ b/src/holosoma/holosoma/config_values/plugin.py
@@ -1,0 +1,24 @@
+"""Registered plugin presets, selectable as ``plugin.<key>:<variant>`` on the CLI."""
+
+from holosoma.config_types.plugin import (
+    ClockPublishPluginConfig,
+    GantryControlPluginConfig,
+    NoOpPluginConfig,
+    PluginConfig,
+)
+from holosoma.utils.config_registry import ConfigRegistry, deprecated_defaults_alias
+
+PLUGIN_REGISTRY = ConfigRegistry(PluginConfig, group="holosoma.config.plugin")
+
+# `none` disables a slot (plugin.<key>:none), mirroring every other config family's `none`
+# preset. Unlike the scalar families (which register a literal None), this dict field
+# registers a real no-op config so the field type stays uniform. Extensions register their own
+# via the entry-point group above or a --import-file that calls PLUGIN_REGISTRY.add(...).
+none = PLUGIN_REGISTRY.add("none", NoOpPluginConfig())
+
+# ROS2 example presets. Their impls import rclpy (optional dep: holosoma[ros2]); the
+# configs stay rclpy-free, so registering them here does not require ROS.
+clock_publish = PLUGIN_REGISTRY.add("clock_publish", ClockPublishPluginConfig())
+gantry_control = PLUGIN_REGISTRY.add("gantry_control", GantryControlPluginConfig())
+
+__getattr__ = deprecated_defaults_alias(__name__, PLUGIN_REGISTRY)

--- a/src/holosoma/holosoma/config_values/tests/test_plugin_registry.py
+++ b/src/holosoma/holosoma/config_values/tests/test_plugin_registry.py
@@ -1,0 +1,150 @@
+"""CLI/registry resolution for the ``RunSimConfig.plugin`` dynamic-dict field."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from typing_extensions import Annotated, TypeAlias
+
+from holosoma.config_types.plugin import (
+    ClockPublishPluginConfig,
+    GantryControlPluginConfig,
+    NoOpPluginConfig,
+    PluginConfig,
+)
+from holosoma.config_types.run_sim import RunSimConfig
+from holosoma.config_values.plugin import PLUGIN_REGISTRY
+from holosoma.utils import config_registry as registry
+from holosoma.utils.config_registry import UseRegistry, parse_config, registry_from_annotated
+from holosoma.utils.tyro_utils import find_dynamic_dict_fields
+
+pytestmark = pytest.mark.no_sim
+
+# Ensure every real registry is discovered so parse_config sees the full menu.
+registry.load_plugins()
+
+
+def test_plugin_registry_holds_builtin_preset() -> None:
+    assert isinstance(PLUGIN_REGISTRY["clock_publish"], ClockPublishPluginConfig)
+    assert PLUGIN_REGISTRY.config_type is PluginConfig
+
+
+def test_run_sim_plugin_field_is_scanned_and_bound() -> None:
+    found = find_dynamic_dict_fields(RunSimConfig)
+    assert "plugin" in found
+    assert registry_from_annotated(found["plugin"]) is PLUGIN_REGISTRY
+
+
+def test_run_sim_defaults_to_empty_plugin() -> None:
+    cfg = parse_config(RunSimConfig, args=["simulator:mujoco"])
+    assert cfg.plugin == {}
+
+
+def test_declare_builtin_plugin() -> None:
+    cfg = parse_config(RunSimConfig, args=["simulator:mujoco", "plugin.clk:clock_publish"])
+    assert set(cfg.plugin) == {"clk"}
+    assert isinstance(cfg.plugin["clk"], ClockPublishPluginConfig)
+
+
+def test_none_preset_resolves_to_noop_config() -> None:
+    # `plugin.<key>:none` selects the no-op preset (mirrors every other family's `none`),
+    # resolving to a real NoOpPluginConfig rather than a literal None.
+    cfg = parse_config(RunSimConfig, args=["simulator:mujoco", "plugin.disabled:none"])
+    assert isinstance(cfg.plugin["disabled"], NoOpPluginConfig)
+
+
+def test_ros2_presets_resolve_with_independent_gantry_topics() -> None:
+    # The two ROS2 example plugins resolve from the registry (their configs are rclpy-free);
+    # per-topic gantry overrides target one property's topic without touching the others.
+    cfg = parse_config(
+        RunSimConfig,
+        args=[
+            "simulator:mujoco",
+            "plugin.clk:clock_publish",
+            "--plugin.clk.topic=/sim_clock",
+            "plugin.g:gantry_control",
+            "--plugin.g.length-topic=/g/len",
+        ],
+    )
+    assert isinstance(cfg.plugin["clk"], ClockPublishPluginConfig)
+    assert cfg.plugin["clk"].topic == "/sim_clock"
+    gantry = cfg.plugin["g"]
+    assert isinstance(gantry, GantryControlPluginConfig)
+    assert gantry.length_topic == "/g/len"
+    # Untouched topics keep their defaults (independent control).
+    assert gantry.position_topic == "/gantry/position"
+    assert gantry.enabled_topic == "/gantry/enabled"
+
+
+def test_declare_plugin_with_leaf_override() -> None:
+    cfg = parse_config(
+        RunSimConfig,
+        args=[
+            "simulator:mujoco",
+            "plugin.clk:clock_publish",
+            "--plugin.clk.publish-every=25",
+            "--plugin.clk.node-name=my_clock",
+        ],
+    )
+    plugin = cfg.plugin["clk"]
+    assert plugin.publish_every == 25
+    assert plugin.node_name == "my_clock"
+
+
+def test_frequency_string_rate_parses_and_validates() -> None:
+    # A frequency string is accepted on a rate field and held as-written (resolved to a
+    # decimation at install time against the phase base rate).
+    cfg = parse_config(
+        RunSimConfig,
+        args=["simulator:mujoco", "plugin.clk:clock_publish", "--plugin.clk.publish-every=20Hz"],
+    )
+    assert cfg.plugin["clk"].publish_every == "20Hz"
+
+
+def test_bad_frequency_string_fails_at_config_time() -> None:
+    with pytest.raises(ValueError, match="publish_every"):
+        ClockPublishPluginConfig(publish_every="not-a-rate")
+
+
+def test_unknown_plugin_variant_fails_loud() -> None:
+    with pytest.raises(SystemExit, match="Unknown plugin variant 'bogus'"):
+        parse_config(RunSimConfig, args=["simulator:mujoco", "plugin.x:bogus"])
+
+
+# A second PluginConfig subclass, resolved from the same registry alongside the built-in,
+# proves the heterogeneous-subclass menu the spec's plugins rely on.
+@dataclasses.dataclass(frozen=True)
+class _PublishPluginConfig(PluginConfig):
+    topic: str = "state"
+
+    def get_cls(self):  # pragma: no cover - not instantiated in this test
+        raise NotImplementedError
+
+
+_PluginField: TypeAlias = Annotated[PluginConfig, UseRegistry(PLUGIN_REGISTRY)]
+
+
+@dataclasses.dataclass(frozen=True)
+class _MultiPluginConfig:
+    plugin: dict[str, _PluginField] = dataclasses.field(default_factory=dict)
+
+
+def test_multiple_heterogeneous_plugins_resolve() -> None:
+    PLUGIN_REGISTRY.add("publish", _PublishPluginConfig())
+    try:
+        cfg = parse_config(
+            _MultiPluginConfig,
+            args=[
+                "plugin.clk:clock_publish",
+                "plugin.your_biz:publish",
+                "--plugin.clk.node-name=base_clock",
+                "--plugin.your-biz.topic=poses",
+            ],
+        )
+        assert isinstance(cfg.plugin["clk"], ClockPublishPluginConfig)
+        assert cfg.plugin["clk"].node_name == "base_clock"
+        assert isinstance(cfg.plugin["your_biz"], _PublishPluginConfig)
+        assert cfg.plugin["your_biz"].topic == "poses"
+    finally:
+        PLUGIN_REGISTRY.pop("publish", None)

--- a/src/holosoma/holosoma/envs/base_task/base_task.py
+++ b/src/holosoma/holosoma/envs/base_task/base_task.py
@@ -91,6 +91,7 @@ class BaseTask:
             simulator=simulator_config.config,
             robot=robot_config,
             scene=tyro_config.scene,
+            plugin=tyro_config.plugin,  # egress/custom plugins; the simulator installs them in __init__
             training=training_config,
             logger=tyro_config.logger,
             experiment_dir=str(experiment_dir),

--- a/src/holosoma/holosoma/simulator/base_simulator/base_simulator.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/base_simulator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -175,6 +175,14 @@ class BaseSimulator:
         self.debug_viz_enabled = self.simulator_config.debug_viz
         self.object_registry = ObjectRegistry(device)
         self.hooks = HookRegistry(base_rates=self._hook_base_rates())
+        # Build plugins from tyro_config.plugin and keep the instances alive (key -> plugin).
+        # Constructing each here registers its hooks on self.hooks, so they fire on later
+        # emit(). The `none` preset disables a slot.
+        self.installed_plugins: dict[str, Any] = {
+            key: cfg.get_cls()(cfg, self) for key, cfg in tyro_config.plugin.items()
+        }
+        if self.installed_plugins:
+            logger.info(f"Installed plugins: {sorted(self.installed_plugins)}")
         self._closed = False
 
         # Virtual gantry system

--- a/src/holosoma/holosoma/simulator/base_simulator/hooks.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/hooks.py
@@ -15,9 +15,9 @@ class Phase(str, Enum):
 
     ``payload`` names the positional args ``emit`` forwards to callbacks. ``periodic`` marks phases
     that fire on a fixed clock (per-substep or per-frame ticks) — only these accept a frequency-string
-    rate (``"30Hz"``) for :meth:`HookRegistry.add`'s ``every``; event phases (episode/close) accept an
-    int decimation ("every Nth event") but reject frequency strings, which have no clock to resolve
-    against.
+    rate (``"30Hz"``) for :meth:`HookRegistry.add`'s ``every``. Episode events accept an int decimation
+    ("every Nth event") but reject frequency strings (no clock to resolve against); CLOSE always
+    fires once and rejects any decimation.
 
     ``FRAME_*`` bracket the outer tick (once per frame); ``*_STEP`` bracket each physics substep. The
     names are engine-agnostic — they don't assume what drives the outer tick (a policy, a bridge, ...).

--- a/src/holosoma/holosoma/simulator/base_simulator/tests/test_plugins.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/tests/test_plugins.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, cast
+
+import pytest
+
+from holosoma.config_types.plugin import NoOpPluginConfig, PluginConfig
+from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+from holosoma.simulator.base_simulator.hooks import HookRegistry, Phase
+
+pytestmark = pytest.mark.no_sim
+
+
+class _FakeSimulator:
+    """Minimal stand-in exposing the surface a plugin touches.
+
+    Cast to ``BaseSimulator`` where a plugin expects one; the plugins below hold a
+    ``_FakeSimulator``-typed reference so their fake-only attribute access type-checks.
+    """
+
+    def __init__(self) -> None:
+        self.hooks = HookRegistry()
+        self.forces: list[tuple[str, list[float]]] = []
+        self.logged: list[str] = []
+
+    def apply_forces(self, actor: str, force: list[float]) -> None:
+        self.forces.append((actor, force))
+
+
+def _build_plugins(sim: _FakeSimulator, configs: dict[str, PluginConfig]) -> dict[str, Any]:
+    """Mirror BaseSimulator.__init__'s plugin construction (cls(cfg, sim)) for the fake sim."""
+    return {key: cfg.get_cls()(cfg, cast("BaseSimulator", sim)) for key, cfg in configs.items()}
+
+
+# A spec-shaped plugin: config declares knobs + get_cls(); the plugin (any class taking
+# (cfg, simulator)) self-registers hooks in __init__.
+@dataclass(frozen=True)
+class _ApplyForcePluginConfig(PluginConfig):
+    ros_name: str = "foo"
+    force_value: tuple[float, ...] = (1.0, 2.0, 3.0)
+
+    def get_cls(self) -> Callable[..., Any]:
+        return _ApplyForcePlugin
+
+
+class _ApplyForcePlugin:
+    def __init__(self, cfg: _ApplyForcePluginConfig, simulator: BaseSimulator) -> None:
+        self.cfg = cfg
+        self.sim = cast("_FakeSimulator", simulator)
+        self.sim.hooks.add(Phase.PRE_STEP, self.set_forces)
+        self.sim.hooks.add(Phase.FRAME_END, self.log)
+
+    def set_forces(self) -> None:
+        self.sim.apply_forces("robot", list(self.cfg.force_value))
+
+    def log(self) -> None:
+        self.sim.logged.append(self.cfg.ros_name)
+
+
+def test_build_plugins_constructs_and_wires_hooks() -> None:
+    sim = _FakeSimulator()
+    installed = _build_plugins(sim, {"apply_force": _ApplyForcePluginConfig(force_value=(10.0, 0.0, 0.0))})
+
+    assert set(installed) == {"apply_force"}
+    assert isinstance(installed["apply_force"], _ApplyForcePlugin)
+
+    # Emitting the phases the plugin registered on runs its callbacks.
+    sim.hooks.emit(Phase.PRE_STEP)
+    sim.hooks.emit(Phase.FRAME_END)
+    assert sim.forces == [("robot", [10.0, 0.0, 0.0])]
+    assert sim.logged == ["foo"]
+
+
+def test_build_plugins_empty_is_noop() -> None:
+    sim = _FakeSimulator()
+    assert _build_plugins(sim, {}) == {}
+    # No hooks registered, so emitting a phase does nothing.
+    sim.hooks.emit(Phase.PRE_STEP)
+    assert sim.forces == []
+
+
+def test_noop_plugin_registers_nothing() -> None:
+    # `plugin.<key>:none` resolves to NoOpPluginConfig -> NoOpPlugin, which registers no hooks:
+    # the slot is disabled but construction still returns an instance.
+    from holosoma.simulator.shared.builtin_plugins import NoOpPlugin
+
+    sim = _FakeSimulator()
+    installed = _build_plugins(sim, {"off": NoOpPluginConfig(), "on": _ApplyForcePluginConfig()})
+    assert set(installed) == {"off", "on"}
+    assert type(installed["off"]) is NoOpPlugin
+    sim.hooks.emit(Phase.FRAME_END)
+    assert sim.logged == ["foo"]  # only the active plugin fired
+
+
+def test_build_plugins_preserves_key_order() -> None:
+    sim = _FakeSimulator()
+    configs: dict[str, PluginConfig] = {
+        "a": _ApplyForcePluginConfig(ros_name="a"),
+        "b": _ApplyForcePluginConfig(ros_name="b"),
+    }
+    installed = _build_plugins(sim, configs)
+    assert list(installed) == ["a", "b"]
+    sim.hooks.emit(Phase.FRAME_END)
+    # Registration order (a before b) is preserved through emit.
+    assert sim.logged == ["a", "b"]
+
+
+def test_plugin_stores_cfg_and_simulator() -> None:
+    sim = _FakeSimulator()
+    cfg = _ApplyForcePluginConfig()
+    plugin = _ApplyForcePlugin(cfg, cast("BaseSimulator", sim))
+    assert plugin.cfg is cfg
+    assert plugin.sim is sim
+
+
+def test_pluginconfig_get_cls_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        PluginConfig()  # type: ignore[abstract]

--- a/src/holosoma/holosoma/simulator/shared/builtin_plugins.py
+++ b/src/holosoma/holosoma/simulator/shared/builtin_plugins.py
@@ -1,0 +1,23 @@
+"""In-tree reference plugins.
+
+These ship as concrete examples of the plugin pattern and are registered in
+``holosoma.config_values.plugin.PLUGIN_REGISTRY``. A plugin is any class constructed as
+``cls(cfg, simulator)`` that registers hooks on ``simulator.hooks`` — there is no
+base class to inherit.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from holosoma.config_types.plugin import NoOpPluginConfig
+    from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+
+
+class NoOpPlugin:
+    """The runtime class for the ``none`` preset: registers nothing."""
+
+    def __init__(self, cfg: NoOpPluginConfig, simulator: BaseSimulator) -> None:
+        self.cfg = cfg
+        self.simulator = simulator

--- a/src/holosoma/holosoma/simulator/shared/ros2_plugins.py
+++ b/src/holosoma/holosoma/simulator/shared/ros2_plugins.py
@@ -1,10 +1,12 @@
 """ROS2 example plugins.
 
-Two reference plugin implementations that talk ROS2 (each constructed as
+Reference plugin implementations that talk ROS2 (each constructed as
 ``cls(cfg, simulator)`` and registering hooks on ``simulator.hooks`` — no base class):
 
 - :class:`ClockPublishPlugin` publishes sim time as ``rosgraph_msgs/msg/Clock``.
 - :class:`GantryControlPlugin` drives the virtual gantry from three independent topics.
+- :class:`ROS2OdometryPlugin` publishes the robot base pose/velocity as ``nav_msgs/Odometry`` — a
+  self-sourced egress that reads ``robot_root_states`` each control step (no camera frames).
 
 rclpy and the ROS message packages are an **optional** dependency (``holosoma[ros2]``).
 They are imported lazily inside methods (never at module top), mirroring
@@ -26,7 +28,11 @@ from loguru import logger
 from holosoma.simulator.base_simulator.hooks import Phase
 
 if TYPE_CHECKING:
-    from holosoma.config_types.plugin import ClockPublishPluginConfig, GantryControlPluginConfig
+    from holosoma.config_types.plugin import (
+        ClockPublishPluginConfig,
+        GantryControlPluginConfig,
+        ROS2OdometryPluginConfig,
+    )
     from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
 
 
@@ -191,6 +197,131 @@ class GantryControlPlugin:
 
     def close(self) -> None:
         """Stop the spin thread and tear down the ROS2 node (idempotent)."""
+        stop = getattr(self, "_spin_stop", None)
+        if stop is not None:
+            stop.set()
+        thread = getattr(self, "_spin_thread", None)
+        if thread is not None:
+            thread.join(timeout=1.0)
+            self._spin_thread = None
+        node = getattr(self, "_node", None)
+        if node is not None:
+            node.destroy_node()
+            self._node = None
+
+
+def _sim_time_to_stamp(sim_time: float):
+    """Build a builtin_interfaces/Time from sim seconds (deferred import; only after start())."""
+    from builtin_interfaces.msg import Time
+
+    sec = int(sim_time)
+    nanosec = round((sim_time - sec) * 1e9)
+    if nanosec >= 1_000_000_000:  # rounding carry
+        sec += 1
+        nanosec -= 1_000_000_000
+    return Time(sec=sec, nanosec=nanosec)
+
+
+class ROS2OdometryPlugin:
+    """Publish the robot base pose/velocity as ``nav_msgs/Odometry`` on a ROS2 topic.
+
+    A self-sourced (non-camera) egress plugin: each control step it reads the base state off
+    ``simulator.robot_root_states`` — the sim analog of the robot's onboard sport/odom estimate — and
+    publishes one ``nav_msgs/Odometry``. Fires on ``FRAME_END`` (base tensors fresh after the frame's
+    refresh), so ``publish_every`` resolves against the control rate. Rides the same in-process rclpy
+    transport the image egress uses (no CycloneDDS entanglement with the Unitree SDK bridge).
+
+    Base velocities in ``robot_root_states`` are WORLD-frame on every backend (the unified contract);
+    ``nav_msgs/Odometry`` expresses its twist in the ``child_frame_id`` (body) frame, so they are
+    rotated world->body via :func:`quat_rotate_inverse`. Timestamps come from sim_time, not wall-clock.
+    """
+
+    cfg: ROS2OdometryPluginConfig
+
+    def __init__(self, cfg: ROS2OdometryPluginConfig, simulator: BaseSimulator) -> None:
+        self.cfg = cfg
+        self.simulator = simulator
+        import rclpy
+        from nav_msgs.msg import Odometry
+        from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
+
+        self._Odometry = Odometry
+
+        _ensure_ros2_init()
+        self._node = rclpy.create_node(cfg.node_name)
+        reliability = ReliabilityPolicy.RELIABLE if cfg.qos == "reliable" else ReliabilityPolicy.BEST_EFFORT
+        qos = QoSProfile(reliability=reliability, history=HistoryPolicy.KEEP_LAST, depth=1)
+        self._pub = self._node.create_publisher(Odometry, cfg.topic, qos)
+
+        # A daemon spin thread so QoS handshakes progress without a sim-side spin (publish-only node).
+        self._spin_stop = threading.Event()
+        self._spin_thread: threading.Thread | None = threading.Thread(
+            target=self._spin, name=f"odometry_spin:{cfg.node_name}", daemon=True
+        )
+        self._spin_thread.start()
+
+        logger.info(f"ROS2OdometryPlugin publishing base odometry on '{cfg.topic}' (node '{cfg.node_name}')")
+
+        # `every` accepts an int decimation or a frequency string ("50Hz"); the registry decimates natively.
+        self.simulator.hooks.add(Phase.FRAME_END, self.publish, name="odometry.publish", every=cfg.publish_every)
+        self.simulator.hooks.add(Phase.CLOSE, self.close, name="odometry.close")
+
+    def _spin(self) -> None:
+        import rclpy
+
+        while not self._spin_stop.is_set():
+            rclpy.spin_once(self._node, timeout_sec=0.1)
+
+    def publish(self) -> None:
+        pos, quat_xyzw, lin_vel_body, ang_vel_body, sim_time = self._read_base_state()
+        msg = self._Odometry()
+        msg.header.stamp = _sim_time_to_stamp(sim_time)
+        msg.header.frame_id = self.cfg.frame_id
+        msg.child_frame_id = self.cfg.child_frame_id
+
+        msg.pose.pose.position.x = pos[0]
+        msg.pose.pose.position.y = pos[1]
+        msg.pose.pose.position.z = pos[2]
+        # robot_root_states quaternion is xyzw; ROS geometry_msgs/Quaternion is also xyzw — direct copy.
+        msg.pose.pose.orientation.x = quat_xyzw[0]
+        msg.pose.pose.orientation.y = quat_xyzw[1]
+        msg.pose.pose.orientation.z = quat_xyzw[2]
+        msg.pose.pose.orientation.w = quat_xyzw[3]
+
+        msg.twist.twist.linear.x = lin_vel_body[0]
+        msg.twist.twist.linear.y = lin_vel_body[1]
+        msg.twist.twist.linear.z = lin_vel_body[2]
+        msg.twist.twist.angular.x = ang_vel_body[0]
+        msg.twist.twist.angular.y = ang_vel_body[1]
+        msg.twist.twist.angular.z = ang_vel_body[2]
+
+        self._pub.publish(msg)
+
+    def _read_base_state(self) -> tuple[list[float], list[float], list[float], list[float], float]:
+        """Read env ``cfg.env_id`` base state off the sim as plain floats.
+
+        Returns ``(position, quat_xyzw, lin_vel_body, ang_vel_body, sim_time)``. The unified
+        ``robot_root_states`` 13-vector is ``[pos(3), quat_xyzw(4), lin_vel_world(3), ang_vel_world(3)]``;
+        the world-frame velocities are rotated into the base (body) frame for the Odometry twist.
+        """
+        from holosoma.utils.rotations import quat_rotate_inverse
+
+        env = self.cfg.env_id
+        root = self.simulator.robot_root_states[env]  # [13]
+        quat_xyzw = root[3:7]  # xyzw
+        lin_vel_world = root[7:10].unsqueeze(0)
+        ang_vel_world = root[10:13].unsqueeze(0)
+        lin_vel_body = quat_rotate_inverse(quat_xyzw.unsqueeze(0), lin_vel_world, w_last=True).squeeze(0)
+        ang_vel_body = quat_rotate_inverse(quat_xyzw.unsqueeze(0), ang_vel_world, w_last=True).squeeze(0)
+
+        pos = root[0:3].detach().cpu().tolist()
+        quat = quat_xyzw.detach().cpu().tolist()
+        lin = lin_vel_body.detach().cpu().tolist()
+        ang = ang_vel_body.detach().cpu().tolist()
+        return pos, quat, lin, ang, self.simulator.time()
+
+    def close(self) -> None:
+        """Stop the spin thread and tear down the ROS2 node (idempotent; safe from Phase.CLOSE)."""
         stop = getattr(self, "_spin_stop", None)
         if stop is not None:
             stop.set()

--- a/src/holosoma/holosoma/simulator/shared/ros2_plugins.py
+++ b/src/holosoma/holosoma/simulator/shared/ros2_plugins.py
@@ -1,0 +1,204 @@
+"""ROS2 example plugins.
+
+Two reference plugin implementations that talk ROS2 (each constructed as
+``cls(cfg, simulator)`` and registering hooks on ``simulator.hooks`` — no base class):
+
+- :class:`ClockPublishPlugin` publishes sim time as ``rosgraph_msgs/msg/Clock``.
+- :class:`GantryControlPlugin` drives the virtual gantry from three independent topics.
+
+rclpy and the ROS message packages are an **optional** dependency (``holosoma[ros2]``).
+They are imported lazily inside methods (never at module top), mirroring
+``holosoma_inference/inputs/impl/ros2.py``, so this module — and the configs that point
+at it — import cleanly on a bare install without ROS.
+
+ROS callbacks run on a background spin thread; they only stash the latest value under a
+lock. The values are read and applied on the simulator thread inside the lifecycle-phase
+callbacks, so no simulator state is touched off-thread.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from holosoma.simulator.base_simulator.hooks import Phase
+
+if TYPE_CHECKING:
+    from holosoma.config_types.plugin import ClockPublishPluginConfig, GantryControlPluginConfig
+    from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+
+
+# Guards rclpy.init() against concurrent calls from multiple plugins/threads.
+_ros2_init_lock = threading.Lock()
+
+
+def _ensure_ros2_init() -> None:
+    """Call ``rclpy.init()`` once; a second call is a harmless no-op."""
+    import rclpy
+
+    with _ros2_init_lock:
+        try:
+            rclpy.init(args=None)
+        except RuntimeError:
+            pass  # Already initialized (rclpy raises if init() is called twice).
+
+
+class ClockPublishPlugin:
+    """Publish the simulator clock as ``rosgraph_msgs/msg/Clock`` on a ROS2 topic.
+
+    Fires on ``POST_STEP`` — right after ``simulate_at_each_physics_step``
+    advances the clock — so it publishes the freshest sim time. ``publish_every`` is
+    therefore a decimation of the PHYSICS rate (resolved against ``fps``), letting the
+    clock tick faster than the control loop. ROS2 nodes running with ``use_sim_time``
+    follow this clock.
+    """
+
+    cfg: ClockPublishPluginConfig
+
+    def __init__(self, cfg: ClockPublishPluginConfig, simulator: BaseSimulator) -> None:
+        self.cfg = cfg
+        self.simulator = simulator
+        import rclpy
+        from rosgraph_msgs.msg import Clock
+
+        self._clock_msg_cls = Clock
+
+        _ensure_ros2_init()
+        self._node = rclpy.create_node(cfg.node_name)
+        self._pub = self._node.create_publisher(Clock, cfg.topic, 10)
+        logger.info(f"ClockPublishPlugin publishing sim time on '{cfg.topic}' (node '{cfg.node_name}')")
+
+        # `every` accepts an int or a frequency string ("100Hz"); the registry decimates natively.
+        self.simulator.hooks.add(Phase.POST_STEP, self.publish, name="clock_publish.publish", every=cfg.publish_every)
+        self.simulator.hooks.add(Phase.CLOSE, self.close, name="clock_publish.close")
+
+    def publish(self) -> None:
+        sim_time = float(self.simulator.time())
+        msg = self._clock_msg_cls()
+        # rosgraph_msgs/Clock carries a builtin_interfaces/Time (sec + nanosec).
+        msg.clock.sec = int(sim_time)
+        msg.clock.nanosec = int((sim_time - int(sim_time)) * 1e9)
+        self._pub.publish(msg)
+
+    def close(self) -> None:
+        """Tear down the ROS2 node (idempotent; safe from Phase.CLOSE)."""
+        node = getattr(self, "_node", None)
+        if node is not None:
+            node.destroy_node()
+            self._node = None
+
+
+class GantryControlPlugin:
+    """Control the virtual gantry over ROS2 via three independent topics.
+
+    Each property is its own subscription, so publishing to one topic changes only that
+    property:
+
+    - ``position_topic`` (``geometry_msgs/msg/Point``) -> gantry anchor point.
+    - ``length_topic`` (``std_msgs/msg/Float64``) -> elastic-band rest length.
+    - ``enabled_topic`` (``std_msgs/msg/Bool``) -> enable / disable.
+
+    Subscription callbacks run on a background spin thread and only stash the latest
+    command under a lock. The commands are drained and applied to the gantry on the
+    simulator thread in the ``FRAME_BEGIN`` callback — before
+    ``PRE_STEP``, where the gantry's own ``step()`` reads ``point`` /
+    ``length`` / ``enabled`` to compute the band force — so a command takes effect on
+    the same control cycle it arrives in rather than one cycle late.
+    """
+
+    cfg: GantryControlPluginConfig
+
+    def __init__(self, cfg: GantryControlPluginConfig, simulator: BaseSimulator) -> None:
+        self.cfg = cfg
+        self.simulator = simulator
+        import rclpy
+        from geometry_msgs.msg import Point
+        from std_msgs.msg import Bool, Float64
+
+        self._lock = threading.Lock()
+        # Pending commands; None means "no new value for this property".
+        self._pending_position: tuple[float, float, float] | None = None
+        self._pending_length: float | None = None
+        self._pending_enabled: bool | None = None
+
+        _ensure_ros2_init()
+        self._node = rclpy.create_node(cfg.node_name)
+        self._node.create_subscription(Point, cfg.position_topic, self._on_position, 10)
+        self._node.create_subscription(Float64, cfg.length_topic, self._on_length, 10)
+        self._node.create_subscription(Bool, cfg.enabled_topic, self._on_enabled, 10)
+        logger.info(
+            "GantryControlPlugin listening: position "
+            f"'{cfg.position_topic}', length '{cfg.length_topic}', enabled '{cfg.enabled_topic}'"
+        )
+
+        self._spin_stop = threading.Event()
+        self._spin_thread: threading.Thread | None = threading.Thread(
+            target=self._spin, name="gantry_control_spin", daemon=True
+        )
+        self._spin_thread.start()
+
+        self.simulator.hooks.add(Phase.FRAME_BEGIN, self.apply, name="gantry_control.apply")
+        self.simulator.hooks.add(Phase.CLOSE, self.close, name="gantry_control.close")
+
+    # ----- ROS callbacks (spin thread): stash only, never touch the simulator -----
+
+    def _on_position(self, msg: Any) -> None:
+        with self._lock:
+            self._pending_position = (float(msg.x), float(msg.y), float(msg.z))
+
+    def _on_length(self, msg: Any) -> None:
+        with self._lock:
+            self._pending_length = float(msg.data)
+
+    def _on_enabled(self, msg: Any) -> None:
+        with self._lock:
+            self._pending_enabled = bool(msg.data)
+
+    def _spin(self) -> None:
+        import rclpy
+
+        # spin_once with a timeout so the loop can notice the stop event and exit.
+        while not self._spin_stop.is_set():
+            rclpy.spin_once(self._node, timeout_sec=0.1)
+
+    # ----- Applied on the simulator thread -----
+
+    def apply(self) -> None:
+        """Apply any commands received since the last control step to the gantry."""
+        with self._lock:
+            position, length, enabled = self._pending_position, self._pending_length, self._pending_enabled
+            self._pending_position = self._pending_length = self._pending_enabled = None
+
+        gantry = self.simulator.virtual_gantry
+        if gantry is None:
+            if position is not None or length is not None or enabled is not None:
+                logger.warning("GantryControlPlugin received a command but no virtual gantry is present")
+            return
+
+        import numpy as np
+
+        if position is not None:
+            gantry.point = np.array(position)
+            logger.info(f"Gantry position set to {position}")
+        if length is not None:
+            gantry.length = length
+            logger.info(f"Gantry length set to {length}")
+        if enabled is not None:
+            gantry.set_enable(enabled)
+            logger.info(f"Gantry {'enabled' if gantry.enabled else 'disabled'}")
+
+    def close(self) -> None:
+        """Stop the spin thread and tear down the ROS2 node (idempotent)."""
+        stop = getattr(self, "_spin_stop", None)
+        if stop is not None:
+            stop.set()
+        thread = getattr(self, "_spin_thread", None)
+        if thread is not None:
+            thread.join(timeout=1.0)
+            self._spin_thread = None
+        node = getattr(self, "_node", None)
+        if node is not None:
+            node.destroy_node()
+            self._node = None

--- a/src/holosoma/holosoma/simulator/shared/tests/test_ros2_plugins.py
+++ b/src/holosoma/holosoma/simulator/shared/tests/test_ros2_plugins.py
@@ -1,0 +1,257 @@
+"""Tests for the ROS2 example plugins.
+
+rclpy is not installed in the no_sim environment, so these tests inject lightweight fake
+``rclpy`` / ROS message modules into ``sys.modules`` to exercise plugin construction +
+callback wiring. A separate test asserts the configs import and resolve with NO rclpy
+present (the optional-dependency guarantee).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+
+from holosoma.config_types.plugin import ClockPublishPluginConfig, GantryControlPluginConfig, PluginConfig
+from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+from holosoma.simulator.base_simulator.hooks import HookRegistry, Phase
+
+pytestmark = pytest.mark.no_sim
+
+
+def _build_plugin(sim: Any, cfg: PluginConfig) -> Any:
+    """Construct a single plugin the way BaseSimulator.__init__ does: cls(cfg, sim)."""
+    return cfg.get_cls()(cfg, cast("BaseSimulator", sim))
+
+
+def test_configs_and_impl_import_without_rclpy() -> None:
+    # The optional-dep guarantee: configs import and get_cls() resolves the impl module
+    # without pulling rclpy (it is deferred into the plugin __init__/methods).
+    assert "rclpy" not in sys.modules
+    assert ClockPublishPluginConfig().get_cls().__name__ == "ClockPublishPlugin"
+    assert GantryControlPluginConfig().get_cls().__name__ == "GantryControlPlugin"
+    assert "rclpy" not in sys.modules
+
+
+# ----- Fake ROS2 stack ------------------------------------------------------------------
+
+
+class _FakeNode:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.published: list[Any] = []
+        self.subscriptions: dict[str, Any] = {}
+        self.destroyed = False
+
+    def create_publisher(self, msg_cls: Any, topic: str, depth: int) -> Any:
+        node = self
+
+        class _Pub:
+            def publish(self, msg: Any) -> None:
+                node.published.append(msg)
+
+        return _Pub()
+
+    def create_subscription(self, msg_cls: Any, topic: str, cb: Any, depth: int) -> None:
+        self.subscriptions[topic] = cb
+
+    def destroy_node(self) -> None:
+        self.destroyed = True
+
+
+@pytest.fixture
+def fake_ros2(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Install fake rclpy + message modules; yield handles the tests can drive."""
+    created_nodes: list[_FakeNode] = []
+
+    rclpy = types.ModuleType("rclpy")
+
+    def _init(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def _create_node(name: str) -> _FakeNode:
+        node = _FakeNode(name)
+        created_nodes.append(node)
+        return node
+
+    def _spin_once(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    rclpy.init = _init  # type: ignore[attr-defined]
+    rclpy.create_node = _create_node  # type: ignore[attr-defined]
+    rclpy.spin_once = _spin_once  # type: ignore[attr-defined]
+
+    # rosgraph_msgs/msg/Clock has a nested builtin_interfaces/Time (sec + nanosec).
+    class _Time:
+        def __init__(self) -> None:
+            self.sec = 0
+            self.nanosec = 0
+
+    class _Clock:
+        def __init__(self) -> None:
+            self.clock = _Time()
+
+    rosgraph = types.ModuleType("rosgraph_msgs")
+    rosgraph_msg = types.ModuleType("rosgraph_msgs.msg")
+    rosgraph_msg.Clock = _Clock  # type: ignore[attr-defined]
+
+    def _simple(name: str) -> type:
+        # Bare message class; test callbacks set attributes (x/y/z, data) directly.
+        return type(name, (), {})
+
+    geo = types.ModuleType("geometry_msgs")
+    geo_msg = types.ModuleType("geometry_msgs.msg")
+    geo_msg.Point = _simple("Point")  # type: ignore[attr-defined]
+    std = types.ModuleType("std_msgs")
+    std_msg = types.ModuleType("std_msgs.msg")
+    std_msg.Float64 = _simple("Float64")  # type: ignore[attr-defined]
+    std_msg.Bool = _simple("Bool")  # type: ignore[attr-defined]
+
+    for name, mod in {
+        "rclpy": rclpy,
+        "rosgraph_msgs": rosgraph,
+        "rosgraph_msgs.msg": rosgraph_msg,
+        "geometry_msgs": geo,
+        "geometry_msgs.msg": geo_msg,
+        "std_msgs": std,
+        "std_msgs.msg": std_msg,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    return {"nodes": created_nodes, "Clock": _Clock}
+
+
+# ----- Fakes for the simulator side -----------------------------------------------------
+
+
+class _FakeGantry:
+    def __init__(self) -> None:
+        self.point: Any = None
+        self.length: float = 0.2
+        self.enabled: bool = False
+
+    def set_enable(self, enable: bool) -> None:
+        self.enabled = enable
+
+
+class _FakeSim:
+    """Minimal simulator stand-in whose HookRegistry is wired with per-phase base rates,
+    mirroring BaseSimulator, so native ``every="20Hz"`` resolution works in tests."""
+
+    def __init__(
+        self,
+        sim_time: float = 0.0,
+        gantry: Any = None,
+        fps: int = 200,
+        control_decimation_steps: int = 4,
+    ) -> None:
+        control_hz = fps / control_decimation_steps
+        base_rates = {
+            Phase.PRE_STEP: float(fps),
+            Phase.POST_STEP: float(fps),
+            Phase.FRAME_BEGIN: control_hz,
+            Phase.FRAME_END: control_hz,
+        }
+        self.hooks = HookRegistry(base_rates=base_rates)
+        self.virtual_gantry = gantry
+        self._t = sim_time
+
+    def time(self) -> float:
+        return self._t
+
+
+@dataclass
+class _Msg:
+    pass
+
+
+def test_clock_publish_plugin_publishes_sim_time_on_physics_phase(fake_ros2: dict[str, Any]) -> None:
+    sim = _FakeSim(sim_time=2.5)
+    plugin = _build_plugin(sim, ClockPublishPluginConfig(topic="/clock"))
+    node = fake_ros2["nodes"][0]
+
+    # It fires on POST_STEP (freshest sim time), not the control phase.
+    sim.hooks.emit(Phase.FRAME_END)
+    assert node.published == []
+    sim.hooks.emit(Phase.POST_STEP)
+    assert len(node.published) == 1
+    msg = node.published[0]
+    assert msg.clock.sec == 2
+    assert msg.clock.nanosec == pytest.approx(0.5e9, abs=1)
+
+    # CLOSE tears the node down.
+    sim.hooks.emit(Phase.CLOSE)
+    assert node.destroyed
+    assert plugin is not None
+
+
+def test_clock_publish_plugin_honors_publish_every(fake_ros2: dict[str, Any]) -> None:
+    sim = _FakeSim(sim_time=1.0)
+    _build_plugin(sim, ClockPublishPluginConfig(publish_every=3))
+    node = fake_ros2["nodes"][0]
+    for _ in range(6):
+        sim.hooks.emit(Phase.POST_STEP)
+    assert len(node.published) == 2  # steps 3 and 6
+
+
+def test_clock_publish_plugin_resolves_frequency_string(fake_ros2: dict[str, Any]) -> None:
+    # fps=200 physics rate; "20Hz" -> decimation 10 (publish every 10th physics step).
+    sim = _FakeSim(sim_time=1.0, fps=200)
+    _build_plugin(sim, ClockPublishPluginConfig(publish_every="20Hz"))
+    node = fake_ros2["nodes"][0]
+    for _ in range(20):
+        sim.hooks.emit(Phase.POST_STEP)
+    assert len(node.published) == 2  # steps 10 and 20
+
+
+def test_gantry_control_applies_each_topic_independently(fake_ros2: dict[str, Any]) -> None:
+    gantry = _FakeGantry()
+    sim = _FakeSim(gantry=gantry)
+    _build_plugin(sim, GantryControlPluginConfig())
+    node = fake_ros2["nodes"][0]
+
+    # Commands apply on FRAME_BEGIN (before the gantry's own force step reads state).
+    # A control-post emit must NOT apply anything.
+    length_msg = _Msg()
+    length_msg.data = 0.75  # type: ignore[attr-defined]
+    node.subscriptions["/gantry/length"](length_msg)
+    sim.hooks.emit(Phase.FRAME_END)
+    assert gantry.length == 0.2  # not applied on the wrong phase
+
+    # Only publish length: position and enabled must be untouched.
+    sim.hooks.emit(Phase.FRAME_BEGIN)
+    assert gantry.length == 0.75
+    assert gantry.point is None  # not touched
+    assert gantry.enabled is False  # not touched
+
+    # Now publish enabled only.
+    enabled_msg = _Msg()
+    enabled_msg.data = True  # type: ignore[attr-defined]
+    node.subscriptions["/gantry/enabled"](enabled_msg)
+    sim.hooks.emit(Phase.FRAME_BEGIN)
+    assert gantry.enabled is True
+    assert gantry.length == 0.75  # unchanged
+
+    # And position only.
+    point_msg = _Msg()
+    point_msg.x, point_msg.y, point_msg.z = 1.0, 2.0, 3.0  # type: ignore[attr-defined]
+    node.subscriptions["/gantry/position"](point_msg)
+    sim.hooks.emit(Phase.FRAME_BEGIN)
+    assert tuple(gantry.point) == (1.0, 2.0, 3.0)
+
+    sim.hooks.emit(Phase.CLOSE)
+    assert node.destroyed
+
+
+def test_gantry_control_no_command_is_noop(fake_ros2: dict[str, Any]) -> None:
+    gantry = _FakeGantry()
+    sim = _FakeSim(gantry=gantry)
+    _build_plugin(sim, GantryControlPluginConfig())
+    sim.hooks.emit(Phase.FRAME_BEGIN)  # nothing published
+    assert gantry.point is None
+    assert gantry.length == 0.2
+    assert gantry.enabled is False
+    sim.hooks.emit(Phase.CLOSE)

--- a/src/holosoma/holosoma/simulator/shared/video_recorder.py
+++ b/src/holosoma/holosoma/simulator/shared/video_recorder.py
@@ -98,12 +98,7 @@ class VideoRecorderInterface(ABC):
             self._setup_threaded_recording()
 
     def register_hooks(self, hooks: HookRegistry) -> None:
-        """Register video lifecycle hooks with the simulator loop.
-
-        Frames are captured on FRAME_END, which fires once per frame (after the last physics substep +
-        tensor refresh) — the control rate the recorder wants — so no manual decimation against
-        control_decimation is needed.
-        """
+        """Register video lifecycle hooks with the simulator loop."""
         hooks.add(Phase.EPISODE_START, self.on_episode_start, name="video.on_episode_start")
         hooks.add(Phase.EPISODE_END, self.on_episode_end, name="video.on_episode_end")
         hooks.add(Phase.FRAME_END, self.capture_frame, name="video.capture_frame")

--- a/src/holosoma/holosoma/utils/sim_utils.py
+++ b/src/holosoma/holosoma/utils/sim_utils.py
@@ -232,6 +232,7 @@ def setup_simulation_environment(
             scene=config.scene,
             training=config.training,
             logger=config.logger,
+            plugin=config.plugin,
             experiment_dir=None,
         )
 
@@ -433,6 +434,9 @@ class DirectSimulation:
         # Step 5: Prepare simulation
         self.simulator.prepare_sim()
         logger.debug("simulator.prepare_sim() completed")
+
+        # Plugins were constructed in BaseSimulator.__init__ (from FullSimConfig.plugin) and
+        # have already registered their hooks, so EPISODE_START below reaches them.
 
         # Step 5.5: Initialize episode (positions virtual gantry, starts lifecycle participants, etc.)
         self.simulator.hooks.emit(Phase.EPISODE_START, 0)

--- a/src/holosoma/setup.py
+++ b/src/holosoma/setup.py
@@ -10,6 +10,11 @@ setup(
     extras_require={
         "unitree": [f"far-unitree-sdk=={UNITREE_VERSION}"],
         "booster": [f"far-booster-sdk=={BOOSTER_VERSION}"],
+        # ROS2 example plugins (clock_publish, gantry_control). rclpy and the ROS message
+        # packages ship with a ROS2 distro / RoboStack, not PyPI, so this extra is a
+        # marker/opt-in rather than a pip-installable set — install rclpy from your ROS
+        # environment. The plugins import rclpy lazily, so core stays ROS-free without it.
+        "ros2": [],
     },
     # Entry points are declared in pyproject.toml [project.entry-points.*]
 )

--- a/src/holosoma/tests/simulators/scene_spawn_assert.py
+++ b/src/holosoma/tests/simulators/scene_spawn_assert.py
@@ -304,6 +304,15 @@ def main() -> int:
         device=device,
         dtype=torch.float32,
     )
+    # Park the robot far from the objects. This harness spawns a full robot alongside the scene
+    # but drives NO policy, so it collapses under gravity; a free object near its footprint gets
+    # struck by the falling limbs, producing chaotic per-env/per-run displacement that corrupts the
+    # fall/velocity checks (a test-rig artifact, not a spawn defect). Objects live within ~2m of
+    # each env origin, so shove the robot 20m along -y — away from every scene object AND off the
+    # +x axis the per-env origins spread along (so it can't land in a neighbour env). One lever
+    # here immunises every scene preset, present and future, instead of tuning each object's pose.
+    _ROBOT_PARK_Y = -20.0
+    base_init[1] = _ROBOT_PARK_Y
     sim.create_envs(n, env_origins, base_init)
     sim.prepare_sim()
 


### PR DESCRIPTION
Builds on the lifecycle hook registry (base branch **#158**): the step loop emits phase events, and behavior attaches as callbacks. Core features (video recording, simulator bridge, virtual gantry) already run this way. This PR lets **config/CLI attach the same kind of behavior** without subclassing a backend, and ships the ROS2 example plugins.

## What this adds

- A `PluginConfig` family (`PLUGIN_REGISTRY`, group `holosoma.config.plugin`) selectable as the dynamic-dict CLI field `plugin.<key>:<preset>`.
- A **plugin** is any class constructed as `cls(cfg, simulator)` that registers hooks on `simulator.hooks` in `__init__` — **duck-typed, no base class**. It pairs with a `PluginConfig` whose `get_cls()` returns the runtime class. Same registry the core features use.
- Plugins are instantiated in `BaseSimulator.__init__` (from `FullSimConfig.plugin`), so their hooks are registered before the loop emits any phase.
- Threaded through **both** entry points: `RunSimConfig.plugin` (sim2sim) **and** `ExperimentConfig.plugin` → `base_task` → `FullSimConfig` (training).
- Shipped presets: `none` (no-op), `clock_publish` + `gantry_control` (ROS2), and `odometry` — a self-sourced (non-camera) egress plugin that reads `robot_root_states` each control step and publishes `nav_msgs/Odometry`.

Why: one mechanism for step-loop side effects, core and custom alike — added logging, ROS2 bridges, teleop, egress, etc. become config presets (packaged entry point or `--import-file`) instead of loop forks.

## API changes

- **New field `FullSimConfig.plugin: dict[str, PluginConfig]`** (default `{}`), plus registry-bound **`RunSimConfig.plugin`** and **`ExperimentConfig.plugin`** (and `EnvConfig.plugin`, threaded through `get_tyro_env_config`). Additive — existing configs unaffected.
- **New public `PluginConfig` ABC** (`holosoma.config_types.plugin`): subclass with your knobs as dataclass fields + implement `get_cls()`. Also `NoOpPluginConfig`, `ClockPublishPluginConfig`, `GantryControlPluginConfig`, `ROS2OdometryPluginConfig`.
- **New entry-point group `holosoma.config.plugin`** for packaged plugin presets.
- **New extra `holosoma[ros2]`** — opt-in marker for the ROS2 plugins (install `rclpy` from your ROS2 distro / RoboStack; the impls import it lazily so core stays importable without ROS).

## Behavior changes

- **None by default.** The `plugin` field is empty unless you select plugins, so no existing run changes.
- When selected, a plugin's hooks fire at lifecycle phases (from the base branch): `FRAME_BEGIN`, `PRE_STEP`, `POST_STEP`, `FRAME_END` (periodic), `EPISODE_START` / `EPISODE_END`, `CLOSE` (once, reverse order).
- Rate fields accept an int decimation **or** a frequency string (`"100Hz"`, `">100Hz"`, `"<100Hz"`), resolved against the phase's base rate; the registry sub-samples natively.

## Usage

```bash
# ROS2: publish /clock at 100 Hz + drive the gantry over three topics
python -m holosoma.run_sim plugin.clk:clock_publish --plugin.clk.publish-every=100Hz plugin.g:gantry_control

# ROS2 odometry: publish the robot base pose/velocity as nav_msgs/Odometry
python -m holosoma.run_sim plugin.odom:odometry --plugin.odom.topic=/odom
```

Write-your-own (config + duck-typed class), phases, and cadence are documented in `docs/writing-extensions.md` (Plugins section).

---
_Stacked on #158 (lifecycle hook system). Review after / alongside it; the diff here is the plugin family only._
