### PR TITLE
fix(config): restore inference --no-flag negation (drop FlagConversionOff on inference only)

### DIFF
--- a/src/holosoma_inference/holosoma_inference/config/tyro_utils.py
+++ b/src/holosoma_inference/holosoma_inference/config/tyro_utils.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 # NOTE FOR AGENTS/MAINTAINERS: This module is intentionally mirrored with
-# holosoma.utils.tyro_utils. Keep behavior changes in sync.
+# holosoma.utils.tyro_utils. Keep behavior changes in sync, with one deliberate
+# exception: TYRO_CONIFG omits tyro.conf.FlagConversionOff here. Inference CLIs
+# and docs use the --flag/--no-flag negation form because the old
+# config/utils.py marker was nested one tuple too deep and silently ignored;
+# training CLIs use --flag=True/False and keep FlagConversionOff.
 import argparse
 import collections.abc
 import copy
@@ -18,7 +22,6 @@ import tyro.conf
 
 TYRO_CONIFG = (
     tyro.conf.CascadeSubcommandArgs,
-    tyro.conf.FlagConversionOff,
     tyro.conf.UsePythonSyntaxForLiteralCollections,
 )
 


### PR DESCRIPTION
## Problem

#159 broke the documented inference negation flags (e.g. `--task.no-use-joystick`).

Root cause is an asymmetry between the packages: training's `TYRO_CONIFG` has always had `FlagConversionOff` active (`--flag=True/False` value form), while inference's old `config/utils.py` tuple nested the marker one level too deep, so tyro silently ignored it and inference booleans kept the `--flag`/`--no-flag` negation form. #159's new flat inference tuple activated `FlagConversionOff` there for the first time.

## Fix

Drop `FlagConversionOff` from the **inference** `tyro_utils` tuple only; training is untouched. This restores each package's pre-#159 behavior exactly, so no caller, doc, test, or workflow changes are needed. tyro's bool handling can't accept both forms at once, so a shared tuple would force rewriting one side's callers. The mirror-in-sync comment now records this one deliberate divergence.

Note: we may align the two packages on a single flag form in the future; that's a breaking CLI change and out of scope here.

## Verification

- tyro 1.0.13: inference tuple accepts `--no-use-joystick` / rejects `--use-joystick=False`; training tuple the inverse — matching each side's docs.
- `test_tyro_utils.py` + `test_tyro_cli.py`: 15 passed.