### PR TITLE
Multiprocess Unitree bridge (isolate CycloneDDS from rclpy)

### DIFF
--- a/src/holosoma/holosoma/bridge/unitree/__init__.py
+++ b/src/holosoma/holosoma/bridge/unitree/__init__.py
@@ -1,7 +1,13 @@
 """
 Unitree SDK2Py bridge implementation.
+
+``UnitreeSdk2Bridge`` talks to the ``unitree_interface`` C++/CycloneDDS binding in-process;
+``UnitreeMpSdk2Bridge`` runs that binding in a spawned child so it never shares the simulator's
+address space with rclpy (ROS2 sensor egress). Both defer the binding import to construction time,
+so importing this package stays CycloneDDS-free.
 """
 
 from .unitree_sdk2py_bridge import UnitreeSdk2Bridge
+from .unitree_sdk2py_bridge_mp import UnitreeMpSdk2Bridge
 
-__all__ = ["UnitreeSdk2Bridge"]
+__all__ = ["UnitreeMpSdk2Bridge", "UnitreeSdk2Bridge"]

--- a/src/holosoma/holosoma/bridge/unitree/tests/_fake_unitree_interface.py
+++ b/src/holosoma/holosoma/bridge/unitree/tests/_fake_unitree_interface.py
@@ -1,0 +1,127 @@
+"""An importable fake ``unitree_interface`` for the multiprocess-bridge test.
+
+The MP bridge's child uses the ``spawn`` start method: a fresh interpreter that re-imports modules by
+name, so an in-memory monkeypatch in the parent would not reach it. This module is a real, on-disk,
+CycloneDDS-free stand-in that the child (and parent test) can inject onto ``sys.path`` and import as
+``unitree_interface``. It records what the child publishes into a file so the parent can assert the
+round-trip, and hands back a deterministic incoming command.
+
+It mimics only the surface the bridge touches: ``RobotType``/``MessageType`` enums, ``UnitreeInterface``
+(``publish_low_state``/``read_incoming_command``/``publish_wireless_controller``), and the
+``LowState``/``MotorCommand``/``WirelessController`` data holders.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from enum import Enum
+
+
+class RobotType(Enum):
+    G1 = "G1"
+    H1 = "H1"
+    H1_2 = "H1_2"
+    GO2 = "GO2"
+
+
+class MessageType(Enum):
+    HG = "HG"
+    GO2 = "GO2"
+
+
+class _Motor:
+    def __init__(self, n: int):
+        self.q = [0.0] * n
+        self.dq = [0.0] * n
+        self.ddq = [0.0] * n
+        self.tau_est = [0.0] * n
+
+
+class _Imu:
+    def __init__(self):
+        self.quat = [0.0, 0.0, 0.0, 0.0]
+        self.omega = [0.0, 0.0, 0.0]
+        self.accel = [0.0, 0.0, 0.0]
+
+
+class LowState:
+    def __init__(self, n: int):
+        self.motor = _Motor(n)
+        self.imu = _Imu()
+        self.tick = 0
+
+
+class MotorCommand:
+    def __init__(self, n: int):
+        self.tau_ff = [0.0] * n
+        self.kp = [0.0] * n
+        self.kd = [0.0] * n
+        self.q_target = [0.0] * n
+        self.dq_target = [0.0] * n
+
+
+class WirelessController:
+    def __init__(self):
+        self.lx = 0.0
+        self.ly = 0.0
+        self.rx = 0.0
+        self.ry = 0.0
+        self.keys = 0
+
+
+# Where publishes are recorded and the canned incoming command is read (set by the test via env var
+# so both the spawned child and the parent agree on the path).
+_RECORD_PATH_ENV = "FAKE_UNITREE_RECORD"
+# Number of motors the canned incoming command is sized for.
+_NUM_MOTOR_ENV = "FAKE_UNITREE_NUM_MOTOR"
+
+
+class UnitreeInterface:
+    def __init__(self, interface_name, robot_type, message_type):
+        self.interface_name = interface_name
+        self.robot_type = robot_type
+        self.message_type = message_type
+        self._record(
+            "init",
+            {"interface": interface_name, "robot_type": robot_type.value, "message_type": message_type.value},
+        )
+
+    def _record(self, kind, payload):
+        path = os.environ.get(_RECORD_PATH_ENV)
+        if not path:
+            return
+        with open(path, "a") as f:
+            f.write(json.dumps({"kind": kind, "payload": payload}) + "\n")
+
+    def publish_low_state(self, low_state: LowState):
+        self._record(
+            "publish_low_state",
+            {
+                "q": list(low_state.motor.q),
+                "dq": list(low_state.motor.dq),
+                "ddq": list(low_state.motor.ddq),
+                "tau_est": list(low_state.motor.tau_est),
+                "quat": list(low_state.imu.quat),
+                "omega": list(low_state.imu.omega),
+                "accel": list(low_state.imu.accel),
+                "tick": low_state.tick,
+            },
+        )
+
+    def read_incoming_command(self) -> MotorCommand:
+        n = int(os.environ.get(_NUM_MOTOR_ENV, "1"))
+        cmd = MotorCommand(n)
+        # Deterministic, distinguishable-per-field values so the parent can assert exact plumbing.
+        cmd.tau_ff = [1.0] * n
+        cmd.kp = [2.0] * n
+        cmd.kd = [3.0] * n
+        cmd.q_target = [4.0] * n
+        cmd.dq_target = [5.0] * n
+        return cmd
+
+    def publish_wireless_controller(self, wc: WirelessController):
+        self._record(
+            "publish_wireless_controller",
+            {"lx": wc.lx, "ly": wc.ly, "rx": wc.rx, "ry": wc.ry, "keys": wc.keys},
+        )

--- a/src/holosoma/holosoma/bridge/unitree/tests/test_unitree_mp_bridge.py
+++ b/src/holosoma/holosoma/bridge/unitree/tests/test_unitree_mp_bridge.py
@@ -1,0 +1,191 @@
+"""Tests for the multiprocess Unitree bridge (``UnitreeMpSdk2Bridge``) — pure, no simulator, no DDS.
+
+Two concerns:
+  1. Import isolation — importing the bridge modules must NOT pull in the ``unitree_interface`` C++
+     binding (that is the whole point: keep CycloneDDS out of the rclpy process).
+  2. End-to-end plumbing — with an on-disk fake ``unitree_interface`` injected, spawn the real child,
+     round-trip publish_low_state / read_incoming_command / publish_wireless_controller, and confirm
+     the inherited torque computation runs against the proxied command.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+_FAKE = Path(__file__).parent / "_fake_unitree_interface.py"
+
+
+# ───────────────────────── 1. import isolation ──────────────────────────
+
+
+def test_importing_bridge_modules_does_not_load_unitree_interface():
+    """Neither the direct nor the MP bridge module may import the C++ binding at module-import time."""
+    guard = _ImportGuard("unitree_interface")
+    sys.meta_path.insert(0, guard)
+    try:
+        # Force a fresh import of both modules with the guard active.
+        for name in [
+            "holosoma.bridge.unitree.unitree_sdk2py_bridge",
+            "holosoma.bridge.unitree.unitree_sdk2py_bridge_mp",
+        ]:
+            sys.modules.pop(name, None)
+        import holosoma.bridge.unitree.unitree_sdk2py_bridge  # noqa: F401
+        import holosoma.bridge.unitree.unitree_sdk2py_bridge_mp as mp
+
+        assert not guard.tripped, "unitree_interface was imported at module-import time"
+        # The MP bridge is a UnitreeSdk2Bridge, so the inherited torque/PD logic is shared.
+        assert issubclass(mp.UnitreeMpSdk2Bridge, mp.UnitreeSdk2Bridge)
+    finally:
+        sys.meta_path.remove(guard)
+
+
+class _ImportGuard:
+    """Records any attempt to import ``forbidden`` (returns None so the real import machinery runs)."""
+
+    def __init__(self, forbidden: str):
+        self.forbidden = forbidden
+        self.tripped = False
+
+    def find_spec(self, name, path=None, target=None):
+        # Return None (implicitly) so the real import machinery still runs; just note the attempt.
+        if name == self.forbidden:
+            self.tripped = True
+
+
+# ───────────────────────── 3. end-to-end via spawned child ──────────────
+
+
+class _FakeSim:
+    """Minimal simulator exposing exactly what the bridge reads off ``self.simulator``."""
+
+    def __init__(self, num_motor: int, device="cpu"):
+        self.num_dof = num_motor
+        self.device = device
+        self._n = num_motor
+        self.dof_pos = torch.arange(num_motor, dtype=torch.float32).reshape(1, num_motor) * 0.1
+        self.dof_vel = torch.zeros(1, num_motor)
+        self.dof_acc = torch.zeros(1, num_motor)
+        # root state: pos(3) quat(3:7 = x,y,z,w = identity) lin(7:10) ang(10:13)
+        root = torch.zeros(1, 13)
+        root[0, 6] = 1.0  # w = 1 (identity quat)
+        self.robot_root_states = root
+        self.base_linear_acc = torch.zeros(1, 3)
+
+    def time(self):
+        return 1.5
+
+    def get_dof_forces(self, env_id):
+        return torch.full((self._n,), 7.0)
+
+
+def _robot_full_config(num_motor: int, robot_type="g1_29dof", sdk_type="unitree_mp"):
+    from holosoma.config_types.robot import RobotBridgeConfig
+
+    return SimpleNamespace(
+        dof_effort_limit_list=[100.0] * num_motor,
+        asset=SimpleNamespace(robot_type=robot_type),
+        bridge=RobotBridgeConfig(sdk_type=sdk_type),
+    )
+
+
+@pytest.fixture
+def fake_binding_on_path(tmp_path, monkeypatch):
+    """Install the fake as an importable ``unitree_interface`` for both the parent and the spawned child.
+
+    ``multiprocessing`` spawn forwards ``sys.path``, but PYTHONPATH is set too so the fresh child
+    interpreter resolves the fake regardless of platform. Returns the record-file path.
+    """
+    pkg_dir = tmp_path / "fake_pkg"
+    pkg_dir.mkdir()
+    shutil.copy(_FAKE, pkg_dir / "unitree_interface.py")
+    record = tmp_path / "record.jsonl"
+
+    import os
+
+    monkeypatch.syspath_prepend(str(pkg_dir))
+    # Prepend for the spawned child interpreter (spawn forwards sys.path too, but be explicit).
+    existing = os.environ.get("PYTHONPATH", "")
+    monkeypatch.setenv("PYTHONPATH", str(pkg_dir) + (os.pathsep + existing if existing else ""))
+    monkeypatch.setenv("FAKE_UNITREE_RECORD", str(record))
+    return record
+
+
+def _read_records(path: Path):
+    import json
+
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_mp_bridge_end_to_end(fake_binding_on_path, monkeypatch):
+    num_motor = 2
+    monkeypatch.setenv("FAKE_UNITREE_NUM_MOTOR", str(num_motor))
+    record = fake_binding_on_path
+
+    from holosoma.bridge.unitree.unitree_sdk2py_bridge_mp import LowCommand, UnitreeMpSdk2Bridge
+
+    sim = _FakeSim(num_motor)
+    robot_cfg = _robot_full_config(num_motor)
+    bridge_cfg = SimpleNamespace(interface="lo")
+
+    bridge = UnitreeMpSdk2Bridge(sim, robot_cfg, bridge_cfg)
+    try:
+        # Parent stand-ins are binding-free and truthy for compute_torques' guard.
+        assert isinstance(bridge.low_cmd, LowCommand)
+
+        # publish_low_state: parent computes fields from sim state, child records them.
+        bridge.publish_low_state()
+
+        # read incoming command from the child (canned deterministic values).
+        bridge.low_cmd_handler()
+        assert list(bridge.low_cmd.tau_ff) == [1.0] * num_motor
+        assert list(bridge.low_cmd.kp) == [2.0] * num_motor
+        assert list(bridge.low_cmd.q_target) == [4.0] * num_motor
+
+        # Inherited PD torque computation runs against the proxied command; result is clipped
+        # to the effort limits and returned as a numpy array of the right length.
+        torques = bridge.compute_torques()
+        assert isinstance(torques, np.ndarray)
+        assert torques.shape == (num_motor,)
+        # tau_ff(1) + kp(2)*(q_target(4) - q_actual) + kd(3)*(dq_target(5) - 0), all within +-100.
+        q_actual = sim.dof_pos[0].numpy()
+        expected = 1.0 + 2.0 * (4.0 - q_actual) + 3.0 * (5.0 - 0.0)
+        np.testing.assert_allclose(torques, np.clip(expected, -100.0, 100.0), rtol=1e-5)
+    finally:
+        bridge.close()
+
+    # The child recorded a construction with the mapped enums and one publish_low_state.
+    records = _read_records(record)
+    kinds = [r["kind"] for r in records]
+    assert "init" in kinds
+    init = next(r for r in records if r["kind"] == "init")
+    assert init["payload"]["robot_type"] == "G1"  # g1_29dof -> G1
+    assert init["payload"]["message_type"] == "HG"  # g1_29dof -> HG
+    assert init["payload"]["interface"] == "lo"
+
+    pub = next(r for r in records if r["kind"] == "publish_low_state")
+    # q shipped as sim dof_pos (0.0, 0.1); quat converted x,y,z,w -> w,x,y,z = identity (1,0,0,0).
+    np.testing.assert_allclose(pub["payload"]["q"], [0.0, 0.1], atol=1e-6)
+    assert pub["payload"]["quat"] == [1.0, 0.0, 0.0, 0.0]
+    assert pub["payload"]["tick"] == int(1.5 * 1e3)
+
+
+def test_mp_bridge_close_is_idempotent(fake_binding_on_path, monkeypatch):
+    monkeypatch.setenv("FAKE_UNITREE_NUM_MOTOR", "1")
+    from holosoma.bridge.unitree.unitree_sdk2py_bridge_mp import UnitreeMpSdk2Bridge
+
+    bridge = UnitreeMpSdk2Bridge(_FakeSim(1), _robot_full_config(1), SimpleNamespace(interface="lo"))
+    bridge.close()
+    bridge.close()  # must not raise
+    assert not bridge._proc.is_alive()

--- a/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge.py
+++ b/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge.py
@@ -1,12 +1,4 @@
 from loguru import logger
-from unitree_interface import (
-    LowState,
-    MessageType,
-    MotorCommand,
-    RobotType,
-    UnitreeInterface,
-    WirelessController,
-)
 
 from holosoma.bridge.base.basic_sdk2py_bridge import BasicSdk2Bridge
 
@@ -16,8 +8,25 @@ class UnitreeSdk2Bridge(BasicSdk2Bridge):
 
     SUPPORTED_ROBOT_TYPES = {"g1_29dof", "h1", "h1-2", "go2_12dof"}
 
+    # robot_type -> SDK enum member NAME (resolved to the real enum via getattr where the binding is
+    # imported). Kept as strings so the parent process can build them without importing the C++
+    # binding — the multiprocess subclass ships them to its child, which owns the CycloneDDS binding.
+    _ROBOT_TYPE_NAMES = {"g1_29dof": "G1", "h1": "H1", "h1-2": "H1_2", "go2_12dof": "GO2"}
+    # Message type (HG for humanoid robots with 35 motors, GO2 for others).
+    _MESSAGE_TYPE_NAMES = {"g1_29dof": "HG", "h1": "GO2", "h1-2": "HG", "go2_12dof": "GO2"}
+
     def _init_sdk_components(self):
         """Initialize Unitree SDK-specific components."""
+        # Imported here (not at module top level) so importing this module never loads the C++
+        # binding's bundled CycloneDDS — the multiprocess subclass keeps the parent binding-free.
+        from unitree_interface import (
+            LowState,
+            MessageType,
+            MotorCommand,
+            RobotType,
+            UnitreeInterface,
+            WirelessController,
+        )
 
         robot_type = self.robot.asset.robot_type
 
@@ -25,24 +34,8 @@ class UnitreeSdk2Bridge(BasicSdk2Bridge):
         if robot_type not in self.SUPPORTED_ROBOT_TYPES:
             raise ValueError(f"Invalid robot type '{robot_type}'. Unitree SDK supports: {self.SUPPORTED_ROBOT_TYPES}")
 
-        # Map robot type to SDK enum
-        robot_type_map = {
-            "g1_29dof": RobotType.G1,
-            "h1": RobotType.H1,
-            "h1-2": RobotType.H1_2,
-            "go2_12dof": RobotType.GO2,
-        }
-
-        # Map to message type (HG for humanoid robots with 35 motors, GO2 for others)
-        message_type_map = {
-            "g1_29dof": MessageType.HG,
-            "h1": MessageType.GO2,
-            "h1-2": MessageType.HG,
-            "go2_12dof": MessageType.GO2,
-        }
-
-        sdk_robot_type = robot_type_map[robot_type]
-        sdk_message_type = message_type_map[robot_type]
+        sdk_robot_type = getattr(RobotType, self._ROBOT_TYPE_NAMES[robot_type])
+        sdk_message_type = getattr(MessageType, self._MESSAGE_TYPE_NAMES[robot_type])
 
         # Get network interface from config
         interface_name = self.bridge_config.interface or "eth0"

--- a/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge_mp.py
+++ b/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge_mp.py
@@ -1,0 +1,292 @@
+"""Multiprocess Unitree bridge.
+
+Runs the CycloneDDS-touching half of :class:`UnitreeSdk2Bridge` in a spawned child process so the
+``unitree_interface`` C++ binding never shares an address space with the simulator's in-process
+``rclpy`` (ROS2 sensor egress). Both bundle CycloneDDS; loading them into one process heap-corrupts
+at SDK init ("free(): invalid pointer"). This mirrors the inference side's
+``holosoma_inference.sdk.unitree.unitree_interface_mp`` — same spawn/RPC/teardown pattern.
+
+Unlike the inference proxy (which runs its *entire* self-contained interface in the child), this
+bridge is coupled to live simulator torch/GPU state and writes PD torques back into the sim, so that
+half MUST stay in the parent. Only the four DDS operations move to the child:
+
+    * constructing ``UnitreeInterface`` (opens CycloneDDS),
+    * ``publish_low_state``       (parent computes the fields from sim state, ships plain lists),
+    * ``read_incoming_command``   (child polls DDS, ships a picklable command back),
+    * ``publish_wireless_controller`` (parent reads the joystick, ships the axes/keys).
+
+``compute_torques`` and every ``_get_*`` simulator read stay inherited from :class:`UnitreeSdk2Bridge`
+unchanged: the parent-side ``self.low_cmd`` is a picklable :class:`LowCommand` carrying exactly the
+attributes ``compute_torques`` reads (``tau_ff``/``kp``/``kd``/``q_target``/``dq_target``).
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import queue
+from types import SimpleNamespace
+from typing import Any, NamedTuple
+
+from loguru import logger
+
+from holosoma.bridge.unitree.unitree_sdk2py_bridge import UnitreeSdk2Bridge
+
+# Seconds to wait for the child to construct the binding (DDS init) before declaring it dead.
+_STARTUP_TIMEOUT_S = 30.0
+# Poll interval for a per-RPC liveness check — an RPC that outlives this and whose child has died is
+# turned into a raised error instead of a silent, permanent block of the simulator step thread.
+_RPC_POLL_S = 1.0
+
+
+class LowCommand(NamedTuple):
+    """Picklable stand-in for the C++ low-level command returned by ``read_incoming_command``.
+
+    Carries exactly the attributes :meth:`UnitreeSdk2Bridge.compute_torques` reads, so the inherited
+    torque computation runs against it in the parent unchanged.
+    """
+
+    tau_ff: list[float]
+    kp: list[float]
+    kd: list[float]
+    q_target: list[float]
+    dq_target: list[float]
+
+
+# Sentinel that tells the worker to shut down.
+_STOP = None
+
+
+# ── child process ──────────────────────────────────────────────────────
+
+
+def _worker(
+    interface_name: str,
+    robot_type_name: str,
+    message_type_name: str,
+    num_motor: int,
+    req_q: mp.Queue,
+    res_q: mp.Queue,
+):
+    """Event loop that owns the real ``unitree_interface`` binding (and its CycloneDDS)."""
+    import ctypes
+    import importlib.util
+    import os
+    from pathlib import Path
+
+    # Preload unitree's bundled CycloneDDS before import so ROS2's version is not picked up via
+    # LD_LIBRARY_PATH (identical to the inference-side proxy).
+    spec = importlib.util.find_spec("unitree_interface")
+    if spec and spec.submodule_search_locations:
+        ui_dir = Path(spec.submodule_search_locations[0])
+        for lib in ["libddsc.so.0", "libddscxx.so.0"]:
+            lib_path = ui_dir / lib
+            if lib_path.exists():
+                ctypes.CDLL(str(lib_path), mode=ctypes.RTLD_GLOBAL)
+
+    # Construct the binding (opens CycloneDDS) BEFORE signalling readiness, so a DDS init failure is
+    # reported to the parent as an error instead of leaving it to block on the first RPC forever.
+    try:
+        from unitree_interface import LowState, MessageType, RobotType, UnitreeInterface, WirelessController
+
+        interface = UnitreeInterface(
+            interface_name,
+            getattr(RobotType, robot_type_name),
+            getattr(MessageType, message_type_name),
+        )
+        # The child owns only the C++ objects the DDS calls need: a reusable LowState the parent fills
+        # each publish, and a WirelessController for joystick publishing. The incoming command lives in
+        # the parent (as a picklable LowCommand), so no MotorCommand is held here.
+        low_state = LowState(num_motor)
+        wireless_controller = WirelessController()
+    except Exception as exc:
+        res_q.put(("err", exc))
+        os._exit(0)
+    res_q.put(("ready", None))
+
+    try:
+        while True:
+            msg = req_q.get()
+            if msg is _STOP:
+                break
+
+            method, args, kwargs = msg
+            try:
+                if method == "publish_low_state":
+                    q, dq, ddq, tau_est, quat, omega, accel, tick = args
+                    low_state.motor.q = q
+                    low_state.motor.dq = dq
+                    low_state.motor.ddq = ddq
+                    low_state.motor.tau_est = tau_est
+                    low_state.imu.quat = quat
+                    low_state.imu.omega = omega
+                    low_state.imu.accel = accel
+                    low_state.tick = tick
+                    interface.publish_low_state(low_state)  # CRC calculated in C++
+                    res_q.put(("ok", None))
+                elif method == "read_incoming_command":
+                    cmd = interface.read_incoming_command()
+                    res_q.put(
+                        (
+                            "ok",
+                            LowCommand(
+                                tau_ff=list(cmd.tau_ff),
+                                kp=list(cmd.kp),
+                                kd=list(cmd.kd),
+                                q_target=list(cmd.q_target),
+                                dq_target=list(cmd.dq_target),
+                            ),
+                        )
+                    )
+                elif method == "publish_wireless_controller":
+                    lx, ly, rx, ry, keys = args
+                    wireless_controller.lx = lx
+                    wireless_controller.ly = ly
+                    wireless_controller.rx = rx
+                    wireless_controller.ry = ry
+                    wireless_controller.keys = keys
+                    interface.publish_wireless_controller(wireless_controller)
+                    res_q.put(("ok", None))
+                else:
+                    res_q.put(("err", ValueError(f"Unknown method '{method}'")))
+            except Exception as exc:
+                res_q.put(("err", exc))
+    finally:
+        # Drop the binding ref before the worker returns so its destructor runs while the DDS event
+        # loop is still alive, then bypass Python's atexit chain — lingering C++ teardown otherwise
+        # surfaces as misleading `Process SpawnProcess-1:` stderr noise (mirrors the inference proxy).
+        del interface
+        os._exit(0)
+
+
+# ── parent-side bridge ───────────────────────────────────────────────────
+
+
+class UnitreeMpSdk2Bridge(UnitreeSdk2Bridge):
+    """Unitree bridge that runs the ``unitree_interface`` binding in a spawned child process.
+
+    Drop-in for :class:`UnitreeSdk2Bridge` (same ``holosoma.bridge`` factory + ``compute_torques``);
+    isolates CycloneDDS from the rest of the process. Select it via ``sdk_type="unitree_mp"`` when the
+    simulator process also loads rclpy (a ROS2 sensor egress) — the two CycloneDDS runtimes cannot
+    coexist in one process.
+    """
+
+    def _init_sdk_components(self):
+        """Spawn the DDS child; keep only picklable, binding-free stand-ins in the parent."""
+        robot_type = self.robot.asset.robot_type
+        if robot_type not in self.SUPPORTED_ROBOT_TYPES:
+            raise ValueError(f"Invalid robot type '{robot_type}'. Unitree SDK supports: {self.SUPPORTED_ROBOT_TYPES}")
+
+        interface_name = self.bridge_config.interface or "eth0"
+
+        ctx = mp.get_context("spawn")
+        self._req_q = ctx.Queue()
+        self._res_q = ctx.Queue()
+        self._proc = ctx.Process(
+            target=_worker,
+            args=(
+                interface_name,
+                self._ROBOT_TYPE_NAMES[robot_type],
+                self._MESSAGE_TYPE_NAMES[robot_type],
+                self.num_motor,
+                self._req_q,
+                self._res_q,
+            ),
+            daemon=True,
+        )
+        self._proc.start()
+
+        # Block until the child has constructed the binding (or failed), so a DDS init error raises
+        # here — like the in-process bridge's synchronous construction — instead of hanging a later
+        # step. (Mirrors the high-level MPClientProxy's readiness handshake.)
+        try:
+            tag, payload = self._res_q.get(timeout=_STARTUP_TIMEOUT_S)
+        except queue.Empty:
+            self.close()
+            raise RuntimeError("Unitree MP bridge: child process did not start within timeout") from None
+        if tag == "err":
+            self.close()
+            raise payload
+
+        # Parent-side stand-ins (never the C++ objects): a zero command truthy for compute_torques'
+        # guard, and a mutable wireless-controller the base joystick code writes its axes/keys onto.
+        zeros = [0.0] * self.num_motor
+        self.low_cmd = LowCommand(tau_ff=zeros, kp=zeros, kd=zeros, q_target=zeros, dq_target=zeros)
+        self.wireless_controller = SimpleNamespace(lx=0.0, ly=0.0, rx=0.0, ry=0.0, keys=0)
+
+    # ── RPC helper ─────────────────────────────────────────────────────
+
+    def _call(self, method: str, *args: Any) -> Any:
+        """Send one request and block for its reply. Raises if the child has died (never hangs).
+
+        Without the liveness check a child that crashed at the C level (segfault, or the very
+        heap-corruption this module isolates) — which never sends a reply — would block the simulator
+        step thread forever. Poll instead, and convert a dead child into a raised error.
+        """
+        self._req_q.put((method, args, {}))
+        while True:
+            try:
+                tag, payload = self._res_q.get(timeout=_RPC_POLL_S)
+                break
+            except queue.Empty:
+                if not self._proc.is_alive():
+                    raise RuntimeError(f"Unitree MP bridge: child died during '{method}'") from None
+        if tag == "err":
+            raise payload
+        return payload
+
+    # ── overridden DDS operations (everything else inherited) ──────────
+
+    def low_cmd_handler(self, msg=None):
+        """Poll the child for the latest incoming command; store its picklable carrier."""
+        self.low_cmd = self._call("read_incoming_command")
+
+    def publish_low_state(self):
+        """Compute the state fields from sim state (parent), ship them to the child to publish."""
+        positions, velocities, accelerations = self._get_dof_states()
+        actuator_forces = self._get_actuator_forces()
+        quaternion, gyro, acceleration = self._get_base_imu_data()
+
+        # _get_base_imu_data already returns the quaternion in SDK order [w, x, y, z]; just floatify
+        # it into a plain list (same as the direct bridge does before assigning imu.quat).
+        quat_array = quaternion.detach().cpu().numpy()
+        quat = [float(quat_array[0]), float(quat_array[1]), float(quat_array[2]), float(quat_array[3])]
+
+        self._call(
+            "publish_low_state",
+            positions.tolist(),
+            velocities.tolist(),
+            accelerations.tolist(),
+            actuator_forces.tolist(),
+            quat,
+            gyro.detach().cpu().numpy().tolist(),
+            acceleration.detach().cpu().numpy().tolist(),
+            int(self.sim_time * 1e3),
+        )
+
+    def publish_wireless_controller(self):
+        """Populate the parent stand-in from the joystick (base class), ship it to the child."""
+        # Skip UnitreeSdk2Bridge (it touches self.interface, which lives in the child) and reach
+        # BasicSdk2Bridge, which reads pygame and writes lx/ly/rx/ry/keys onto self.wireless_controller.
+        super(UnitreeSdk2Bridge, self).publish_wireless_controller()
+
+        if self.joystick is not None:
+            wc = self.wireless_controller
+            self._call("publish_wireless_controller", wc.lx, wc.ly, wc.rx, wc.ry, wc.keys)
+
+    # ── lifecycle ──────────────────────────────────────────────────────
+
+    def close(self):
+        """Stop the child process (idempotent)."""
+        if not hasattr(self, "_proc"):
+            return
+        if self._proc.is_alive():
+            self._req_q.put(_STOP)
+            self._proc.join(timeout=5)
+            if self._proc.is_alive():
+                self._proc.kill()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception as exc:  # never raise from GC
+            logger.debug(f"UnitreeMpSdk2Bridge teardown ignored error: {exc}")

--- a/src/holosoma/holosoma/config_types/robot.py
+++ b/src/holosoma/holosoma/config_types/robot.py
@@ -16,7 +16,12 @@ class RobotBridgeConfig:
     """
 
     sdk_type: str = "unitree"
-    """SDK type for robot communication ('unitree', 'booster', 'ros2')."""
+    """SDK type for robot communication ('unitree', 'unitree_mp', 'booster', 'ros2').
+
+    'unitree_mp' runs the Unitree SDK's C++/CycloneDDS binding in a spawned child process so it never
+    shares the simulator's address space. Select it when this process also loads rclpy (a ROS2 sensor
+    egress): the Unitree SDK's bundled CycloneDDS heap-corrupts if it coexists with rclpy's CycloneDDS
+    in one process. Otherwise 'unitree' (in-process) is fine."""
 
     motor_type: str = "serial"
     """Motor communication type ('serial', etc.)."""

--- a/src/holosoma/pyproject.toml
+++ b/src/holosoma/pyproject.toml
@@ -56,8 +56,9 @@ dependencies = [
 dynamic = ["optional-dependencies"]
 
 [project.entry-points."holosoma.bridge"]
-unitree = "holosoma.bridge.unitree:UnitreeSdk2Bridge"
-booster = "holosoma.bridge.booster:BoosterSdk2Bridge"
+unitree = "holosoma.bridge.unitree.unitree_sdk2py_bridge:UnitreeSdk2Bridge"
+unitree_mp = "holosoma.bridge.unitree.unitree_sdk2py_bridge_mp:UnitreeMpSdk2Bridge"
+booster = "holosoma.bridge.booster.booster_sdk2py_bridge:BoosterSdk2Bridge"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
# Multiprocess Unitree bridge

Base: `main`. 1 commit, 8 files.

Split out of the sim_cameras branch — the MP bridge is independent of the camera work, so it can land on its own.

## Why

The Unitree SDK's `unitree_interface` binding bundles its own CycloneDDS. So does `rclpy`. Load both into one process and the SDK heap-corrupts at init (`free(): invalid pointer`). That's exactly what happens once the simulator process runs a ROS2 sensor egress alongside the bridge.

## What

`UnitreeMpSdk2Bridge`, selected with `sdk_type="unitree_mp"`, runs the binding in a spawned child so its CycloneDDS never shares the simulator's address space. Same spawn/RPC/teardown shape as the inference-side `unitree_interface_mp`.

Only the four DDS calls move to the child (construct binding, `publish_low_state`, `read_incoming_command`, `publish_wireless_controller`). `compute_torques` and the sim-state reads stay in the parent, inherited from `UnitreeSdk2Bridge` unchanged, driven by a picklable `LowCommand`. A per-RPC liveness poll turns a dead child into a raised error instead of blocking the step thread forever.

To keep the parent binding-free, `UnitreeSdk2Bridge` now imports `unitree_interface` lazily (inside `_init_sdk_components`) and holds the robot/message enums as strings the child resolves. Plain `unitree` (in-process) is unchanged; use `unitree_mp` only when the process also loads rclpy.

## Tests

`test_unitree_mp_bridge.py` injects an on-disk fake `unitree_interface` and spawns the real child to round-trip all three DDS ops with no DDS installed, and asserts importing the bridge modules never pulls the binding. Runs under `no_sim`.
