### PR TITLE
Add camera sensor simulation 

### DIFF
--- a/docs/writing-extensions.md
+++ b/docs/writing-extensions.md
@@ -136,7 +136,7 @@ A plugin's hooks attach to lifecycle phases via `add(phase, callback, *, name=No
 
 `every` sub-samples a phase: an int runs the callback every Nth emission; a frequency string (`"100Hz"`, `">100Hz"`, `"<100Hz"`) is resolved against the phase's base rate (`fps` for the per-substep `*_STEP` phases, `fps/control_decimation` for the per-frame `FRAME_*` phases). Frequency strings are periodic-phases only; `CLOSE` always fires once. The registry sub-samples natively — hooks never write their own counters.
 
-Built-ins to copy: the dependency-free `none` no-op in `holosoma/simulator/shared/builtin_plugins.py`; `clock_publish` / `gantry_control` / `odometry` (ROS2, `rclpy` imported lazily so core stays ROS-free) in `ros2_plugins.py`. Select `plugin.<key>:none` to disable a slot.
+Built-ins to copy: the dependency-free `none` no-op in `holosoma/simulator/shared/builtin_plugins.py`; `clock_publish` / `gantry_control` / `odometry` (ROS2, `rclpy` imported lazily so core stays ROS-free) in `ros2_plugins.py`. Camera-frame egress ships as plugins too — `ros2-image` / `ros2-stereo` / `ros2-waist-depth*` publish rendered cameras over ROS2, `viz` / `viz-record` tile them into a live window or an mp4; their impls live in `holosoma/simulator/plugins/` and subclass the shared `CameraConsumerPlugin` base (which self-serves each step's fresh frames via `get_camera_data`). Select `plugin.<key>:none` to disable a slot.
 
 ## Don't
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -107,6 +107,9 @@ ignore_missing_imports = True
 [mypy-rosgraph_msgs.*]
 ignore_missing_imports = True
 
+[mypy-sensor_msgs.*]
+ignore_missing_imports = True
+
 [mypy-nav_msgs.*]
 ignore_missing_imports = True
 

--- a/scripts/setup_mujoco.sh
+++ b/scripts/setup_mujoco.sh
@@ -12,9 +12,13 @@ if ! command -v sudo &> /dev/null; then
   export -f sudo
 fi
 
-# MuJoCo Warp version to install -- the repo is missing version tags and branches
-# Arbitrarily chosen from mainline at the time we've ~tested against
-MUJOCO_WARP_COMMIT="09ec1da"
+# MuJoCo Warp version to install -- the repo is missing version tags and branches.
+# Pinned to the 3.10.0 line, which ships the batched-camera renderer API
+# (mujoco_warp.create_render_context / render / get_rgb / get_depth) the WarpBackend uses;
+# the older 09ec1da mainline predated it. mujoco_warp[cuda]'s own deps pull warp-lang>=1.14 from
+# pypi.nvidia.com (public PyPI caps at 1.10.1), installed after holosoma below; holosoma itself only
+# floors warp-lang>=1.10 so the non-mujoco images (plain PyPI) still resolve.
+MUJOCO_WARP_COMMIT="ecaef88917a3c90cd238bf76681ca770f58033df"
 
 # Parse command-line arguments
 INSTALL_WARP=true  # Default: install warp (GPU-accelerated)

--- a/src/holosoma/holosoma/bridge/unitree/__init__.py
+++ b/src/holosoma/holosoma/bridge/unitree/__init__.py
@@ -1,7 +1,13 @@
 """
 Unitree SDK2Py bridge implementation.
+
+``UnitreeSdk2Bridge`` talks to the ``unitree_interface`` C++/CycloneDDS binding in-process;
+``UnitreeMpSdk2Bridge`` runs that binding in a spawned child so it never shares the simulator's
+address space with rclpy (ROS2 sensor egress). Both defer the binding import to construction time,
+so importing this package stays CycloneDDS-free.
 """
 
 from .unitree_sdk2py_bridge import UnitreeSdk2Bridge
+from .unitree_sdk2py_bridge_mp import UnitreeMpSdk2Bridge
 
-__all__ = ["UnitreeSdk2Bridge"]
+__all__ = ["UnitreeMpSdk2Bridge", "UnitreeSdk2Bridge"]

--- a/src/holosoma/holosoma/bridge/unitree/tests/_fake_unitree_interface.py
+++ b/src/holosoma/holosoma/bridge/unitree/tests/_fake_unitree_interface.py
@@ -1,0 +1,127 @@
+"""An importable fake ``unitree_interface`` for the multiprocess-bridge test.
+
+The MP bridge's child uses the ``spawn`` start method: a fresh interpreter that re-imports modules by
+name, so an in-memory monkeypatch in the parent would not reach it. This module is a real, on-disk,
+CycloneDDS-free stand-in that the child (and parent test) can inject onto ``sys.path`` and import as
+``unitree_interface``. It records what the child publishes into a file so the parent can assert the
+round-trip, and hands back a deterministic incoming command.
+
+It mimics only the surface the bridge touches: ``RobotType``/``MessageType`` enums, ``UnitreeInterface``
+(``publish_low_state``/``read_incoming_command``/``publish_wireless_controller``), and the
+``LowState``/``MotorCommand``/``WirelessController`` data holders.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from enum import Enum
+
+
+class RobotType(Enum):
+    G1 = "G1"
+    H1 = "H1"
+    H1_2 = "H1_2"
+    GO2 = "GO2"
+
+
+class MessageType(Enum):
+    HG = "HG"
+    GO2 = "GO2"
+
+
+class _Motor:
+    def __init__(self, n: int):
+        self.q = [0.0] * n
+        self.dq = [0.0] * n
+        self.ddq = [0.0] * n
+        self.tau_est = [0.0] * n
+
+
+class _Imu:
+    def __init__(self):
+        self.quat = [0.0, 0.0, 0.0, 0.0]
+        self.omega = [0.0, 0.0, 0.0]
+        self.accel = [0.0, 0.0, 0.0]
+
+
+class LowState:
+    def __init__(self, n: int):
+        self.motor = _Motor(n)
+        self.imu = _Imu()
+        self.tick = 0
+
+
+class MotorCommand:
+    def __init__(self, n: int):
+        self.tau_ff = [0.0] * n
+        self.kp = [0.0] * n
+        self.kd = [0.0] * n
+        self.q_target = [0.0] * n
+        self.dq_target = [0.0] * n
+
+
+class WirelessController:
+    def __init__(self):
+        self.lx = 0.0
+        self.ly = 0.0
+        self.rx = 0.0
+        self.ry = 0.0
+        self.keys = 0
+
+
+# Where publishes are recorded and the canned incoming command is read (set by the test via env var
+# so both the spawned child and the parent agree on the path).
+_RECORD_PATH_ENV = "FAKE_UNITREE_RECORD"
+# Number of motors the canned incoming command is sized for.
+_NUM_MOTOR_ENV = "FAKE_UNITREE_NUM_MOTOR"
+
+
+class UnitreeInterface:
+    def __init__(self, interface_name, robot_type, message_type):
+        self.interface_name = interface_name
+        self.robot_type = robot_type
+        self.message_type = message_type
+        self._record(
+            "init",
+            {"interface": interface_name, "robot_type": robot_type.value, "message_type": message_type.value},
+        )
+
+    def _record(self, kind, payload):
+        path = os.environ.get(_RECORD_PATH_ENV)
+        if not path:
+            return
+        with open(path, "a") as f:
+            f.write(json.dumps({"kind": kind, "payload": payload}) + "\n")
+
+    def publish_low_state(self, low_state: LowState):
+        self._record(
+            "publish_low_state",
+            {
+                "q": list(low_state.motor.q),
+                "dq": list(low_state.motor.dq),
+                "ddq": list(low_state.motor.ddq),
+                "tau_est": list(low_state.motor.tau_est),
+                "quat": list(low_state.imu.quat),
+                "omega": list(low_state.imu.omega),
+                "accel": list(low_state.imu.accel),
+                "tick": low_state.tick,
+            },
+        )
+
+    def read_incoming_command(self) -> MotorCommand:
+        n = int(os.environ.get(_NUM_MOTOR_ENV, "1"))
+        cmd = MotorCommand(n)
+        # Deterministic, distinguishable-per-field values so the parent can assert exact plumbing.
+        cmd.tau_ff = [1.0] * n
+        cmd.kp = [2.0] * n
+        cmd.kd = [3.0] * n
+        cmd.q_target = [4.0] * n
+        cmd.dq_target = [5.0] * n
+        return cmd
+
+    def publish_wireless_controller(self, wc: WirelessController):
+        self._record(
+            "publish_wireless_controller",
+            {"lx": wc.lx, "ly": wc.ly, "rx": wc.rx, "ry": wc.ry, "keys": wc.keys},
+        )

--- a/src/holosoma/holosoma/bridge/unitree/tests/test_unitree_mp_bridge.py
+++ b/src/holosoma/holosoma/bridge/unitree/tests/test_unitree_mp_bridge.py
@@ -1,0 +1,191 @@
+"""Tests for the multiprocess Unitree bridge (``UnitreeMpSdk2Bridge``) — pure, no simulator, no DDS.
+
+Two concerns:
+  1. Import isolation — importing the bridge modules must NOT pull in the ``unitree_interface`` C++
+     binding (that is the whole point: keep CycloneDDS out of the rclpy process).
+  2. End-to-end plumbing — with an on-disk fake ``unitree_interface`` injected, spawn the real child,
+     round-trip publish_low_state / read_incoming_command / publish_wireless_controller, and confirm
+     the inherited torque computation runs against the proxied command.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+_FAKE = Path(__file__).parent / "_fake_unitree_interface.py"
+
+
+# ───────────────────────── 1. import isolation ──────────────────────────
+
+
+def test_importing_bridge_modules_does_not_load_unitree_interface():
+    """Neither the direct nor the MP bridge module may import the C++ binding at module-import time."""
+    guard = _ImportGuard("unitree_interface")
+    sys.meta_path.insert(0, guard)
+    try:
+        # Force a fresh import of both modules with the guard active.
+        for name in [
+            "holosoma.bridge.unitree.unitree_sdk2py_bridge",
+            "holosoma.bridge.unitree.unitree_sdk2py_bridge_mp",
+        ]:
+            sys.modules.pop(name, None)
+        import holosoma.bridge.unitree.unitree_sdk2py_bridge  # noqa: F401
+        import holosoma.bridge.unitree.unitree_sdk2py_bridge_mp as mp
+
+        assert not guard.tripped, "unitree_interface was imported at module-import time"
+        # The MP bridge is a UnitreeSdk2Bridge, so the inherited torque/PD logic is shared.
+        assert issubclass(mp.UnitreeMpSdk2Bridge, mp.UnitreeSdk2Bridge)
+    finally:
+        sys.meta_path.remove(guard)
+
+
+class _ImportGuard:
+    """Records any attempt to import ``forbidden`` (returns None so the real import machinery runs)."""
+
+    def __init__(self, forbidden: str):
+        self.forbidden = forbidden
+        self.tripped = False
+
+    def find_spec(self, name, path=None, target=None):
+        # Return None (implicitly) so the real import machinery still runs; just note the attempt.
+        if name == self.forbidden:
+            self.tripped = True
+
+
+# ───────────────────────── 3. end-to-end via spawned child ──────────────
+
+
+class _FakeSim:
+    """Minimal simulator exposing exactly what the bridge reads off ``self.simulator``."""
+
+    def __init__(self, num_motor: int, device="cpu"):
+        self.num_dof = num_motor
+        self.device = device
+        self._n = num_motor
+        self.dof_pos = torch.arange(num_motor, dtype=torch.float32).reshape(1, num_motor) * 0.1
+        self.dof_vel = torch.zeros(1, num_motor)
+        self.dof_acc = torch.zeros(1, num_motor)
+        # root state: pos(3) quat(3:7 = x,y,z,w = identity) lin(7:10) ang(10:13)
+        root = torch.zeros(1, 13)
+        root[0, 6] = 1.0  # w = 1 (identity quat)
+        self.robot_root_states = root
+        self.base_linear_acc = torch.zeros(1, 3)
+
+    def time(self):
+        return 1.5
+
+    def get_dof_forces(self, env_id):
+        return torch.full((self._n,), 7.0)
+
+
+def _robot_full_config(num_motor: int, robot_type="g1_29dof", sdk_type="unitree_mp"):
+    from holosoma.config_types.robot import RobotBridgeConfig
+
+    return SimpleNamespace(
+        dof_effort_limit_list=[100.0] * num_motor,
+        asset=SimpleNamespace(robot_type=robot_type),
+        bridge=RobotBridgeConfig(sdk_type=sdk_type),
+    )
+
+
+@pytest.fixture
+def fake_binding_on_path(tmp_path, monkeypatch):
+    """Install the fake as an importable ``unitree_interface`` for both the parent and the spawned child.
+
+    ``multiprocessing`` spawn forwards ``sys.path``, but PYTHONPATH is set too so the fresh child
+    interpreter resolves the fake regardless of platform. Returns the record-file path.
+    """
+    pkg_dir = tmp_path / "fake_pkg"
+    pkg_dir.mkdir()
+    shutil.copy(_FAKE, pkg_dir / "unitree_interface.py")
+    record = tmp_path / "record.jsonl"
+
+    import os
+
+    monkeypatch.syspath_prepend(str(pkg_dir))
+    # Prepend for the spawned child interpreter (spawn forwards sys.path too, but be explicit).
+    existing = os.environ.get("PYTHONPATH", "")
+    monkeypatch.setenv("PYTHONPATH", str(pkg_dir) + (os.pathsep + existing if existing else ""))
+    monkeypatch.setenv("FAKE_UNITREE_RECORD", str(record))
+    return record
+
+
+def _read_records(path: Path):
+    import json
+
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_mp_bridge_end_to_end(fake_binding_on_path, monkeypatch):
+    num_motor = 2
+    monkeypatch.setenv("FAKE_UNITREE_NUM_MOTOR", str(num_motor))
+    record = fake_binding_on_path
+
+    from holosoma.bridge.unitree.unitree_sdk2py_bridge_mp import LowCommand, UnitreeMpSdk2Bridge
+
+    sim = _FakeSim(num_motor)
+    robot_cfg = _robot_full_config(num_motor)
+    bridge_cfg = SimpleNamespace(interface="lo")
+
+    bridge = UnitreeMpSdk2Bridge(sim, robot_cfg, bridge_cfg)
+    try:
+        # Parent stand-ins are binding-free and truthy for compute_torques' guard.
+        assert isinstance(bridge.low_cmd, LowCommand)
+
+        # publish_low_state: parent computes fields from sim state, child records them.
+        bridge.publish_low_state()
+
+        # read incoming command from the child (canned deterministic values).
+        bridge.low_cmd_handler()
+        assert list(bridge.low_cmd.tau_ff) == [1.0] * num_motor
+        assert list(bridge.low_cmd.kp) == [2.0] * num_motor
+        assert list(bridge.low_cmd.q_target) == [4.0] * num_motor
+
+        # Inherited PD torque computation runs against the proxied command; result is clipped
+        # to the effort limits and returned as a numpy array of the right length.
+        torques = bridge.compute_torques()
+        assert isinstance(torques, np.ndarray)
+        assert torques.shape == (num_motor,)
+        # tau_ff(1) + kp(2)*(q_target(4) - q_actual) + kd(3)*(dq_target(5) - 0), all within +-100.
+        q_actual = sim.dof_pos[0].numpy()
+        expected = 1.0 + 2.0 * (4.0 - q_actual) + 3.0 * (5.0 - 0.0)
+        np.testing.assert_allclose(torques, np.clip(expected, -100.0, 100.0), rtol=1e-5)
+    finally:
+        bridge.close()
+
+    # The child recorded a construction with the mapped enums and one publish_low_state.
+    records = _read_records(record)
+    kinds = [r["kind"] for r in records]
+    assert "init" in kinds
+    init = next(r for r in records if r["kind"] == "init")
+    assert init["payload"]["robot_type"] == "G1"  # g1_29dof -> G1
+    assert init["payload"]["message_type"] == "HG"  # g1_29dof -> HG
+    assert init["payload"]["interface"] == "lo"
+
+    pub = next(r for r in records if r["kind"] == "publish_low_state")
+    # q shipped as sim dof_pos (0.0, 0.1); quat converted x,y,z,w -> w,x,y,z = identity (1,0,0,0).
+    np.testing.assert_allclose(pub["payload"]["q"], [0.0, 0.1], atol=1e-6)
+    assert pub["payload"]["quat"] == [1.0, 0.0, 0.0, 0.0]
+    assert pub["payload"]["tick"] == int(1.5 * 1e3)
+
+
+def test_mp_bridge_close_is_idempotent(fake_binding_on_path, monkeypatch):
+    monkeypatch.setenv("FAKE_UNITREE_NUM_MOTOR", "1")
+    from holosoma.bridge.unitree.unitree_sdk2py_bridge_mp import UnitreeMpSdk2Bridge
+
+    bridge = UnitreeMpSdk2Bridge(_FakeSim(1), _robot_full_config(1), SimpleNamespace(interface="lo"))
+    bridge.close()
+    bridge.close()  # must not raise
+    assert not bridge._proc.is_alive()

--- a/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge.py
+++ b/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge.py
@@ -1,12 +1,4 @@
 from loguru import logger
-from unitree_interface import (
-    LowState,
-    MessageType,
-    MotorCommand,
-    RobotType,
-    UnitreeInterface,
-    WirelessController,
-)
 
 from holosoma.bridge.base.basic_sdk2py_bridge import BasicSdk2Bridge
 
@@ -16,8 +8,25 @@ class UnitreeSdk2Bridge(BasicSdk2Bridge):
 
     SUPPORTED_ROBOT_TYPES = {"g1_29dof", "h1", "h1-2", "go2_12dof"}
 
+    # robot_type -> SDK enum member NAME (resolved to the real enum via getattr where the binding is
+    # imported). Kept as strings so the parent process can build them without importing the C++
+    # binding — the multiprocess subclass ships them to its child, which owns the CycloneDDS binding.
+    _ROBOT_TYPE_NAMES = {"g1_29dof": "G1", "h1": "H1", "h1-2": "H1_2", "go2_12dof": "GO2"}
+    # Message type (HG for humanoid robots with 35 motors, GO2 for others).
+    _MESSAGE_TYPE_NAMES = {"g1_29dof": "HG", "h1": "GO2", "h1-2": "HG", "go2_12dof": "GO2"}
+
     def _init_sdk_components(self):
         """Initialize Unitree SDK-specific components."""
+        # Imported here (not at module top level) so importing this module never loads the C++
+        # binding's bundled CycloneDDS — the multiprocess subclass keeps the parent binding-free.
+        from unitree_interface import (
+            LowState,
+            MessageType,
+            MotorCommand,
+            RobotType,
+            UnitreeInterface,
+            WirelessController,
+        )
 
         robot_type = self.robot.asset.robot_type
 
@@ -25,24 +34,8 @@ class UnitreeSdk2Bridge(BasicSdk2Bridge):
         if robot_type not in self.SUPPORTED_ROBOT_TYPES:
             raise ValueError(f"Invalid robot type '{robot_type}'. Unitree SDK supports: {self.SUPPORTED_ROBOT_TYPES}")
 
-        # Map robot type to SDK enum
-        robot_type_map = {
-            "g1_29dof": RobotType.G1,
-            "h1": RobotType.H1,
-            "h1-2": RobotType.H1_2,
-            "go2_12dof": RobotType.GO2,
-        }
-
-        # Map to message type (HG for humanoid robots with 35 motors, GO2 for others)
-        message_type_map = {
-            "g1_29dof": MessageType.HG,
-            "h1": MessageType.GO2,
-            "h1-2": MessageType.HG,
-            "go2_12dof": MessageType.GO2,
-        }
-
-        sdk_robot_type = robot_type_map[robot_type]
-        sdk_message_type = message_type_map[robot_type]
+        sdk_robot_type = getattr(RobotType, self._ROBOT_TYPE_NAMES[robot_type])
+        sdk_message_type = getattr(MessageType, self._MESSAGE_TYPE_NAMES[robot_type])
 
         # Get network interface from config
         interface_name = self.bridge_config.interface or "eth0"

--- a/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge_mp.py
+++ b/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge_mp.py
@@ -1,0 +1,292 @@
+"""Multiprocess Unitree bridge.
+
+Runs the CycloneDDS-touching half of :class:`UnitreeSdk2Bridge` in a spawned child process so the
+``unitree_interface`` C++ binding never shares an address space with the simulator's in-process
+``rclpy`` (ROS2 sensor egress). Both bundle CycloneDDS; loading them into one process heap-corrupts
+at SDK init ("free(): invalid pointer"). This mirrors the inference side's
+``holosoma_inference.sdk.unitree.unitree_interface_mp`` — same spawn/RPC/teardown pattern.
+
+Unlike the inference proxy (which runs its *entire* self-contained interface in the child), this
+bridge is coupled to live simulator torch/GPU state and writes PD torques back into the sim, so that
+half MUST stay in the parent. Only the four DDS operations move to the child:
+
+    * constructing ``UnitreeInterface`` (opens CycloneDDS),
+    * ``publish_low_state``       (parent computes the fields from sim state, ships plain lists),
+    * ``read_incoming_command``   (child polls DDS, ships a picklable command back),
+    * ``publish_wireless_controller`` (parent reads the joystick, ships the axes/keys).
+
+``compute_torques`` and every ``_get_*`` simulator read stay inherited from :class:`UnitreeSdk2Bridge`
+unchanged: the parent-side ``self.low_cmd`` is a picklable :class:`LowCommand` carrying exactly the
+attributes ``compute_torques`` reads (``tau_ff``/``kp``/``kd``/``q_target``/``dq_target``).
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import queue
+from types import SimpleNamespace
+from typing import Any, NamedTuple
+
+from loguru import logger
+
+from holosoma.bridge.unitree.unitree_sdk2py_bridge import UnitreeSdk2Bridge
+
+# Seconds to wait for the child to construct the binding (DDS init) before declaring it dead.
+_STARTUP_TIMEOUT_S = 30.0
+# Poll interval for a per-RPC liveness check — an RPC that outlives this and whose child has died is
+# turned into a raised error instead of a silent, permanent block of the simulator step thread.
+_RPC_POLL_S = 1.0
+
+
+class LowCommand(NamedTuple):
+    """Picklable stand-in for the C++ low-level command returned by ``read_incoming_command``.
+
+    Carries exactly the attributes :meth:`UnitreeSdk2Bridge.compute_torques` reads, so the inherited
+    torque computation runs against it in the parent unchanged.
+    """
+
+    tau_ff: list[float]
+    kp: list[float]
+    kd: list[float]
+    q_target: list[float]
+    dq_target: list[float]
+
+
+# Sentinel that tells the worker to shut down.
+_STOP = None
+
+
+# ── child process ──────────────────────────────────────────────────────
+
+
+def _worker(
+    interface_name: str,
+    robot_type_name: str,
+    message_type_name: str,
+    num_motor: int,
+    req_q: mp.Queue,
+    res_q: mp.Queue,
+):
+    """Event loop that owns the real ``unitree_interface`` binding (and its CycloneDDS)."""
+    import ctypes
+    import importlib.util
+    import os
+    from pathlib import Path
+
+    # Preload unitree's bundled CycloneDDS before import so ROS2's version is not picked up via
+    # LD_LIBRARY_PATH (identical to the inference-side proxy).
+    spec = importlib.util.find_spec("unitree_interface")
+    if spec and spec.submodule_search_locations:
+        ui_dir = Path(spec.submodule_search_locations[0])
+        for lib in ["libddsc.so.0", "libddscxx.so.0"]:
+            lib_path = ui_dir / lib
+            if lib_path.exists():
+                ctypes.CDLL(str(lib_path), mode=ctypes.RTLD_GLOBAL)
+
+    # Construct the binding (opens CycloneDDS) BEFORE signalling readiness, so a DDS init failure is
+    # reported to the parent as an error instead of leaving it to block on the first RPC forever.
+    try:
+        from unitree_interface import LowState, MessageType, RobotType, UnitreeInterface, WirelessController
+
+        interface = UnitreeInterface(
+            interface_name,
+            getattr(RobotType, robot_type_name),
+            getattr(MessageType, message_type_name),
+        )
+        # The child owns only the C++ objects the DDS calls need: a reusable LowState the parent fills
+        # each publish, and a WirelessController for joystick publishing. The incoming command lives in
+        # the parent (as a picklable LowCommand), so no MotorCommand is held here.
+        low_state = LowState(num_motor)
+        wireless_controller = WirelessController()
+    except Exception as exc:
+        res_q.put(("err", exc))
+        os._exit(0)
+    res_q.put(("ready", None))
+
+    try:
+        while True:
+            msg = req_q.get()
+            if msg is _STOP:
+                break
+
+            method, args, kwargs = msg
+            try:
+                if method == "publish_low_state":
+                    q, dq, ddq, tau_est, quat, omega, accel, tick = args
+                    low_state.motor.q = q
+                    low_state.motor.dq = dq
+                    low_state.motor.ddq = ddq
+                    low_state.motor.tau_est = tau_est
+                    low_state.imu.quat = quat
+                    low_state.imu.omega = omega
+                    low_state.imu.accel = accel
+                    low_state.tick = tick
+                    interface.publish_low_state(low_state)  # CRC calculated in C++
+                    res_q.put(("ok", None))
+                elif method == "read_incoming_command":
+                    cmd = interface.read_incoming_command()
+                    res_q.put(
+                        (
+                            "ok",
+                            LowCommand(
+                                tau_ff=list(cmd.tau_ff),
+                                kp=list(cmd.kp),
+                                kd=list(cmd.kd),
+                                q_target=list(cmd.q_target),
+                                dq_target=list(cmd.dq_target),
+                            ),
+                        )
+                    )
+                elif method == "publish_wireless_controller":
+                    lx, ly, rx, ry, keys = args
+                    wireless_controller.lx = lx
+                    wireless_controller.ly = ly
+                    wireless_controller.rx = rx
+                    wireless_controller.ry = ry
+                    wireless_controller.keys = keys
+                    interface.publish_wireless_controller(wireless_controller)
+                    res_q.put(("ok", None))
+                else:
+                    res_q.put(("err", ValueError(f"Unknown method '{method}'")))
+            except Exception as exc:
+                res_q.put(("err", exc))
+    finally:
+        # Drop the binding ref before the worker returns so its destructor runs while the DDS event
+        # loop is still alive, then bypass Python's atexit chain — lingering C++ teardown otherwise
+        # surfaces as misleading `Process SpawnProcess-1:` stderr noise (mirrors the inference proxy).
+        del interface
+        os._exit(0)
+
+
+# ── parent-side bridge ───────────────────────────────────────────────────
+
+
+class UnitreeMpSdk2Bridge(UnitreeSdk2Bridge):
+    """Unitree bridge that runs the ``unitree_interface`` binding in a spawned child process.
+
+    Drop-in for :class:`UnitreeSdk2Bridge` (same ``holosoma.bridge`` factory + ``compute_torques``);
+    isolates CycloneDDS from the rest of the process. Select it via ``sdk_type="unitree_mp"`` when the
+    simulator process also loads rclpy (a ROS2 sensor egress) — the two CycloneDDS runtimes cannot
+    coexist in one process.
+    """
+
+    def _init_sdk_components(self):
+        """Spawn the DDS child; keep only picklable, binding-free stand-ins in the parent."""
+        robot_type = self.robot.asset.robot_type
+        if robot_type not in self.SUPPORTED_ROBOT_TYPES:
+            raise ValueError(f"Invalid robot type '{robot_type}'. Unitree SDK supports: {self.SUPPORTED_ROBOT_TYPES}")
+
+        interface_name = self.bridge_config.interface or "eth0"
+
+        ctx = mp.get_context("spawn")
+        self._req_q = ctx.Queue()
+        self._res_q = ctx.Queue()
+        self._proc = ctx.Process(
+            target=_worker,
+            args=(
+                interface_name,
+                self._ROBOT_TYPE_NAMES[robot_type],
+                self._MESSAGE_TYPE_NAMES[robot_type],
+                self.num_motor,
+                self._req_q,
+                self._res_q,
+            ),
+            daemon=True,
+        )
+        self._proc.start()
+
+        # Block until the child has constructed the binding (or failed), so a DDS init error raises
+        # here — like the in-process bridge's synchronous construction — instead of hanging a later
+        # step. (Mirrors the high-level MPClientProxy's readiness handshake.)
+        try:
+            tag, payload = self._res_q.get(timeout=_STARTUP_TIMEOUT_S)
+        except queue.Empty:
+            self.close()
+            raise RuntimeError("Unitree MP bridge: child process did not start within timeout") from None
+        if tag == "err":
+            self.close()
+            raise payload
+
+        # Parent-side stand-ins (never the C++ objects): a zero command truthy for compute_torques'
+        # guard, and a mutable wireless-controller the base joystick code writes its axes/keys onto.
+        zeros = [0.0] * self.num_motor
+        self.low_cmd = LowCommand(tau_ff=zeros, kp=zeros, kd=zeros, q_target=zeros, dq_target=zeros)
+        self.wireless_controller = SimpleNamespace(lx=0.0, ly=0.0, rx=0.0, ry=0.0, keys=0)
+
+    # ── RPC helper ─────────────────────────────────────────────────────
+
+    def _call(self, method: str, *args: Any) -> Any:
+        """Send one request and block for its reply. Raises if the child has died (never hangs).
+
+        Without the liveness check a child that crashed at the C level (segfault, or the very
+        heap-corruption this module isolates) — which never sends a reply — would block the simulator
+        step thread forever. Poll instead, and convert a dead child into a raised error.
+        """
+        self._req_q.put((method, args, {}))
+        while True:
+            try:
+                tag, payload = self._res_q.get(timeout=_RPC_POLL_S)
+                break
+            except queue.Empty:
+                if not self._proc.is_alive():
+                    raise RuntimeError(f"Unitree MP bridge: child died during '{method}'") from None
+        if tag == "err":
+            raise payload
+        return payload
+
+    # ── overridden DDS operations (everything else inherited) ──────────
+
+    def low_cmd_handler(self, msg=None):
+        """Poll the child for the latest incoming command; store its picklable carrier."""
+        self.low_cmd = self._call("read_incoming_command")
+
+    def publish_low_state(self):
+        """Compute the state fields from sim state (parent), ship them to the child to publish."""
+        positions, velocities, accelerations = self._get_dof_states()
+        actuator_forces = self._get_actuator_forces()
+        quaternion, gyro, acceleration = self._get_base_imu_data()
+
+        # _get_base_imu_data already returns the quaternion in SDK order [w, x, y, z]; just floatify
+        # it into a plain list (same as the direct bridge does before assigning imu.quat).
+        quat_array = quaternion.detach().cpu().numpy()
+        quat = [float(quat_array[0]), float(quat_array[1]), float(quat_array[2]), float(quat_array[3])]
+
+        self._call(
+            "publish_low_state",
+            positions.tolist(),
+            velocities.tolist(),
+            accelerations.tolist(),
+            actuator_forces.tolist(),
+            quat,
+            gyro.detach().cpu().numpy().tolist(),
+            acceleration.detach().cpu().numpy().tolist(),
+            int(self.sim_time * 1e3),
+        )
+
+    def publish_wireless_controller(self):
+        """Populate the parent stand-in from the joystick (base class), ship it to the child."""
+        # Skip UnitreeSdk2Bridge (it touches self.interface, which lives in the child) and reach
+        # BasicSdk2Bridge, which reads pygame and writes lx/ly/rx/ry/keys onto self.wireless_controller.
+        super(UnitreeSdk2Bridge, self).publish_wireless_controller()
+
+        if self.joystick is not None:
+            wc = self.wireless_controller
+            self._call("publish_wireless_controller", wc.lx, wc.ly, wc.rx, wc.ry, wc.keys)
+
+    # ── lifecycle ──────────────────────────────────────────────────────
+
+    def close(self):
+        """Stop the child process (idempotent)."""
+        if not hasattr(self, "_proc"):
+            return
+        if self._proc.is_alive():
+            self._req_q.put(_STOP)
+            self._proc.join(timeout=5)
+            if self._proc.is_alive():
+                self._proc.kill()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception as exc:  # never raise from GC
+            logger.debug(f"UnitreeMpSdk2Bridge teardown ignored error: {exc}")

--- a/src/holosoma/holosoma/config_types/env.py
+++ b/src/holosoma/holosoma/config_types/env.py
@@ -13,6 +13,7 @@ from holosoma.config_types.randomization import RandomizationManagerCfg
 from holosoma.config_types.reward import RewardManagerCfg
 from holosoma.config_types.robot import RobotConfig
 from holosoma.config_types.scene import SceneConfig
+from holosoma.config_types.sensor import CameraSensorConfig, validate_camera_dict
 from holosoma.config_types.simulator import SimulatorConfig
 from holosoma.config_types.termination import TerminationManagerCfg
 from holosoma.config_types.terrain import TerrainManagerCfg
@@ -26,6 +27,7 @@ class EnvConfig:
 
     simulator: SimulatorConfig
     scene: SceneConfig
+    sensors: dict[str, CameraSensorConfig]
     terrain: TerrainManagerCfg
     observation: ObservationManagerCfg | None
     action: ActionManagerCfg | None
@@ -38,8 +40,8 @@ class EnvConfig:
     training: TrainingConfig
     logger: LoggerConfig
     plugin: dict[str, PluginConfig]
-    """Plugins to install on the simulator (key -> resolved PluginConfig). Threaded into
-    FullSimConfig; installed in ``BaseSimulator.__init__``."""
+    """Plugins to install on the simulator (key -> resolved PluginConfig), including the
+    ROS2/viz/video egress sinks. Threaded into FullSimConfig; installed in ``BaseSimulator.__init__``."""
 
 
 def get_tyro_env_config(tyro_config: ExperimentConfig) -> EnvConfig:
@@ -55,11 +57,16 @@ def get_tyro_env_config(tyro_config: ExperimentConfig) -> EnvConfig:
     EnvConfig
         Environment configuration with extracted fields.
     """
+    # Cross-camera validation (Warp render-flag agreement) across the assembled camera dict.
+    validate_camera_dict(tyro_config.sensor)
     return EnvConfig(
         env_class=tyro_config.env_class,
         training=tyro_config.training,
         simulator=tyro_config.simulator,
         scene=tyro_config.scene,
+        # The CLI declares cameras per-key in the dynamic ``sensor`` dict (key = sensor name).
+        sensors=dict(tyro_config.sensor),
+        plugin=dict(tyro_config.plugin),
         terrain=tyro_config.terrain,
         observation=tyro_config.observation,
         action=tyro_config.action,
@@ -70,5 +77,4 @@ def get_tyro_env_config(tyro_config: ExperimentConfig) -> EnvConfig:
         curriculum=tyro_config.curriculum,
         robot=tyro_config.robot,
         logger=tyro_config.logger,
-        plugin=dict(tyro_config.plugin),
     )

--- a/src/holosoma/holosoma/config_types/experiment.py
+++ b/src/holosoma/holosoma/config_types/experiment.py
@@ -20,6 +20,7 @@ import holosoma.config_values.randomization
 import holosoma.config_values.reward
 import holosoma.config_values.robot
 import holosoma.config_values.scene
+import holosoma.config_values.sensor
 import holosoma.config_values.simulator
 import holosoma.config_values.termination
 import holosoma.config_values.terrain
@@ -34,6 +35,7 @@ from holosoma.config_types.randomization import RandomizationManagerCfg
 from holosoma.config_types.reward import RewardManagerCfg
 from holosoma.config_types.robot import RobotConfig
 from holosoma.config_types.scene import SceneConfig
+from holosoma.config_types.sensor import CameraSensorConfig
 from holosoma.config_types.simulator import SimulatorConfig
 from holosoma.config_types.termination import TerminationManagerCfg
 from holosoma.config_types.terrain import TerrainManagerCfg
@@ -121,9 +123,15 @@ class ExperimentConfig:
     scene: Annotated[SceneConfig, UseRegistry(holosoma.config_values.scene.SCENE_REGISTRY)] = (
         holosoma.config_values.scene.empty
     )
+    # Mounted cameras, declared per-key on the CLI as ``--sensor.<name>:<variant>`` (resolved from
+    # CAMERA_REGISTRY), optionally with per-key field overrides (e.g. ``--sensor.<name>.width 224``).
+    # The dict key becomes the sensor name. Empty by default (no cameras).
+    sensor: dict[str, Annotated[CameraSensorConfig, UseRegistry(holosoma.config_values.sensor.CAMERA_REGISTRY)]] = (
+        dataclasses.field(default_factory=dict)
+    )
     # Plugins, declared per-key as ``plugin.<key>:<variant>`` (resolved from PLUGIN_REGISTRY),
-    # optionally with per-key field overrides. Installed in ``BaseSimulator.__init__``. Threaded into
-    # FullSimConfig so plugins work in the training path (run_sim already exposes the same field).
+    # optionally with per-key field overrides. Includes the camera-frame egress sinks (ROS2 publish,
+    # viz window, video record) and any custom plugin. Installed in ``BaseSimulator.__init__``.
     plugin: dict[str, Annotated[PluginConfig, UseRegistry(holosoma.config_values.plugin.PLUGIN_REGISTRY)]] = (
         dataclasses.field(default_factory=dict)
     )

--- a/src/holosoma/holosoma/config_types/full_sim.py
+++ b/src/holosoma/holosoma/config_types/full_sim.py
@@ -9,6 +9,7 @@ from holosoma.config_types.logger import LoggerConfig
 from holosoma.config_types.plugin import PluginConfig
 from holosoma.config_types.robot import RobotConfig
 from holosoma.config_types.scene import SceneConfig
+from holosoma.config_types.sensor import CameraSensorConfig
 from holosoma.config_types.simulator import SimulatorInitConfig
 
 
@@ -27,7 +28,11 @@ class FullSimConfig:
 
     plugin: dict[str, PluginConfig] = field(default_factory=dict)
     """Plugins (key -> config). Each is instantiated against the live simulator in
-    ``BaseSimulator.__init__`` via ``cfg.get_cls()(cfg, self)``."""
+    ``BaseSimulator.__init__`` via ``cfg.get_cls()(cfg, self)``. Frame consumers (ROS2 egress, viz,
+    video) are plugins too — selected here, not in ``sensors``."""
+
+    sensors: dict[str, CameraSensorConfig] = field(default_factory=dict)
+    """Mounted cameras, keyed by sensor name (the ``get_camera_data`` key). Empty (default) = none."""
 
     experiment_dir: str | None = None
     """Experiment directory path (computed from logger config in base_task)."""

--- a/src/holosoma/holosoma/config_types/observation.py
+++ b/src/holosoma/holosoma/config_types/observation.py
@@ -54,4 +54,4 @@ class ObservationManagerCfg:
     """Mapping of group name to its configuration."""
 
     clip_observations: float = 100.0
-    """Global observation clipping threshold (applied to all observations)."""
+    """Global observation clipping threshold (applied to all non-image observations)."""

--- a/src/holosoma/holosoma/config_types/plugin.py
+++ b/src/holosoma/holosoma/config_types/plugin.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import Any, Callable
+from dataclasses import field as dc_field
+from typing import Any, Callable, Literal
+
+from pydantic import ConfigDict, model_validator
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from holosoma.config_types.frequency import DecimationLike, validate_decimation_like
 
@@ -162,3 +166,220 @@ class ROS2OdometryPluginConfig(PluginConfig):
         from holosoma.simulator.shared.ros2_plugins import ROS2OdometryPlugin
 
         return ROS2OdometryPlugin
+
+
+# ----------------------------------------------------------------------------------------------- #
+# Camera-frame egress plugins
+#
+# These plugins consume the sim's rendered camera frames and push them to a sink: ROS2 topics, a
+# live cv2 window, or an mp4. Each is a ``PluginConfig`` selected as ``plugin.<key>:<variant>`` just
+# like the plugins above; ``get_cls`` returns a
+# :class:`~holosoma.simulator.plugins.camera_consumer.CameraConsumerPlugin` subclass, imported lazily
+# so the transport dependency (rclpy, cv2, …) loads only when the sink is selected. A consumer reads
+# the raw rendered buffer from ``BaseSimulator.get_camera_data`` (rgb ``uint8`` R,G,B; depth
+# ``float32`` meters), passing ``device="cpu"`` so the first reader per (camera, modality) pays the
+# one device->host copy and the rest share it.
+# ----------------------------------------------------------------------------------------------- #
+
+# Reject unknown fields on every egress config.
+_FORBID_EXTRA = ConfigDict(extra="forbid")
+
+# Depth colormap names accepted by the viz plugin (mapped to cv2.COLORMAP_* there).
+_DEPTH_COLORMAPS = ("inferno", "turbo", "viridis", "magma", "jet", "gray")
+
+# Modalities an egress route can carry.
+EgressModality = Literal["rgb", "depth"]
+
+# Wire encodings a ROS2 image route may request:
+#   - "rgb8"  : raw sensor_msgs/Image, R,G,B (no BGR swap; that is a cv2/JPEG artifact only).
+#   - "jpeg"  : sensor_msgs/CompressedImage, lossy (teleop/viz, not depth or training datasets).
+#   - "png"   : sensor_msgs/CompressedImage, lossless RGB.
+#   - "32FC1" : raw sensor_msgs/Image depth, float32 meters (matches get_camera_data).
+#   - "16UC1" : raw sensor_msgs/Image depth, uint16 millimeters.
+#
+# A ``depth`` route MAY pick an rgb format (rgb8/jpeg/png): the depth map is then COLORIZED to RGB
+# (same colormap the viz plugin uses) before encoding, for a human-viewable stream. A ``depth`` route
+# with a depth format (32FC1/16UC1) publishes the raw metric depth. An ``rgb`` route may only use an
+# rgb format (there is nothing to colorize).
+ROS2ImageFormat = Literal["rgb8", "jpeg", "png", "32FC1", "16UC1"]
+_RGB_FORMATS = ("rgb8", "jpeg", "png")
+_DEPTH_FORMATS = ("32FC1", "16UC1")
+
+
+@pydantic_dataclass(frozen=True, config=_FORBID_EXTRA)
+class ROS2ImageRoute:
+    """One camera-stream to ROS2-topic mapping within a :class:`ROS2ImagePluginConfig`."""
+
+    camera: str
+    """Camera name; must match a key in the active ``--sensor`` camera dict."""
+
+    topic: str
+    """ROS2 topic to publish on, used verbatim (no auto-suffixing). For a CompressedImage
+    (``jpeg``/``png``) the ROS convention is a ``/compressed`` suffix, e.g.
+    ``/sim_cameras/head/image/compressed``; spell it out here if you want it."""
+
+    modality: EgressModality = "rgb"
+    """Which rendered modality to publish; must be in the camera's ``data_types``."""
+
+    format: ROS2ImageFormat = "jpeg"
+    """Wire encoding (see :data:`ROS2ImageFormat`). An ``rgb`` route needs an rgb format; a ``depth``
+    route may pick a depth format (raw metric) OR an rgb format (colorized to RGB before encoding)."""
+
+    depth_colormap: str = "inferno"
+    """Colormap used when a ``depth`` route is colorized to RGB (rgb format): inferno (default),
+    turbo, viridis, magma, jet, or gray. Ignored for raw-depth and rgb routes."""
+
+    depth_range: list[float] | None = None
+    """Fixed ``[min_m, max_m]`` depth range (meters) for stable colorization of a colorized ``depth``
+    route; ``None`` means ``[0.01, 5.0]``. ``+inf`` (no hit) maps to the far end. Ignored otherwise."""
+
+    @model_validator(mode="after")
+    def validate_route(self) -> ROS2ImageRoute:
+        if not self.camera:
+            raise ValueError("ROS2ImageRoute.camera must be a non-empty camera name.")
+        if not self.topic:
+            raise ValueError(f"ROS2ImageRoute for camera '{self.camera}' needs a non-empty topic.")
+        rgb_fmt = self.format in _RGB_FORMATS
+        # rgb modality must use an rgb format. depth modality accepts either: a depth format (raw) or
+        # an rgb format (colorized to RGB before encoding) — so only rgb+depth-format is rejected.
+        if self.modality == "rgb" and not rgb_fmt:
+            raise ValueError(
+                f"ROS2ImageRoute camera '{self.camera}': modality 'rgb' needs an rgb format "
+                f"{_RGB_FORMATS}, got '{self.format}'."
+            )
+        # depth is colorized only when the format is an rgb one; the colormap/range knobs are used
+        # then. Validate the colormap and range regardless so a misconfig fails loud at construction.
+        if self.depth_colormap not in _DEPTH_COLORMAPS:
+            raise ValueError(
+                f"ROS2ImageRoute camera '{self.camera}': depth_colormap '{self.depth_colormap}' "
+                f"unknown; allowed: {sorted(_DEPTH_COLORMAPS)}."
+            )
+        if self.depth_range is not None and (len(self.depth_range) != 2 or self.depth_range[0] >= self.depth_range[1]):
+            raise ValueError(
+                f"ROS2ImageRoute camera '{self.camera}': depth_range must be [min_m, max_m] with "
+                f"min<max, got {self.depth_range}."
+            )
+        return self
+
+
+@pydantic_dataclass(frozen=True, config=_FORBID_EXTRA)
+class ROS2ImagePluginConfig(PluginConfig):
+    """One ROS2 image-publishing sink: a single node fanning out to the cameras in ``routes``."""
+
+    node_name: str = "sim_cameras"
+    """ROS2 node name created for this sink."""
+
+    qos: str = "best_effort"
+    """QoS profile: ``best_effort`` (default, matches ZED/sensor drivers) or ``reliable``."""
+
+    async_publish: bool = True
+    """True (default): snapshot on the sim thread, encode and publish on per-route worker threads
+    (drop-oldest under backpressure). False: encode and publish inline on the sim thread, lossless
+    and every-frame (dataset capture); the sim waits."""
+
+    queue_maxlen: int = 2
+    """Per-route bounded queue depth when ``async_publish``. Drop-oldest beyond this (latest wins):
+    1 keeps the freshest frame only, 2 gives one frame of jitter tolerance. Ignored when not async."""
+
+    publish_camera_info: bool = True
+    """Also publish a latched ``sensor_msgs/CameraInfo`` per camera (static K from intrinsics)."""
+
+    jpeg_quality: int = 50
+    """JPEG encode quality 1-100 for ``jpeg`` routes (ignored by other formats). Default 50."""
+
+    env_id: int = 0
+    """Which environment's view to publish. Default 0 (the single real-time robot); set higher to
+    stream a specific env of a vectorized run. One env per node; all routes share it."""
+
+    routes: dict[str, ROS2ImageRoute] = dc_field(default_factory=dict)
+    """Camera-to-topic routes this node publishes, keyed by an arbitrary label. The key is a
+    CLI handle only (like a list index was) — it does not affect publishing; the route's
+    ``camera``/``topic`` fields do."""
+
+    def get_cls(self) -> Callable[..., Any]:
+        # Deferred import: keeps rclpy out of CLI-build import.
+        from holosoma.simulator.plugins.ros2.ros2_image_plugin import ROS2ImagePlugin
+
+        return ROS2ImagePlugin
+
+    @model_validator(mode="after")
+    def validate_egress(self) -> ROS2ImagePluginConfig:
+        if self.qos not in ("best_effort", "reliable"):
+            raise ValueError(f"ROS2ImagePluginConfig.qos must be 'best_effort' or 'reliable', got '{self.qos}'.")
+        if self.queue_maxlen < 1:
+            raise ValueError(f"ROS2ImagePluginConfig.queue_maxlen must be >= 1, got {self.queue_maxlen}.")
+        if not 1 <= self.jpeg_quality <= 100:
+            raise ValueError(f"ROS2ImagePluginConfig.jpeg_quality must be in [1, 100], got {self.jpeg_quality}.")
+        if self.env_id < 0:
+            raise ValueError(f"ROS2ImagePluginConfig.env_id must be >= 0, got {self.env_id}.")
+        topics = [r.topic for r in self.routes.values()]
+        dupes = {t for t in topics if topics.count(t) > 1}
+        if dupes:
+            raise ValueError(f"ROS2ImagePluginConfig node '{self.node_name}' has duplicate topics: {sorted(dupes)}.")
+        return self
+
+
+@pydantic_dataclass(frozen=True, config=_FORBID_EXTRA)
+class CameraVizPluginConfig(PluginConfig):
+    """Local visualization plugin: tile mounted-camera views into a live cv2 window and/or an mp4.
+
+    Tiles all watched (camera, modality, env) panels into one grid per step. Inline only:
+    ``publish`` composes the grid and shows or buffers it on the calling thread.
+    """
+
+    live_window: bool = False
+    """Show a live ``cv2`` window of the camera view(s). Needs a display; ignored headless."""
+
+    record_video: bool = False
+    """Buffer frames and encode an mp4 (H.264) at stop."""
+
+    env_ids: list[int] = dc_field(default_factory=lambda: [0])
+    """Environments to visualize (default ``[0]``). Multiple env ids tile as a grid: one row per
+    env, one column per (camera, modality) panel."""
+
+    cameras: list[str] | None = None
+    """Camera names to show; ``None`` (default) means all configured cameras."""
+
+    modalities: list[EgressModality] | None = None
+    """Modalities to show; ``None`` (default) means every modality each selected camera produces."""
+
+    depth_range: list[float] | None = None
+    """Fixed ``[min_m, max_m]`` depth range (meters) for stable colorization; ``None`` means
+    ``[0.01, 5.0]``. ``+inf`` (no hit) maps to the far end."""
+
+    depth_colormap: str = "inferno"
+    """OpenCV colormap for depth: inferno (default), turbo, viridis, magma, jet, or gray."""
+
+    update_decimation: DecimationLike = 1
+    """Int visualizes every Nth rendered frame of the fastest watched camera; a frequency string
+    ("10Hz") is a target against the control rate, converted to a frame-decimation by the recorder."""
+
+    playback_rate: float = 1.0
+    """Video playback speed factor; 1.0 plays back at true wall-clock speed."""
+
+    save_dir: str | None = None
+    """Output directory for the video; ``None`` derives it from the experiment/video dir."""
+
+    def get_cls(self) -> Callable[..., Any]:
+        # Deferred import: keeps cv2/video utils out of CLI-build import.
+        from holosoma.simulator.plugins.viz.viz_plugin import CameraVizPlugin
+
+        return CameraVizPlugin
+
+    @model_validator(mode="after")
+    def validate_recorder(self) -> CameraVizPluginConfig:
+        validate_decimation_like(self.update_decimation, field="CameraVizPluginConfig.update_decimation")
+        if not self.env_ids:
+            raise ValueError("CameraVizPluginConfig.env_ids must be non-empty (default [0]).")
+        if any(e < 0 for e in self.env_ids):
+            raise ValueError(f"CameraVizPluginConfig.env_ids must all be >= 0, got {self.env_ids}.")
+        if self.depth_range is not None and (len(self.depth_range) != 2 or self.depth_range[0] >= self.depth_range[1]):
+            raise ValueError(
+                f"CameraVizPluginConfig.depth_range must be [min_m, max_m] with min<max, got {self.depth_range}."
+            )
+        if self.depth_colormap not in _DEPTH_COLORMAPS:
+            raise ValueError(
+                f"CameraVizPluginConfig.depth_colormap '{self.depth_colormap}' unknown; "
+                f"allowed: {sorted(_DEPTH_COLORMAPS)}."
+            )
+        return self

--- a/src/holosoma/holosoma/config_types/robot.py
+++ b/src/holosoma/holosoma/config_types/robot.py
@@ -16,7 +16,12 @@ class RobotBridgeConfig:
     """
 
     sdk_type: str = "unitree"
-    """SDK type for robot communication ('unitree', 'booster', 'ros2')."""
+    """SDK type for robot communication ('unitree', 'unitree_mp', 'booster', 'ros2').
+
+    'unitree_mp' runs the Unitree SDK's C++/CycloneDDS binding in a spawned child process so it never
+    shares the simulator's address space. Select it when this process also loads rclpy (a ROS2 sensor
+    egress): the Unitree SDK's bundled CycloneDDS heap-corrupts if it coexists with rclpy's CycloneDDS
+    in one process. Otherwise 'unitree' (in-process) is fine."""
 
     motor_type: str = "serial"
     """Motor communication type ('serial', etc.)."""

--- a/src/holosoma/holosoma/config_types/run_sim.py
+++ b/src/holosoma/holosoma/config_types/run_sim.py
@@ -16,12 +16,14 @@ import holosoma.config_values.plugin
 import holosoma.config_values.robot
 import holosoma.config_values.run_sim
 import holosoma.config_values.scene
+import holosoma.config_values.sensor
 import holosoma.config_values.terrain
 from holosoma.config_types.experiment import TrainingConfig
 from holosoma.config_types.logger import DisabledLoggerConfig, LoggerConfig
 from holosoma.config_types.plugin import PluginConfig
 from holosoma.config_types.robot import RobotConfig
 from holosoma.config_types.scene import SceneConfig
+from holosoma.config_types.sensor import CameraSensorConfig
 from holosoma.config_types.simulator import SimulatorConfig
 from holosoma.config_types.terrain import TerrainManagerCfg
 from holosoma.config_types.video import VideoConfig
@@ -73,6 +75,13 @@ class RunSimConfig:
     # instantiated against the live simulator in ``BaseSimulator.__init__``. Empty by default.
     plugin: dict[str, Annotated[PluginConfig, UseRegistry(holosoma.config_values.plugin.PLUGIN_REGISTRY)]] = field(
         default_factory=dict
+    )
+
+    # Mounted cameras, declared per-key on the CLI as ``--sensor.<name>:<variant>`` (resolved from
+    # CAMERA_REGISTRY), optionally with per-key field overrides (e.g. ``--sensor.<name>.width 224``).
+    # The dict key becomes the sensor name. Empty by default (no cameras).
+    sensor: dict[str, Annotated[CameraSensorConfig, UseRegistry(holosoma.config_values.sensor.CAMERA_REGISTRY)]] = (
+        field(default_factory=dict)
     )
 
     # Minimal configs needed for FullSimConfig

--- a/src/holosoma/holosoma/config_types/sensor.py
+++ b/src/holosoma/holosoma/config_types/sensor.py
@@ -1,0 +1,292 @@
+"""Sensor configuration types.
+
+A sensor is a read-only producer mounted onto an existing body (a robot link or a
+spawned scene actor) that it follows.
+
+The camera optical frame is ``-Z`` forward, ``+Y`` up (OpenGL/USD/MuJoCo-native). Each
+backend converts this convention to its native basis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import field
+from typing import Literal, cast, get_args
+
+from pydantic import ConfigDict, model_validator
+from pydantic.dataclasses import dataclass
+
+from holosoma.config_types.frequency import DecimationLike, validate_decimation_like
+
+# Reject unknown fields on every sensor config (a typo'd field fails at construction).
+_FORBID_EXTRA = ConfigDict(extra="forbid")
+
+# Camera data types. "rgb" and "depth" are implemented.
+CameraDataType = Literal["rgb", "depth"]
+CAMERA_DATA_TYPES = cast("tuple[CameraDataType, ...]", get_args(CameraDataType))
+
+# Depth-clipping behavior for a depth camera: what the sensor reports for rays that hit nothing
+# within the far plane (IsaacSim's ``distance_to_image_plane`` is ``+inf`` there). These are the
+# exact values of IsaacLab's ``TiledCameraCfg.depth_clipping_behavior`` — passed through natively:
+#   - "none"  : keep ``+inf`` for no-hit (raw sensor output; consumers must handle non-finite).
+#   - "max"   : clip ``+inf`` (and anything beyond ``far``) to the ``far`` clip distance in meters.
+#   - "zero"  : set no-hit to ``0.0`` (the ROS ``16UC1``/OpenNI no-return convention).
+DepthClippingBehavior = Literal["none", "max", "zero"]
+
+# Which body a sensor mounts on:
+#   - "robot_link" resolves through the robot-only body index (find_rigid_body_indice).
+#   - "actor" resolves a spawned scene/individual actor through the ObjectRegistry.
+#   - "world" is a free-floating camera fixed in each env's frame (no body to follow); ``target``
+#     is unused. position/orientation are the pose in the per-env frame (env origin + offset), so
+#     every env gets its own fixed camera at the same relative spot. Useful for logging/overview.
+MountKind = Literal["robot_link", "actor", "world"]
+
+# Pixel memory layout of a transformed image. ``get_camera_data`` returns HWC
+# (row-major, channel-last); "CHW" emits channel-first for torch vision policies.
+ImageLayout = Literal["HWC", "CHW"]
+
+# Output dtype/range of a transformed image:
+#   - "native"     : passthrough, no scaling (rgb uint8 [0,255]; depth float32 meters).
+#   - "float01"    : float32 in [0,1]  (rgb /255; depth normalized via depth_range).
+#   - "float_pm1"  : float32 in [-1,1] (rgb /127.5-1; depth normalized then mapped to [-1,1]).
+ImageScale = Literal["native", "float01", "float_pm1"]
+
+
+@dataclass(frozen=True, config=_FORBID_EXTRA)
+class ImageTransformConfig:
+    """Transform applied to a camera obs term's frame, for visual policies.
+
+    Applied after the ``get_camera_data`` read by ``apply_image_transform``, in a fixed order
+    (resize, scale, layout, flatten). All defaults are no-ops, leaving the ``[N, H, W, C]`` frame
+    untouched.
+    """
+
+    resize: list[int] | None = None
+    """Target ``[H, W]`` in pixels; ``None`` keeps the native resolution. RGB uses bilinear,
+    depth uses nearest."""
+
+    layout: ImageLayout = "HWC"
+    """Axis order of the (un-flattened) output (see :data:`ImageLayout`). Defaults to HWC.
+    ``CHW`` for torch vision policies; also the serialization order when ``flatten``."""
+
+    scale: ImageScale = "native"
+    """Output dtype/range (see :data:`ImageScale`). Defaults to passthrough (rgb uint8,
+    depth float32 meters)."""
+
+    flatten: bool = False
+    """Flatten the per-env image to a 1-D ``[N, C*H*W]`` vector (consumed by ``CNNWrapper`` via
+    ``view(N, C, H, W)``). Requires ``layout="CHW"`` to match that reshape; ``False`` keeps the
+    4-D image."""
+
+    depth_range: list[float] | None = None
+    """For depth under a float ``scale``: ``[min_m, max_m]`` mapped to the output range (``+inf``
+    no-hit maps to the far end). Required when scaling depth to float; ignored for rgb and ``native``."""
+
+    @model_validator(mode="after")
+    def validate_transform(self) -> ImageTransformConfig:
+        if self.resize is not None and (len(self.resize) != 2 or self.resize[0] <= 0 or self.resize[1] <= 0):
+            raise ValueError(f"ImageTransformConfig.resize must be positive [H, W], got {self.resize}.")
+        if self.flatten and self.layout != "CHW":
+            raise ValueError(
+                f"ImageTransformConfig.flatten requires layout='CHW' (the order CNNWrapper reshapes "
+                f"back via view(N, C, H, W)); got layout='{self.layout}'."
+            )
+        if self.depth_range is not None and (len(self.depth_range) != 2 or self.depth_range[0] >= self.depth_range[1]):
+            raise ValueError(
+                f"ImageTransformConfig.depth_range must be [min_m, max_m] with min<max, got {self.depth_range}."
+            )
+        return self
+
+
+@dataclass(frozen=True, config=_FORBID_EXTRA)
+class IsaacSimCameraConfig:
+    """IsaacSim-only camera knobs (USD ``PinholeCameraCfg``) beyond the agnostic core.
+
+    All ``None`` (default) derive from the core fields.
+    """
+
+    focal_length: float | None = None
+    """Lens focal length in USD units (the aperture pair is derived from it to hit ``vertical_fov``).
+    ``None`` means 24.0."""
+
+    f_stop: float | None = None
+    """Aperture f-stop. ``0.0`` (default when None) is pinhole / no depth-of-field; ``>0`` enables
+    defocus blur (IsaacSim-only)."""
+
+    focus_distance: float | None = None
+    """Focus distance in meters (only meaningful when ``f_stop`` > 0). ``None`` keeps the default."""
+
+    depth_clipping_behavior: DepthClippingBehavior = "none"
+    """For a depth camera, what the TiledCamera reports where a ray hits nothing within ``far``
+    (``distance_to_image_plane`` is ``+inf`` there). Passed through to IsaacLab's
+    ``TiledCameraCfg.depth_clipping_behavior``: ``"none"`` (default) keeps the raw ``+inf``;
+    ``"max"`` clips no-hit and anything beyond ``far`` to the ``far`` distance; ``"zero"`` maps
+    no-hit to ``0.0``. Only affects the ``depth`` modality on IsaacSim."""
+
+
+@dataclass(frozen=True, config=_FORBID_EXTRA)
+class IsaacGymCameraConfig:
+    """IsaacGym-only camera knobs (``gymapi.CameraProperties``) beyond the agnostic core."""
+
+    supersampling_horizontal: int | None = None
+    """Horizontal supersampling factor (anti-aliasing); ``None`` keeps IsaacGym's default (1)."""
+
+    supersampling_vertical: int | None = None
+    """Vertical supersampling factor (anti-aliasing); ``None`` keeps IsaacGym's default (1)."""
+
+    use_collision_geometry: bool | None = None
+    """Render collision geometry instead of visual meshes; ``None`` keeps the default (False)."""
+
+
+@dataclass(frozen=True, config=_FORBID_EXTRA)
+class MujocoCameraConfig:
+    """MuJoCo-only camera knobs (``<camera>`` + Warp render context) beyond the agnostic core.
+
+    The three appearance flags below are global to the Warp render context, not per-camera; cameras
+    that set a given flag must agree (validated in :func:`validate_camera_dict`).
+    ``None`` is unset (renderer default)."""
+
+    use_shadows: bool | None = None
+    """(Warp, global) Render shadows; ``None`` keeps the renderer default (off). Ignored by classic."""
+
+    use_textures: bool | None = None
+    """(Warp, global) Apply textures; ``None`` keeps the renderer default (on). Ignored by classic."""
+
+    use_precomputed_rays: bool | None = None
+    """(Warp, global) Precompute camera rays; set ``False`` to allow per-step intrinsics
+    domain-randomization. ``None`` keeps the renderer default (True). Ignored by classic."""
+
+
+@dataclass(frozen=True, config=_FORBID_EXTRA)
+class SensorMountConfig:
+    """Where a sensor is mounted and its fixed offset (on that body, or in the per-env frame)."""
+
+    target_kind: MountKind = "robot_link"
+    """Which namespace ``target`` is resolved in (see :data:`MountKind`)."""
+
+    target: str = ""
+    """Body/actor name. Required and non-empty for ``robot_link`` (a robot link name; use the root
+    link, e.g. ``"pelvis"``, to mount on the base) and ``actor`` (an ObjectRegistry actor name).
+    Must be empty for ``world`` (a free-floating camera anchors to no body)."""
+
+    position: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
+    """Offset position ``[x, y, z]`` in meters. In the mount-body frame for ``robot_link``/``actor``;
+    in the per-env frame (env origin + offset) for ``world``. Defaults to origin."""
+
+    orientation: list[float] = field(default_factory=lambda: [1.0, 0.0, 0.0, 0.0])  # [w,x,y,z]
+    """Offset orientation quaternion ``[w, x, y, z]`` (w-first). In the mount-body frame for
+    ``robot_link``/``actor``; in the per-env frame for ``world``. Identity means the camera optical
+    axis is ``-Z`` forward / ``+Y`` up."""
+
+    @model_validator(mode="after")
+    def validate_mount(self) -> SensorMountConfig:
+        """``position``/``orientation`` arity, and the target/kind contract."""
+        if len(self.position) != 3:
+            raise ValueError(f"SensorMountConfig.position must have 3 elements [x,y,z], got {self.position}.")
+        if len(self.orientation) != 4:
+            raise ValueError(f"SensorMountConfig.orientation must have 4 elements [w,x,y,z], got {self.orientation}.")
+        if self.target_kind == "world":
+            if self.target:
+                raise ValueError(
+                    f"SensorMountConfig.target must be empty for target_kind='world' (a free-floating "
+                    f"camera anchors to no body); got '{self.target}'."
+                )
+        elif not self.target:
+            raise ValueError(
+                f"SensorMountConfig.target must be a non-empty body/actor name when target_kind='{self.target_kind}'."
+            )
+        return self
+
+
+@dataclass(frozen=True, config=_FORBID_EXTRA)
+class CameraSensorConfig:
+    """One mounted camera. The core fields mean the same thing on every backend.
+
+    ``width``/``height``/``vertical_fov``/``near``/``far``/``data_types`` and the ``mount``
+    are backend-agnostic; the optional ``isaacsim``/``isaacgym``/``mujoco`` sub-configs hold
+    only the few intrinsics a given engine interprets in its own way.
+
+    Keyed by its sensor name in the ``--sensor`` dict — the handle for
+    ``get_camera_data(name, ...)`` and the observation-term parameter.
+    """
+
+    mount: SensorMountConfig
+    """Body the camera is mounted on and follows, plus the fixed offset. Required (``target`` must
+    be non-empty)."""
+
+    width: int = 128
+    """Rendered image width in pixels. Defaults to 128."""
+
+    height: int = 128
+    """Rendered image height in pixels. Defaults to 128."""
+
+    vertical_fov: float = 45.0
+    """Vertical field of view in degrees (the single shared FOV convention). Defaults to 45."""
+
+    near: float = 0.01
+    """Near clipping plane in meters. Defaults to 0.01.
+
+    Per-camera on IsaacSim/IsaacGym. MuJoCo's clip is global (``model.vis.map.znear``), so across
+    multiple cameras the shared range widens to ``min(near)``; a camera may then see nearer than
+    its own value."""
+
+    far: float = 1000.0
+    """Far clipping plane in meters. Defaults to 1000.0.
+
+    Per-camera on IsaacSim/IsaacGym; global on MuJoCo, where the shared range widens to ``max(far)``
+    across all cameras. MuJoCo's far-clip also doubles as the depth no-hit boundary."""
+
+    data_types: list[CameraDataType] = field(default_factory=lambda: ["rgb"])
+    """Modalities to produce: ``"rgb"`` and/or ``"depth"``, e.g. ``["rgb", "depth"]``. The public
+    ``get_camera_data(name, data_type)`` accessor is keyed by these."""
+
+    update_decimation: DecimationLike = 1
+    """Render every Nth control step (1 = every step). Int, or a frequency string ("20Hz") resolved
+    against the control rate (fps/control_decimation) at the simulator. Lets slow cameras skip steps."""
+
+    isaacsim: IsaacSimCameraConfig | None = None
+    """IsaacSim-specific intrinsics overrides. Defaults to None (derive from core fields)."""
+
+    isaacgym: IsaacGymCameraConfig | None = None
+    """IsaacGym-specific intrinsics overrides. Defaults to None (derive from core fields)."""
+
+    mujoco: MujocoCameraConfig | None = None
+    """MuJoCo-specific intrinsics overrides. Defaults to None (derive from core fields)."""
+
+    @model_validator(mode="after")
+    def validate_camera(self) -> CameraSensorConfig:
+        """Positive resolution, known data types, at least one modality, valid mount target."""
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError(f"CameraSensorConfig needs positive width/height, got {self.width}x{self.height}.")
+        if not self.data_types:
+            raise ValueError("CameraSensorConfig must request at least one data_type.")
+        validate_decimation_like(self.update_decimation, field="CameraSensorConfig update_decimation")
+        # The robot is addressed via the ``robot_link`` kind; an ``actor`` mount must not name it.
+        if self.mount.target_kind == "actor" and self.mount.target == "robot":
+            raise ValueError(
+                "Camera mounts on actor 'robot'; use target_kind='robot_link' "
+                "(name the robot link, e.g. 'pelvis') for the robot."
+            )
+        return self
+
+
+def validate_camera_dict(cameras: dict[str, CameraSensorConfig]) -> None:
+    """Validate cross-camera constraints on a mounted-camera dict (keyed by sensor name).
+
+    Individual ``CameraSensorConfig`` validation runs at construction; this covers only the checks
+    that span multiple cameras. Call at the boundary that assembles the per-key ``--sensor`` dict
+    (or any code that builds one directly) before handing it to a backend.
+
+    Rejects conflicting MuJoCo-Warp appearance flags: ``use_shadows`` / ``use_textures`` /
+    ``use_precomputed_rays`` are global to the shared Warp render context, so cameras that set a
+    given flag must agree (``None`` imposes no constraint).
+    """
+    for attr in ("use_shadows", "use_textures", "use_precomputed_rays"):
+        setters = {name: getattr(c.mujoco, attr) for name, c in cameras.items() if c.mujoco is not None}
+        distinct = {v for v in setters.values() if v is not None}
+        if len(distinct) > 1:
+            conflicting = {n: v for n, v in setters.items() if v is not None}
+            raise ValueError(
+                f"MuJoCo-Warp render flag '{attr}' is GLOBAL to the shared render context but "
+                f"cameras set conflicting values {conflicting}. All cameras that set it must agree "
+                f"(or leave it None)."
+            )

--- a/src/holosoma/holosoma/config_types/tests/test_frequency.py
+++ b/src/holosoma/holosoma/config_types/tests/test_frequency.py
@@ -6,9 +6,14 @@ import pydantic
 import pytest
 
 from holosoma.config_types.frequency import resolve_decimation
+from holosoma.config_types.plugin import CameraVizPluginConfig
+from holosoma.config_types.sensor import CameraSensorConfig, SensorMountConfig
 from holosoma.config_types.simulator import PhysxConfig, SimEngineConfig
 
 pytestmark = pytest.mark.no_sim
+
+# A minimal valid mount required on every camera.
+_MOUNT = SensorMountConfig(target_kind="robot_link", target="pelvis")
 
 
 # ----- resolve_decimation -----
@@ -118,3 +123,21 @@ def test_sim_config_rejects_bad_rate_at_construction():
         _sim("banana")
     with pytest.raises(pydantic.ValidationError):
         _sim(0)
+
+
+# ----- sensor configs keep the raw value (resolved later, at the simulator) -----
+
+
+def test_camera_keeps_raw_string():
+    cam = CameraSensorConfig(mount=_MOUNT, update_decimation="20Hz")
+    assert cam.update_decimation == "20Hz"  # resolved by SensorManager at registration
+
+
+def test_camera_rejects_malformed_at_construction():
+    with pytest.raises(ValueError, match="update_decimation"):
+        CameraSensorConfig(mount=_MOUNT, update_decimation="20hz!")
+
+
+def test_viz_plugin_keeps_raw_string():
+    rec = CameraVizPluginConfig(update_decimation="10Hz")
+    assert rec.update_decimation == "10Hz"

--- a/src/holosoma/holosoma/config_types/tests/test_plugin_egress_config.py
+++ b/src/holosoma/holosoma/config_types/tests/test_plugin_egress_config.py
@@ -1,0 +1,79 @@
+"""Unit tests for camera-egress plugin config validators (pure, no simulator, no ROS).
+
+Construction-time validation checks on the frozen pydantic dataclasses in
+``config_types/plugin.py``. No rclpy is imported; ``get_cls`` is never touched.
+Runtime behavior is covered by the consumer-hook/ROS tests in ``simulator/plugins/tests/``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from holosoma.config_types.plugin import ROS2ImagePluginConfig, ROS2ImageRoute
+
+pytestmark = pytest.mark.no_sim
+
+
+def test_inline_mode_is_configurable():
+    assert ROS2ImagePluginConfig(async_publish=False, routes={}).async_publish is False
+
+
+def test_jpeg_quality_validated():
+    with pytest.raises(ValueError, match="jpeg_quality"):
+        ROS2ImagePluginConfig(jpeg_quality=0, routes={})
+    with pytest.raises(ValueError, match="jpeg_quality"):
+        ROS2ImagePluginConfig(jpeg_quality=101, routes={})
+
+
+def test_queue_maxlen_validated():
+    with pytest.raises(ValueError, match="queue_maxlen"):
+        ROS2ImagePluginConfig(queue_maxlen=0, routes={})
+
+
+def test_qos_validated():
+    with pytest.raises(ValueError, match="qos"):
+        ROS2ImagePluginConfig(qos="bogus", routes={})
+
+
+def test_duplicate_topics_rejected():
+    with pytest.raises(ValueError, match="duplicate topics"):
+        ROS2ImagePluginConfig(
+            routes={
+                "a": ROS2ImageRoute(camera="a", topic="/same", modality="rgb", format="jpeg"),
+                "b": ROS2ImageRoute(camera="b", topic="/same", modality="rgb", format="jpeg"),
+            }
+        )
+
+
+def test_route_format_modality_mismatch_rejected():
+    # rgb modality still requires an rgb format (a depth format has nothing to colorize).
+    with pytest.raises(ValueError, match="needs an rgb format"):
+        ROS2ImageRoute(camera="a", topic="/t", modality="rgb", format="32FC1")
+
+
+def test_depth_route_accepts_rgb_format_for_colorization():
+    # A depth route MAY pick an rgb format: it is colorized to RGB before encoding. Both a raw depth
+    # format and a colorizing rgb format must construct cleanly.
+    raw = ROS2ImageRoute(camera="a", topic="/t", modality="depth", format="32FC1")
+    color = ROS2ImageRoute(camera="a", topic="/t", modality="depth", format="jpeg", depth_colormap="turbo")
+    assert raw.format == "32FC1"
+    assert color.format == "jpeg" and color.depth_colormap == "turbo"
+
+
+def test_route_depth_colormap_validated():
+    with pytest.raises(ValueError, match="depth_colormap"):
+        ROS2ImageRoute(camera="a", topic="/t", modality="depth", format="jpeg", depth_colormap="bogus")
+
+
+def test_route_depth_range_validated():
+    with pytest.raises(ValueError, match="depth_range"):
+        ROS2ImageRoute(camera="a", topic="/t", modality="depth", format="jpeg", depth_range=[5.0, 1.0])
+    with pytest.raises(ValueError, match="depth_range"):
+        ROS2ImageRoute(camera="a", topic="/t", modality="depth", format="jpeg", depth_range=[1.0])
+
+
+def test_route_requires_camera_and_topic():
+    with pytest.raises(ValueError, match="non-empty camera"):
+        ROS2ImageRoute(camera="", topic="/t", modality="rgb", format="jpeg")
+    with pytest.raises(ValueError, match="non-empty topic"):
+        ROS2ImageRoute(camera="a", topic="", modality="rgb", format="jpeg")

--- a/src/holosoma/holosoma/config_types/tests/test_sensor_config.py
+++ b/src/holosoma/holosoma/config_types/tests/test_sensor_config.py
@@ -1,0 +1,63 @@
+"""Unit tests for camera-config validators (pure, no simulator).
+
+Per-camera checks run at ``CameraSensorConfig`` construction; the cross-camera Warp render-flag
+check is :func:`validate_camera_dict`, called at the CLI boundary that assembles the ``--sensor``
+dict.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from holosoma.config_types.sensor import (
+    CameraSensorConfig,
+    MujocoCameraConfig,
+    SensorMountConfig,
+    validate_camera_dict,
+)
+
+pytestmark = pytest.mark.no_sim
+
+
+def _cam(*, target_kind="robot_link", target="pelvis", mujoco=None):
+    return CameraSensorConfig(
+        mount=SensorMountConfig(target_kind=target_kind, target=target),
+        data_types=["rgb"],
+        mujoco=mujoco,
+    )
+
+
+def test_actor_mount_named_robot_rejected():
+    # The robot is addressed via target_kind="robot_link", never as an actor named "robot".
+    with pytest.raises(ValueError, match="use target_kind='robot_link'"):
+        _cam(target_kind="actor", target="robot")
+
+
+def test_actor_mount_other_name_allowed():
+    _cam(target_kind="actor", target="panel")  # must not raise
+
+
+def test_conflicting_warp_render_flag_rejected():
+    # use_shadows is global to the shared Warp render context; cameras setting it differently are
+    # rejected.
+    a = _cam(mujoco=MujocoCameraConfig(use_shadows=True))
+    b = _cam(mujoco=MujocoCameraConfig(use_shadows=False))
+    with pytest.raises(ValueError, match="render flag 'use_shadows'"):
+        validate_camera_dict({"a": a, "b": b})
+
+
+def test_agreeing_warp_render_flag_allowed():
+    a = _cam(mujoco=MujocoCameraConfig(use_shadows=True))
+    b = _cam(mujoco=MujocoCameraConfig(use_shadows=True))
+    validate_camera_dict({"a": a, "b": b})  # agreement is fine
+
+
+def test_none_warp_render_flag_imposes_no_constraint():
+    # One camera sets the flag, the other leaves it None: no conflict.
+    a = _cam(mujoco=MujocoCameraConfig(use_textures=False))
+    b = _cam()  # mujoco=None
+    validate_camera_dict({"a": a, "b": b})  # must not raise
+
+
+# The camera-frame sink fields (cameras/modalities/record_video/...) live on CameraVizPluginConfig;
+# their validation is covered in config_types/tests/test_plugin_egress_config.py.

--- a/src/holosoma/holosoma/config_values/plugin.py
+++ b/src/holosoma/holosoma/config_values/plugin.py
@@ -1,10 +1,21 @@
-"""Registered plugin presets, selectable as ``plugin.<key>:<variant>`` on the CLI."""
+"""Registered plugin presets, selectable as ``plugin.<key>:<variant>`` on the CLI.
+
+Holds the in-tree plugin presets: the ``none`` no-op, the ROS2 example plugins
+(``clock_publish``/``gantry_control``/``odometry``), and the camera-frame egress sinks
+(``ros2-image`` and friends, ``viz``/``viz-record``). All live in one ``PLUGIN_REGISTRY`` and
+compose per-key on the CLI, e.g. ``plugin.clk:clock_publish plugin.head:ros2-image plugin.rec:viz``.
+
+Imported at CLI-build time; stays ROS-free (a preset's impl loads only when its ``get_cls`` fires).
+"""
 
 from holosoma.config_types.plugin import (
+    CameraVizPluginConfig,
     ClockPublishPluginConfig,
     GantryControlPluginConfig,
     NoOpPluginConfig,
     PluginConfig,
+    ROS2ImagePluginConfig,
+    ROS2ImageRoute,
     ROS2OdometryPluginConfig,
 )
 from holosoma.utils.config_registry import ConfigRegistry, deprecated_defaults_alias
@@ -13,8 +24,7 @@ PLUGIN_REGISTRY = ConfigRegistry(PluginConfig, group="holosoma.config.plugin")
 
 # `none` disables a slot (plugin.<key>:none), mirroring every other config family's `none`
 # preset. Unlike the scalar families (which register a literal None), this dict field
-# registers a real no-op config so the field type stays uniform. Extensions register their own
-# via the entry-point group above or a --import-file that calls PLUGIN_REGISTRY.add(...).
+# registers a real no-op config so the field type stays uniform.
 none = PLUGIN_REGISTRY.add("none", NoOpPluginConfig())
 
 # ROS2 example presets. Their impls import rclpy (optional dep: holosoma[ros2]); the
@@ -26,5 +36,115 @@ gantry_control = PLUGIN_REGISTRY.add("gantry_control", GantryControlPluginConfig
 # reads robot_root_states each control step. Rides the same in-process rclpy transport as the image
 # egress (no CycloneDDS entanglement with the Unitree SDK bridge).
 odometry = PLUGIN_REGISTRY.add("odometry", ROS2OdometryPluginConfig())
+
+# ------------------------------------------------------------------------------------------------ #
+# Camera-frame egress presets. Compose several on the CLI by giving each its own key, e.g.
+#   plugin.head:ros2-image plugin.rec:viz-record --plugin.head.node_name cams
+# Field overrides key off the plugin name, e.g. --plugin.waist.routes.front.depth_range '[0.1, 6.0]'.
+# ------------------------------------------------------------------------------------------------ #
+
+# One ROS2 node publishing the G1 head camera as JPEG plus latched CameraInfo. Pair with a sensor
+# rig that defines `head_cam` (e.g. `--sensor.head_cam:g1-head`).
+ros2_image = PLUGIN_REGISTRY.add(
+    "ros2-image",
+    ROS2ImagePluginConfig(
+        node_name="sim_cameras_head",
+        routes={
+            "head": ROS2ImageRoute(
+                camera="head_cam", topic="/sim_cameras/head/image/compressed", modality="rgb", format="jpeg"
+            )
+        },
+    ),
+)
+
+# Stereo head pair as CompressedImage on the exact topics the rfmpi teleop stack subscribes to:
+# /ros_camera/rgb/{left,right}/compressed. Pair with a stereo head rig keyed head_cam_left/right.
+# CameraInfo off for this teleop stack.
+ros2_stereo = PLUGIN_REGISTRY.add(
+    "ros2-stereo",
+    ROS2ImagePluginConfig(
+        node_name="sim_cameras_head_stereo",
+        publish_camera_info=False,
+        routes={
+            "left": ROS2ImageRoute(
+                camera="head_cam_left", topic="/ros_camera/rgb/left/compressed", modality="rgb", format="jpeg"
+            ),
+            "right": ROS2ImageRoute(
+                camera="head_cam_right", topic="/ros_camera/rgb/right/compressed", modality="rgb", format="jpeg"
+            ),
+        },
+    ),
+)
+
+# One ROS2 node publishing the G1 waist forward/back depth cameras as raw float32-meter Image
+# (sensor_msgs/Image, 32FC1) plus latched CameraInfo. Pair with a rig keyed waist_front_cam /
+# waist_back_cam (`--sensor.waist_front_cam:g1-waist-front --sensor.waist_back_cam:g1-waist-back`).
+ros2_waist_depth = PLUGIN_REGISTRY.add(
+    "ros2-waist-depth",
+    ROS2ImagePluginConfig(
+        node_name="sim_cameras_waist",
+        routes={
+            "front": ROS2ImageRoute(
+                camera="waist_front_cam", topic="/sim_cameras/waist_front/depth", modality="depth", format="32FC1"
+            ),
+            "back": ROS2ImageRoute(
+                camera="waist_back_cam", topic="/sim_cameras/waist_back/depth", modality="depth", format="32FC1"
+            ),
+        },
+    ),
+)
+
+# Like `ros2-waist-depth`, but publishes the waist depth cameras COLORIZED to RGB (turbo colormap)
+# as CompressedImage (jpeg) — a human-viewable depth stream for rviz/teleop rather than raw metric
+# depth. Depth modality + an rgb format triggers colorization; depth_range fixes the color scale.
+ros2_waist_depth_color = PLUGIN_REGISTRY.add(
+    "ros2-waist-depth-color",
+    ROS2ImagePluginConfig(
+        node_name="sim_cameras_waist_color",
+        routes={
+            "front": ROS2ImageRoute(
+                camera="waist_front_cam",
+                topic="/sim_cameras/waist_front/depth_color/compressed",
+                modality="depth",
+                format="jpeg",
+                depth_colormap="turbo",
+                depth_range=[0.1, 4.0],
+            ),
+            "back": ROS2ImageRoute(
+                camera="waist_back_cam",
+                topic="/sim_cameras/waist_back/depth_color/compressed",
+                modality="depth",
+                format="jpeg",
+                depth_colormap="turbo",
+                depth_range=[0.1, 4.0],
+            ),
+        },
+    ),
+)
+
+# Both at once from ONE node: each waist camera published as raw metric depth (32FC1) AND colorized
+# RGB (jpeg) — the machine-readable stream for perception plus the human-viewable stream for
+# rviz/teleop. The raw and colorized routes for a camera share the same (camera, depth) stream key,
+# so the consumer does ONE cached device->host copy per camera and each route encodes it its own way
+# (no extra render/copy cost). Pair with a waist rig.
+ros2_waist_depth_raw_and_color = PLUGIN_REGISTRY.add(
+    "ros2-waist-depth-raw+color",
+    ROS2ImagePluginConfig(
+        node_name="sim_cameras_waist",
+        routes={
+            "front_raw": ros2_waist_depth.routes["front"],
+            "back_raw": ros2_waist_depth.routes["back"],
+            "front_color": ros2_waist_depth_color.routes["front"],
+            "back_color": ros2_waist_depth_color.routes["back"],
+        },
+    ),
+)
+
+# Visualize all configured cameras (every modality) in a live cv2 window. cameras=None watches them
+# all; add ``--plugin.<key>.record_video True`` to also write an mp4 at teardown.
+viz = PLUGIN_REGISTRY.add("viz", CameraVizPluginConfig(live_window=True))
+
+# Record all configured cameras to an mp4 at teardown (no live window; runs headless).
+viz_record = PLUGIN_REGISTRY.add("viz-record", CameraVizPluginConfig(record_video=True))
 
 __getattr__ = deprecated_defaults_alias(__name__, PLUGIN_REGISTRY)

--- a/src/holosoma/holosoma/config_values/sensor.py
+++ b/src/holosoma/holosoma/config_values/sensor.py
@@ -1,0 +1,57 @@
+"""Named single-camera building blocks, selectable per key via the dynamic ``--sensor`` dict.
+
+Each preset is ONE :class:`CameraSensorConfig`. Compose a rig by giving each camera its own key,
+e.g. ``--sensor.my_head:g1-head --sensor.my_left_wrist:g1-left-wrist``; the key becomes the sensor
+name that ``get_camera_data`` and the observation terms address. Any camera field can be overridden
+per key, e.g. ``--sensor.my_head.width 224``.
+
+Combination presets (a head + two wrists, stereo + wrists, ...) are intentionally gone: the dynamic
+dict composes them from these building blocks at the CLI.
+
+Extensions add cameras by registering into ``CAMERA_REGISTRY`` (e.g. via a ``holosoma.config.sensor``
+entry point).
+"""
+
+from holosoma.config_types.sensor import CameraSensorConfig, SensorMountConfig
+from holosoma.config_values.wbt.g1.sensor import (
+    head_camera,
+    left_wrist_camera,
+    right_wrist_camera,
+    stereo_head_camera_left,
+    stereo_head_camera_right,
+    waist_back_camera,
+    waist_front_camera,
+)
+from holosoma.utils.config_registry import ConfigRegistry
+
+CAMERA_REGISTRY = ConfigRegistry(CameraSensorConfig, group="holosoma.config.sensor")
+
+# Free-floating overview camera: fixed at an elevated corner of each env, looking down at the scene
+# center in an angled ISOMETRIC view. The ``world`` mount anchors to the env frame (not any body),
+# so it never moves with the robot — useful for logging/overview. Placed at (2.5, -2.5, 2.5) m
+# (front-right, up); the orientation is the look-at quaternion aiming the optical axis (-Z) at the
+# origin with +Y up, giving a ~35.26deg downward elevation (the true isometric angle). Verified: the
+# camera's -Z maps to the normalized eye->origin direction and +Y stays up. Robot/scene-agnostic,
+# 640x480.
+_ISO_LOOK_AT_ORIGIN_WXYZ = [0.820473, 0.424708, 0.17592, 0.339851]
+overview_camera = CameraSensorConfig(
+    mount=SensorMountConfig(target_kind="world", position=[2.5, -2.5, 2.5], orientation=_ISO_LOOK_AT_ORIGIN_WXYZ),
+    width=640,
+    height=480,
+    vertical_fov=60.0,
+    data_types=["rgb"],
+)
+
+# Egocentric G1 head camera, forward-facing.
+CAMERA_REGISTRY.add("g1-head", head_camera)
+# G1 stereo head eyes (compose both for a stereo pair).
+CAMERA_REGISTRY.add("g1-stereo-left", stereo_head_camera_left)
+CAMERA_REGISTRY.add("g1-stereo-right", stereo_head_camera_right)
+# G1 wrist grasp cameras.
+CAMERA_REGISTRY.add("g1-left-wrist", left_wrist_camera)
+CAMERA_REGISTRY.add("g1-right-wrist", right_wrist_camera)
+# G1 waist-height forward/back depth cameras.
+CAMERA_REGISTRY.add("g1-waist-front", waist_front_camera)
+CAMERA_REGISTRY.add("g1-waist-back", waist_back_camera)
+# Free-floating angled isometric overview camera looking at the scene center (640x480).
+CAMERA_REGISTRY.add("overview", overview_camera)

--- a/src/holosoma/holosoma/config_values/wbt/g1/sensor.py
+++ b/src/holosoma/holosoma/config_values/wbt/g1/sensor.py
@@ -1,0 +1,110 @@
+"""Individual camera building blocks for the G1 robot.
+
+Each value is one :class:`CameraSensorConfig`; compose them per-key on the CLI, e.g.
+``--sensor.my_head:g1-head --sensor.my_left_wrist:g1-left-wrist``. Mounts on ``g1_29dof`` body
+names and frames (see ``data/robots/g1/g1_29dof.xml``):
+
+- Head: the ``torso_link`` frame origin is at the waist-pitch joint; the head and ``mid360``
+  Livox site sit at ``z ~= 0.41`` in that frame.
+- Wrists: in the ``*_wrist_yaw_link`` frame the hand points along +X (``*_palm`` site at
+  ``[0.08,0,0]``).
+
+The mount orientations below reorient the camera's optical -Z to look along body +X.
+"""
+
+from __future__ import annotations
+
+from holosoma.config_types.sensor import CameraSensorConfig, SensorMountConfig
+
+# Egocentric head camera (torso-frame z~=0.41, by the mid360 mount), looking forward and upright.
+head_camera = CameraSensorConfig(
+    mount=SensorMountConfig(
+        target_kind="robot_link",
+        target="torso_link",
+        position=[0.05, 0.0, 0.41],
+        # forward = body +X, up = body +Z (level, forward-facing)
+        orientation=[0.5, 0.5, -0.5, -0.5],
+    ),
+    width=128,
+    height=128,
+    data_types=["rgb"],
+    update_decimation="50Hz",
+)
+
+
+def _stereo_head_camera(sign: int) -> CameraSensorConfig:
+    """One eye of a stereo head pair, offset along body +Y by half the interpupillary distance."""
+    return CameraSensorConfig(
+        mount=SensorMountConfig(
+            target_kind="robot_link",
+            target="torso_link",
+            # Default eye separation (meters) along body +Y (human interpupillary distance) is 0.063
+            position=[0.05, sign * 0.063 / 2, 0.41],
+            # forward = body +X, up = body +Z (level, forward-facing)
+            orientation=[0.5, 0.5, -0.5, -0.5],
+        ),
+        width=128,
+        height=128,
+        vertical_fov=45,
+        data_types=["rgb"],
+        update_decimation="50Hz",
+    )
+
+
+stereo_head_camera_left = _stereo_head_camera(+1)
+stereo_head_camera_right = _stereo_head_camera(-1)
+
+
+def _wrist_camera(side: str) -> CameraSensorConfig:
+    """One grasp camera per wrist: offset up off the back of the wrist (+Z, clear of the hand)
+    and pitched down to watch the palm/grasp region ahead."""
+    return CameraSensorConfig(
+        mount=SensorMountConfig(
+            target_kind="robot_link",
+            target=f"{side}_wrist_yaw_link",
+            position=[0.03, 0.0, 0.06],
+            # forward = +X pitched 30deg toward -Z, up near +Z,
+            orientation=[0.61237244, 0.35355339, -0.35355339, -0.61237244],
+        ),
+        width=128,
+        height=128,
+        near=0.02,
+        data_types=["rgb"],
+        update_decimation="50Hz",
+    )
+
+
+left_wrist_camera = _wrist_camera("left")
+right_wrist_camera = _wrist_camera("right")
+
+# Waist-height depth cameras (torso_link frame origin sits at the waist-pitch joint, z~=0 => waist
+# height). Depth-only, for near-body obstacle sensing / whole-body awareness fore and aft.
+
+# forward = body +X pitched 70deg down toward -Z, up in the +X/+Z plane; just ahead of the torso,
+# looking down at the ground ahead of the feet.
+waist_front_camera = CameraSensorConfig(
+    mount=SensorMountConfig(
+        target_kind="robot_link",
+        target="torso_link",
+        position=[0.1, 0.0, 0.0],
+        orientation=[0.69636424, 0.1227878, -0.1227878, -0.69636424],
+    ),
+    width=128,
+    height=128,
+    data_types=["depth"],
+    update_decimation="50Hz",
+)
+
+# forward = body -X, up = body +Z (level), just behind the torso (180deg yaw of the front).
+waist_back_camera = CameraSensorConfig(
+    mount=SensorMountConfig(
+        target_kind="robot_link",
+        target="torso_link",
+        position=[-0.1, 0.0, 0.0],
+        orientation=[0.5, 0.5, 0.5, 0.5],
+    ),
+    width=128,
+    height=128,
+    data_types=["depth"],
+    update_decimation="50Hz",
+)

--- a/src/holosoma/holosoma/data/scene_objects/panels/red_panel.urdf
+++ b/src/holosoma/holosoma/data/scene_objects/panels/red_panel.urdf
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<!-- Flat bright-red panel for camera-geometry behavioral tests (URDF; IsaacGym/IsaacSim).
+     URDF box size is the FULL extent: 0.02 x 0.4 x 0.4 m (thin in X, 0.4 m in Y and Z),
+     matching red_panel.xml's 0.01/0.2/0.2 MJCF half-extents. Pure red so the panel
+     silhouette is trivially segmentable from the background. -->
+<robot name="red_panel">
+  <link name="baseLink">
+    <inertial>
+      <mass value="0.1"/>
+      <origin xyz="0 0 0"/>
+      <inertia ixx="0.0002" ixy="0" ixz="0" iyy="0.0002" iyz="0" izz="0.0002"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry><box size="0.02 0.4 0.4"/></geometry>
+      <material name="red"><color rgba="1 0 0 1"/></material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry><box size="0.02 0.4 0.4"/></geometry>
+    </collision>
+  </link>
+</robot>

--- a/src/holosoma/holosoma/data/scene_objects/panels/red_panel.usda
+++ b/src/holosoma/holosoma/data/scene_objects/panels/red_panel.usda
@@ -1,0 +1,27 @@
+#usda 1.0
+(
+    # Flat bright-red panel for camera-geometry behavioral tests (USD; IsaacSim).
+    # A unit Cube scaled to 0.02 x 0.4 x 0.4 m (thin in X, 0.4 m in Y and Z), matching
+    # red_panel.urdf / red_panel.xml. displayColor red so the silhouette segments by hue
+    # (lighting-robust), the USD counterpart of the URDF/MJCF rgba="1 0 0 1".
+    defaultPrim = "red_panel"
+    metersPerUnit = 1.0
+    upAxis = "Z"
+)
+
+def Xform "red_panel" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+)
+{
+    float physics:mass = 0.1
+
+    def Cube "geom" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double size = 1.0
+        float3 xformOp:scale = (0.02, 0.4, 0.4)
+        uniform token[] xformOpOrder = ["xformOp:scale"]
+        color3f[] primvars:displayColor = [(1.0, 0.0, 0.0)]
+    }
+}

--- a/src/holosoma/holosoma/data/scene_objects/panels/red_panel.xml
+++ b/src/holosoma/holosoma/data/scene_objects/panels/red_panel.xml
@@ -1,0 +1,12 @@
+<!-- Flat bright-red panel for camera-geometry behavioral tests (MJCF).
+     Thin in X (depth), 0.4 m wide in Y, 0.4 m tall in Z. MJCF geom size is HALF-extent,
+     so size="0.01 0.2 0.2" => 0.02 x 0.4 x 0.4 m. One top-level body, no joint (the scene
+     manager adds a free joint for free bodies, leaves it jointless for static). Pure red
+     (rgba 1 0 0 1) so the panel silhouette is trivially segmentable from the background. -->
+<mujoco model="red_panel">
+  <worldbody>
+    <body name="baseLink">
+      <geom type="box" size="0.01 0.2 0.2" rgba="1 0 0 1" mass="0.1"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/src/holosoma/holosoma/envs/base_task/base_task.py
+++ b/src/holosoma/holosoma/envs/base_task/base_task.py
@@ -91,6 +91,7 @@ class BaseTask:
             simulator=simulator_config.config,
             robot=robot_config,
             scene=tyro_config.scene,
+            sensors=tyro_config.sensors,
             plugin=tyro_config.plugin,  # egress/custom plugins; the simulator installs them in __init__
             training=training_config,
             logger=tyro_config.logger,
@@ -464,6 +465,8 @@ class BaseTask:
 
     def _post_physics_step(self):
         self._refresh_sim_tensors()
+        # Cameras render and egress consumers publish here, as FRAME_END plugins (the cameras'
+        # render_sensors is registered before any consumer, so buffers are fresh on read).
         self.simulator.hooks.emit(Phase.FRAME_END)
         self.episode_length_buf += 1
         self._update_counters_each_step()
@@ -526,15 +529,38 @@ class BaseTask:
         if not final_obs_dict:
             return
         final_store = self.extras.setdefault("final_observations", {})
+
+        def _store_value(store_parent, key, value, template):
+            # A concatenate=False group is a dict of per-term tensors; recurse one level so the
+            # per-env final-obs copy works for image groups too (env-axis is dim 0 either way).
+            if isinstance(value, dict):
+                sub = store_parent.setdefault(key, {})
+                for sub_key, sub_val in value.items():
+                    _store_value(sub, sub_key, sub_val, template[sub_key])
+                return
+            if key not in store_parent:
+                store_parent[key] = torch.zeros_like(template)
+            store_parent[key][env_ids] = value[env_ids]
+
         for obs_key, values in final_obs_dict.items():
-            if obs_key not in final_store:
-                final_store[obs_key] = torch.zeros_like(self.obs_buf_dict[obs_key])
-            final_store[obs_key][env_ids] = values[env_ids]
+            _store_value(final_store, obs_key, values, self.obs_buf_dict[obs_key])
 
     def _clip_observations(self):
         clip_limit = self.observation_manager.cfg.clip_observations
+
+        def _clip_value(value):
+            # A concatenate=False group is a dict of per-term tensors; recurse one level.
+            if isinstance(value, dict):
+                return {k: _clip_value(v) for k, v in value.items()}
+            # Only clip flat (2-D [N, feature]) float observations. Image/depth terms
+            # ([N, H, W, C]) are not bounded observations and clipping would corrupt them
+            # (e.g. collapse the depth +inf no-hit sentinel to clip_limit).
+            if isinstance(value, torch.Tensor) and value.is_floating_point() and value.ndim == 2:
+                return torch.clip(value, -clip_limit, clip_limit)
+            return value
+
         for obs_key, obs_val in self.obs_buf_dict.items():
-            self.obs_buf_dict[obs_key] = torch.clip(obs_val, -clip_limit, clip_limit)
+            self.obs_buf_dict[obs_key] = _clip_value(obs_val)
 
     def _compute_reward(self):
         self.rew_buf[:] = self.reward_manager.compute(self.dt)

--- a/src/holosoma/holosoma/envs/tests/test_obs_dict_group.py
+++ b/src/holosoma/holosoma/envs/tests/test_obs_dict_group.py
@@ -1,0 +1,99 @@
+"""Tests for dict/dtype-aware observation handling in BaseTask.
+
+A ``concatenate=False`` observation group computes to a dict of per-term tensors. These tests pin
+that ``_clip_observations`` and ``_store_final_observations`` handle a dict group value (and a
+uint8 image term) without flattening or clipping it, by calling the unbound methods on a stub.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from holosoma.envs.base_task.base_task import BaseTask
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+
+def _make_stub(obs_buf_dict, clip_limit=100.0):
+    """Minimal object carrying just what the two methods touch."""
+    stub = types.SimpleNamespace()
+    stub.obs_buf_dict = obs_buf_dict
+    stub.extras = {}
+    stub.observation_manager = types.SimpleNamespace(cfg=types.SimpleNamespace(clip_observations=clip_limit))
+    return stub
+
+
+def test_clip_observations_handles_dict_group_and_uint8():
+    """A flat float group is clipped; a dict group recurses; uint8 images pass through unclipped."""
+    flat = torch.tensor([[500.0, -500.0, 1.0]])  # exceeds +/-100, gets clipped
+    image = torch.full((1, 4, 4, 3), 200, dtype=torch.uint8)  # uint8 image, stays unclipped
+    proprio = torch.tensor([[5.0, -5.0]])  # within range, unchanged
+    obs = {
+        "actor_obs": flat,
+        "image_group": {"front_rgb": image, "proprio": proprio},
+    }
+    stub = _make_stub(obs)
+
+    BaseTask._clip_observations(stub)
+
+    # Flat float group clipped to +/-100.
+    assert torch.equal(stub.obs_buf_dict["actor_obs"], torch.tensor([[100.0, -100.0, 1.0]]))
+    # Dict group preserved as a dict.
+    assert isinstance(stub.obs_buf_dict["image_group"], dict)
+    # uint8 image untouched (not clipped to +/-100).
+    assert torch.equal(stub.obs_buf_dict["image_group"]["front_rgb"], image)
+    assert stub.obs_buf_dict["image_group"]["front_rgb"].dtype == torch.uint8
+    # Float term inside the dict group within range, unchanged.
+    assert torch.equal(stub.obs_buf_dict["image_group"]["proprio"], proprio)
+
+
+def test_clip_observations_preserves_depth_inf_sentinel():
+    """A float32 depth image (4-D) keeps its +inf no-hit sentinel; clipping would corrupt it."""
+    depth = torch.full((1, 4, 4, 1), 250.0)  # finite far depth, beyond the +/-100 clip
+    depth[0, 0, 0, 0] = float("inf")  # no-hit sentinel
+    obs = {"image_group": {"front_depth": depth.clone()}}
+    stub = _make_stub(obs, clip_limit=100.0)
+
+    BaseTask._clip_observations(stub)
+
+    out = stub.obs_buf_dict["image_group"]["front_depth"]
+    assert torch.isinf(out[0, 0, 0, 0])  # sentinel survives (not clamped to 100)
+    assert float(out[0, 1, 1, 0]) == 250.0  # far depth not clamped
+
+
+def test_store_final_observations_handles_dict_group():
+    """Final-obs copy works for both a flat group and a dict (image) group, per env."""
+    num_envs = 3
+    cur = {
+        "actor_obs": torch.zeros(num_envs, 2),
+        "image_group": {"front_rgb": torch.zeros(num_envs, 2, 2, 3, dtype=torch.uint8)},
+    }
+    stub = _make_stub(cur)
+
+    final = {
+        "actor_obs": torch.arange(num_envs * 2, dtype=torch.float32).reshape(num_envs, 2),
+        "image_group": {"front_rgb": torch.full((num_envs, 2, 2, 3), 7, dtype=torch.uint8)},
+    }
+    env_ids = torch.tensor([0, 2])  # store envs 0 and 2 only
+
+    BaseTask._store_final_observations(stub, env_ids, final)
+
+    store = stub.extras["final_observations"]
+    # Flat group: env 0 and 2 copied from final, env 1 left zero.
+    assert torch.equal(store["actor_obs"][env_ids], final["actor_obs"][env_ids])
+    assert torch.equal(store["actor_obs"][1], torch.zeros(2))
+    # Dict group recursed: image copied for the selected envs, dtype preserved.
+    img_store = store["image_group"]["front_rgb"]
+    assert img_store.dtype == torch.uint8
+    assert torch.equal(img_store[env_ids], final["image_group"]["front_rgb"][env_ids])
+    assert int(img_store[1].sum()) == 0  # env 1 untouched
+
+
+def test_store_final_observations_empty_is_noop():
+    """An empty final-obs dict stores nothing."""
+    stub = _make_stub({"actor_obs": torch.zeros(2, 2)})
+    BaseTask._store_final_observations(stub, torch.tensor([0]), {})
+    assert "final_observations" not in stub.extras

--- a/src/holosoma/holosoma/managers/observation/manager.py
+++ b/src/holosoma/holosoma/managers/observation/manager.py
@@ -121,8 +121,11 @@ class ObservationManager:
             if group_cfg.enable_noise and term_cfg.noise > 0:
                 obs = self._apply_noise(obs, term_cfg.noise)
 
-            # 3. Apply scaling (matches direct: scale after noise)
-            obs = self._apply_scale(obs, term_cfg.scale)
+            # 3. Apply scaling (matches direct: scale after noise). Skip the multiply when the
+            # scale is the default 1.0 (numerically a no-op) so a non-float term (e.g. a uint8
+            # RGB image) keeps its native dtype instead of being promoted to float.
+            if term_cfg.scale != 1.0:
+                obs = self._apply_scale(obs, term_cfg.scale)
 
             # 4. Apply clipping (if specified)
             if term_cfg.clip is not None:
@@ -139,6 +142,13 @@ class ObservationManager:
             # Concatenate in alphabetically sorted order (to match direct system behavior)
             # Direct system does: sorted(obs_config) before concatenation
             sorted_keys = sorted(obs_tensors.keys())
+            for key in sorted_keys:
+                if obs_tensors[key].ndim != 2:
+                    raise ValueError(
+                        f"Observation term '{key}' in concatenate=True group '{group_name}' must be "
+                        f"2-D [num_envs, feature], got shape {tuple(obs_tensors[key].shape)}. Image terms "
+                        f"(e.g. camera_rgb/camera_depth) belong only in a concatenate=False (dict) group."
+                    )
             return torch.cat([obs_tensors[key] for key in sorted_keys], dim=-1)
         return obs_tensors
 
@@ -296,17 +306,21 @@ class ObservationManager:
             for instance in group_instances.values():
                 instance.reset(env_ids_tensor)
 
-    def get_obs_dims(self) -> dict[str, int | dict[str, int]]:
+    def get_obs_dims(self) -> dict[str, int | dict[str, int | tuple[int, ...]]]:
         """Get observation dimensions for each group.
+
+        Concatenate groups require 2-D terms and report a single summed int. Dict groups
+        return per-term feature size: an int for 2-D terms, or the trailing-dim shape tuple
+        (``obs.shape[1:]``) for image terms.
 
         Returns
         -------
-        dict[str, int or dict[str, int]]
+        dict[str, int or dict[str, int or tuple]]
             Mapping from group names to observation dimensions. Values are integers
             when the group concatenates terms, otherwise dictionaries of per-term
             dimensions.
         """
-        dims: dict[str, int | dict[str, int]] = {}
+        dims: dict[str, int | dict[str, int | tuple[int, ...]]] = {}
         for group_name, group_cfg in self.cfg.groups.items():
             if group_cfg.concatenate:
                 # Sum up all term dimensions
@@ -314,6 +328,12 @@ class ObservationManager:
                 for term_name, term_cfg in group_cfg.terms.items():
                     # Compute term once to get its dimension
                     obs = self._compute_term(group_name, term_name, term_cfg)
+                    if obs.ndim != 2:
+                        raise ValueError(
+                            f"Observation term '{term_name}' in concatenate=True group '{group_name}' must be "
+                            f"2-D [num_envs, feature], got shape {tuple(obs.shape)}. Image terms "
+                            f"(e.g. camera_rgb/camera_depth) belong only in a concatenate=False (dict) group."
+                        )
                     term_dim = obs.shape[1]
 
                     # Account for history at group level
@@ -323,10 +343,11 @@ class ObservationManager:
                     total_dim += term_dim
                 dims[group_name] = total_dim
             else:
-                # Return dict of individual dimensions
-                term_dims: dict[str, int] = {
-                    term_name: self._compute_term(group_name, term_name, term_cfg).shape[1]
-                    for term_name, term_cfg in group_cfg.terms.items()
-                }
+                # Return dict of per-term feature sizes: an int for 2-D terms, or the
+                # trailing-dim shape tuple for image terms ([N, H, W, C] -> (H, W, C)).
+                term_dims: dict[str, int | tuple[int, ...]] = {}
+                for term_name, term_cfg in group_cfg.terms.items():
+                    obs = self._compute_term(group_name, term_name, term_cfg)
+                    term_dims[term_name] = obs.shape[1] if obs.ndim == 2 else tuple(obs.shape[1:])
                 dims[group_name] = term_dims
         return dims

--- a/src/holosoma/holosoma/managers/observation/terms/cameras.py
+++ b/src/holosoma/holosoma/managers/observation/terms/cameras.py
@@ -1,0 +1,54 @@
+"""Camera-sensor observation terms.
+
+Read a mounted camera's rendered image via the simulator's ``get_camera_data`` accessor.
+
+Image terms return a 4-D ``[N, H, W, C]`` tensor and belong in a ``concatenate=False`` observation
+group, not the flat policy vector. An optional ``transform`` (an :class:`ImageTransformConfig`
+dict) reshapes a term's frame via ``apply_image_transform``; when omitted, the frame is returned
+unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from holosoma.config_types.sensor import ImageTransformConfig
+from holosoma.simulator.shared.image_transform import apply_image_transform
+
+if TYPE_CHECKING:
+    import torch
+
+    from holosoma.envs.base_task.base_task import BaseTask
+
+
+def _camera_obs(env: BaseTask, sensor: str, modality: str, transform: dict | None) -> torch.Tensor:
+    """Cached read of one camera modality, optionally transformed for a visual policy."""
+    image = env.simulator.get_camera_data(sensor, modality)
+    if transform is None:
+        return image
+    return apply_image_transform(image, ImageTransformConfig(**transform), modality)
+
+
+def camera_rgb(env: BaseTask, sensor: str, transform: dict | None = None) -> torch.Tensor:
+    """RGB frames for one mounted camera: ``[num_envs, H, W, 3]`` uint8 (R,G,B), all envs.
+
+    Cached read of the frame rendered this step by ``render_sensors``.
+
+    Parameters
+    ----------
+    env : BaseTask
+        The task (provides ``env.simulator``).
+    sensor : str
+        Camera name (the ``CameraSensorConfig.name`` key).
+    transform : dict | None
+        Optional :class:`ImageTransformConfig` fields (resize, layout, scale) for a visual policy;
+        ``None`` returns the unmodified frame.
+    """
+    return _camera_obs(env, sensor, "rgb", transform)
+
+
+def camera_depth(env: BaseTask, sensor: str, transform: dict | None = None) -> torch.Tensor:
+    """Depth frames for one mounted camera: ``[num_envs, H, W, 1]`` float32 meters
+    (image-plane, ``+inf`` no-hit), all envs. Cached read like :func:`camera_rgb`; ``transform``
+    reshapes or scales it (depth float scaling needs ``depth_range``)."""
+    return _camera_obs(env, sensor, "depth", transform)

--- a/src/holosoma/holosoma/managers/observation/tests/test_camera_obs_terms.py
+++ b/src/holosoma/holosoma/managers/observation/tests/test_camera_obs_terms.py
@@ -1,0 +1,140 @@
+"""Integration tests for camera observation terms through the real ObservationManager (no sim).
+
+The camera terms (``camera_rgb``/``camera_depth``) read the ``get_camera_data`` accessor,
+so a stub simulator returning camera tensors exercises the full term -> ObservationManager path
+without a backend. Pins:
+- an image term flows through a ``concatenate=False`` dict group with its dtype/values intact
+  (the uint8 RGB is NOT promoted to float by the scale=1.0 path);
+- ``get_obs_dims`` reports the per-term image shape for a dict group;
+- an image term in a ``concatenate=True`` group is rejected with a clear, named error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from holosoma.config_types.observation import ObservationManagerCfg, ObsGroupCfg, ObsTermCfg
+from holosoma.managers.observation.manager import ObservationManager
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+_TERMS = "holosoma.managers.observation.terms.cameras"
+
+
+class _CameraSim:
+    """Stub simulator: returns camera tensors for a fixed (name -> tensor) map."""
+
+    def __init__(self, frames: dict[tuple[str, str], torch.Tensor]):
+        self._frames = frames
+
+    def get_camera_data(self, name: str, data_type: str = "rgb", env_ids=None) -> torch.Tensor:
+        buf = self._frames[(name, data_type)]
+        return buf if env_ids is None else buf[env_ids]
+
+
+class _Env:
+    def __init__(self, sim, num_envs):
+        self.simulator = sim
+        self.device = "cpu"
+        self.num_envs = num_envs
+
+
+def _make_env(num_envs=2, h=4, w=6):
+    rgb = torch.randint(0, 256, (num_envs, h, w, 3), dtype=torch.uint8)
+    depth = torch.full((num_envs, h, w, 1), 2.5, dtype=torch.float32)
+    sim = _CameraSim({("head", "rgb"): rgb, ("head", "depth"): depth})
+    return _Env(sim, num_envs), rgb, depth
+
+
+def test_rgb_term_flows_through_dict_group_unaltered():
+    env, rgb, _ = _make_env()
+    cfg = ObservationManagerCfg(
+        groups={
+            "image": ObsGroupCfg(
+                concatenate=False,
+                terms={"head_rgb": ObsTermCfg(func=f"{_TERMS}:camera_rgb", params={"sensor": "head"})},
+            )
+        }
+    )
+    mgr = ObservationManager(cfg, env, device="cpu")
+    obs = mgr.compute()["image"]
+    assert isinstance(obs, dict) and set(obs) == {"head_rgb"}
+    # uint8 preserved (scale=1.0 must not promote to float) and values unchanged.
+    assert obs["head_rgb"].dtype == torch.uint8
+    assert torch.equal(obs["head_rgb"], rgb)
+
+
+def test_depth_term_dict_group_shape_and_dtype():
+    env, _, depth = _make_env()
+    cfg = ObservationManagerCfg(
+        groups={
+            "image": ObsGroupCfg(
+                concatenate=False,
+                terms={"head_depth": ObsTermCfg(func=f"{_TERMS}:camera_depth", params={"sensor": "head"})},
+            )
+        }
+    )
+    mgr = ObservationManager(cfg, env, device="cpu")
+    obs = mgr.compute()["image"]
+    assert obs["head_depth"].dtype == torch.float32
+    assert tuple(obs["head_depth"].shape) == tuple(depth.shape)
+
+
+def test_get_obs_dims_reports_image_shape_for_dict_group():
+    env, _, _ = _make_env(num_envs=2, h=4, w=6)
+    cfg = ObservationManagerCfg(
+        groups={
+            "image": ObsGroupCfg(
+                concatenate=False,
+                terms={
+                    "head_rgb": ObsTermCfg(func=f"{_TERMS}:camera_rgb", params={"sensor": "head"}),
+                    "head_depth": ObsTermCfg(func=f"{_TERMS}:camera_depth", params={"sensor": "head"}),
+                },
+            )
+        }
+    )
+    mgr = ObservationManager(cfg, env, device="cpu")
+    dims = mgr.get_obs_dims()["image"]
+    assert dims == {"head_rgb": (4, 6, 3), "head_depth": (4, 6, 1)}
+
+
+def test_image_term_in_concatenate_group_is_rejected():
+    env, _, _ = _make_env()
+    cfg = ObservationManagerCfg(
+        groups={
+            "bad": ObsGroupCfg(
+                concatenate=True,
+                terms={"head_rgb": ObsTermCfg(func=f"{_TERMS}:camera_rgb", params={"sensor": "head"})},
+            )
+        }
+    )
+    mgr = ObservationManager(cfg, env, device="cpu")
+    with pytest.raises(ValueError, match="concatenate=True group 'bad'"):
+        mgr.get_obs_dims()
+    with pytest.raises(ValueError, match="concatenate=True group 'bad'"):
+        mgr.compute()
+
+
+def test_rgb_term_transform_to_chw_float_for_policy():
+    """A transform param reshapes the term to the CHW float [0,1] a visual policy expects, and
+    get_obs_dims reports the transformed shape."""
+    env, _, _ = _make_env(num_envs=2, h=8, w=6)
+    transform = {"resize": [4, 4], "layout": "CHW", "scale": "float01"}
+    cfg = ObservationManagerCfg(
+        groups={
+            "image": ObsGroupCfg(
+                concatenate=False,
+                terms={
+                    "head_rgb": ObsTermCfg(
+                        func=f"{_TERMS}:camera_rgb", params={"sensor": "head", "transform": transform}
+                    )
+                },
+            )
+        }
+    )
+    mgr = ObservationManager(cfg, env, device="cpu")
+    out = mgr.compute()["image"]["head_rgb"]
+    assert tuple(out.shape) == (2, 3, 4, 4) and out.dtype == torch.float32
+    assert float(out.min()) >= 0.0 and float(out.max()) <= 1.0
+    assert mgr.get_obs_dims()["image"]["head_rgb"] == (3, 4, 4)

--- a/src/holosoma/holosoma/simulator/base_simulator/base_simulator.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/base_simulator.py
@@ -22,6 +22,7 @@ from holosoma.utils.simulator_config import SimulatorType, get_simulator_type
 
 if TYPE_CHECKING:
     from holosoma.simulator.shared.camera_controller import CameraController
+    from holosoma.simulator.shared.camera_sensor import SensorManager
     from holosoma.simulator.shared.simulator_bridge import SimulatorBridge
     from holosoma.simulator.shared.video_recorder import VideoRecorderInterface
     from holosoma.simulator.shared.virtual_gantry import VirtualGantry
@@ -168,6 +169,7 @@ class BaseSimulator:
         self.training_config = tyro_config.training
         self.simulator_config = tyro_config.simulator
         self.scene_config = tyro_config.scene
+        self.sensor_config = tyro_config.sensors
         self.robot_config = tyro_config.robot
         self.video_config = tyro_config.logger.video
         self.sim_device = device
@@ -175,6 +177,10 @@ class BaseSimulator:
         self.debug_viz_enabled = self.simulator_config.debug_viz
         self.object_registry = ObjectRegistry(device)
         self.hooks = HookRegistry(base_rates=self._hook_base_rates())
+        # Register camera rendering FIRST (before the plugins below), so on FRAME_END cameras render
+        # before any camera-consumer plugin (egress/viz/video) reads. No-ops until a backend builds
+        # sensor_manager during setup; harmless when no cameras are configured.
+        self.hooks.add(Phase.FRAME_END, self.render_sensors, name="sensors.render")
         # Build plugins from tyro_config.plugin and keep the instances alive (key -> plugin).
         # Constructing each here registers its hooks on self.hooks, so they fire on later
         # emit(). The `none` preset disables a slot.
@@ -196,6 +202,10 @@ class BaseSimulator:
 
         # Bridge system
         self.bridge: SimulatorBridge | None = None
+
+        # Mounted-camera sensors, populated by each backend during its own sensor setup (None until
+        # then, and when no cameras are configured). The render_sensors hook above no-ops until it exists.
+        self.sensor_manager: SensorManager | None = None
 
         # To be overridden by subclasses
         self.height_samples = None
@@ -602,6 +612,12 @@ class BaseSimulator:
         self._closed = True
         self.hooks.emit(Phase.CLOSE)
 
+    def _stop_bridge(self) -> None:
+        """Tear down the bridge if enabled (joins the multiprocess Unitree DDS child). Safe if unset."""
+        if self.bridge is not None:
+            self.bridge.close()
+            self.bridge = None
+
     # ----- Actor/Object Access Interface -----
     # These methods provide unified access to objects registered with ObjectType enum
 
@@ -742,6 +758,85 @@ class BaseSimulator:
             return
         zeros = torch.zeros(poses.shape[0], 6, device=poses.device, dtype=poses.dtype)
         self.set_actor_states(list(names), env_ids, torch.cat([poses, zeros], dim=1))
+
+    # ----- Sensor (camera) interface -----
+
+    def render_sensors(self) -> None:
+        """Render all due cameras once, at control frequency, into their cached buffers.
+
+        Called once per control step from the task loop (after sim tensors refresh, before
+        observations compute), honoring each camera's ``update_decimation``. Consumers then do
+        cheap cached reads via :meth:`get_camera_data`."""
+        raise NotImplementedError("The 'render_sensors' method must be implemented in subclasses.")
+
+    def get_camera_data(
+        self,
+        name: str,
+        data_type: str = "rgb",
+        env_ids: EnvIds | None = None,
+        device: torch.device | str | None = None,
+    ) -> torch.Tensor:
+        """Read a camera's most-recent output.
+
+        Output format:
+
+        - **Shape** ``[len(env_ids), H, W, C]``, environment axis FIRST.
+        - **Layout** HWC, row-major: row 0 = TOP of the image, column 0 = LEFT.
+        - **rgb**: ``torch.uint8`` in ``[0, 255]``, channel order **R, G, B** (C=3).
+        - **depth**: ``torch.float32`` meters, distance-to-image-plane, ``+inf`` for no-hit, C=1.
+        - **device**: ``device`` if given, else ``self.sim_device``.
+        - **Optical frame**: camera looks down its local ``-Z``, ``+Y`` up; the
+          mount offset is applied in the mount-body frame.
+
+        Parameters
+        ----------
+        name : str
+            Sensor name (the ``CameraSensorConfig.name`` key).
+        data_type : str, default="rgb"
+            Modality to read: ``"rgb"`` or ``"depth"``. Must be in the camera's ``data_types``.
+        env_ids : EnvIds | None, default=None
+            Absolute environment indices into ``[0, num_envs)`` to return (every camera renders
+            all envs, so these index the full buffer); ``None`` returns all environments.
+        device : torch.device | str | None, default=None
+            Where to return the tensor. ``None`` keeps the sim device (no copy). Any other device
+            (e.g. ``"cpu"``) returns a cached cross-device copy of the FULL buffer: the first caller
+            per ``(data_type, device)`` this render pays the transfer, later callers reuse it (so
+            several egress consumers reading the same camera on host cost one device->host sync, not
+            one each). The returned tensor is **read-only** — do not mutate it in place; it is shared.
+
+        Raises
+        ------
+        NotImplementedError
+            If the backend has no camera support (no ``sensor_manager``).
+        """
+        if self.sensor_manager is None or not self.sensor_manager.has_camera(name):
+            raise NotImplementedError(
+                f"{type(self).__name__} has no camera '{name}'. Created cameras: {self.get_sensor_names()}."
+            )
+        runtime = self.sensor_manager.get(name)
+        if data_type not in runtime.buffers:
+            raise RuntimeError(
+                f"Camera '{name}' has no '{data_type}' frame. Ensure '{data_type}' is in the camera's "
+                f"data_types and render_sensors() has run. Buffered: {sorted(runtime.buffers)}."
+            )
+        buf = runtime.buffer_on(data_type, device)
+        return buf if env_ids is None else buf[env_ids]
+
+    def get_sensor_names(self) -> list[str]:
+        """Names of all created sensors, or ``[]`` if none."""
+        if self.sensor_manager is None:
+            return []
+        return self.sensor_manager.names
+
+    def sensor_config_by_name(self, name: str):
+        """The ``CameraSensorConfig`` for ``name`` from the active mounted-camera dict.
+
+        Used by camera-consumer hooks (egress) to read a camera's intrinsics. Raises if unknown.
+        """
+        cam = self.sensor_config.get(name)
+        if cam is None:
+            raise KeyError(f"No camera named '{name}'. Defined cameras: {list(self.sensor_config)}.")
+        return cam
 
     # Explicit names-based methods
     def get_actor_states_by_names(self, names: ActorNames, env_ids: EnvIds) -> ActorStates:

--- a/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
+++ b/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import math
 import sys
 from pathlib import Path
 from typing import Any
@@ -32,8 +33,14 @@ from holosoma.simulator.shared.virtual_gantry import (
 from holosoma.simulator.types import ActorIndices, ActorNames, ActorPoses, ActorStates, EnvIds
 from holosoma.utils.draw import draw_line, draw_sphere
 from holosoma.utils.module_utils import get_holosoma_root
+from holosoma.utils.rotations import quat_mul
 from holosoma.utils.safe_torch_import import torch
 from holosoma.utils.torch_utils import to_torch, torch_rand_float
+
+# Change-of-basis quaternion (xyzw) from the holosoma camera frame (-Z fwd / +Y up) to
+# IsaacGym's native camera frame (+X fwd / +Z up): the rotation sending +X->-Z, +Z->+Y, +Y->-X.
+# MuJoCo/IsaacSim use the -Z fwd / +Y up frame directly.
+_CANONICAL_TO_ISAACGYM_XYZW = (0.5, -0.5, -0.5, -0.5)
 
 
 class Scene:
@@ -138,11 +145,14 @@ class IsaacGym(BaseSimulator):
         else:
             self.device = "cpu"
 
+        # Cameras (video recorder or perception sensors) need a graphics context even when
+        # headless; without it create_camera_sensor returns no image (black frame).
+        self._cameras_enabled = self.video_config.enabled or bool(self.sensor_config)
         self.graphics_device_id = self.sim_device_id
-        if self.headless and not self.video_config.enabled:
+        if self.headless and not self._cameras_enabled:
             self.graphics_device_id = -1
-        elif self.video_config.enabled:
-            logger.info("Video recording enabled: keeping graphics enabled for camera support")
+        elif self._cameras_enabled:
+            logger.info("Cameras enabled: keeping graphics enabled for camera sensor support")
 
         if self.video_config.enabled:
             self.video_recorder = IsaacGymVideoRecorder(self.video_config, self)
@@ -390,6 +400,9 @@ class IsaacGym(BaseSimulator):
         # get/set_actor_states API works on every backend.
         self._register_objects()
 
+        # Register the per-env camera handles into the SensorManager.
+        self._create_sensors()
+
         # Invoke startup randomization for domain randomization
         # This must happen AFTER all envs are created but BEFORE prepare_sim()
         self._invoke_startup_randomization()
@@ -497,6 +510,151 @@ class IsaacGym(BaseSimulator):
             self.object_handles[object_name].append(object_handle)
             object_idx = self.gym.get_actor_index(env_ptr, object_handle, gymapi.DOMAIN_SIM)
             self.gym_object_indices[object_name].append(object_idx)
+
+        # Mounted cameras for this env: created per-env and attached to the mount body so they
+        # follow it. IsaacGym has no batched camera: one sensor per env. The handle lists span all
+        # envs (parallel to self.envs), so initialize them once and append per env.
+        if env_id == 0:
+            self._camera_handles: dict[str, list[Any]] = {name: [] for name in self.sensor_config}
+        self._build_env_cameras(env_id, env_ptr, robot_handle)
+
+    # ----- Camera sensors -----
+
+    def _resolve_mount_body_handle(self, env_ptr, robot_handle, mount):
+        """Return the rigid-body handle for a sensor mount within ``env_ptr``.
+
+        ``robot_link`` -> a named robot link (name the root link to mount on the base);
+        ``actor`` -> a scene actor's (single) body. Uses IsaacGym's per-actor body lookup.
+        """
+        if mount.target_kind == "robot_link":
+            body_name = mount.target
+            handle = self.gym.find_actor_rigid_body_handle(env_ptr, robot_handle, body_name)
+            if handle < 0:
+                raise ValueError(f"Camera robot mount body '{body_name}' not found in robot bodies {self._body_list}.")
+            return handle
+        if mount.target_kind == "actor":
+            actor_handles = self.object_handles.get(mount.target)
+            if not actor_handles:
+                raise ValueError(f"Camera actor mount '{mount.target}' is not a registered scene object.")
+            actor_handle = actor_handles[-1]  # the handle just built for this env
+            body_name = self.gym.get_actor_rigid_body_names(env_ptr, actor_handle)[0]
+            return self.gym.find_actor_rigid_body_handle(env_ptr, actor_handle, body_name)
+        raise ValueError(f"Unknown camera mount target_kind '{mount.target_kind}'.")
+
+    def _build_env_cameras(self, env_id, env_ptr, robot_handle):
+        """Create and body-attach one camera sensor per configured camera, for this env."""
+        for cam_name, cam in self.sensor_config.items():
+            props = gymapi.CameraProperties()
+            props.width = cam.width
+            props.height = cam.height
+            props.enable_tensors = True  # GPU image tensors (zero-copy read)
+            props.near_plane = cam.near  # agnostic-core clipping, honored on every backend
+            props.far_plane = cam.far
+            # IsaacGym takes a horizontal fov; derive it from the vertical fov and aspect.
+            aspect = cam.width / cam.height
+            props.horizontal_fov = math.degrees(2 * math.atan(math.tan(math.radians(cam.vertical_fov) / 2) * aspect))
+            ig = cam.isaacgym
+            if ig and ig.supersampling_horizontal is not None:
+                props.supersampling_horizontal = ig.supersampling_horizontal
+            if ig and ig.supersampling_vertical is not None:
+                props.supersampling_vertical = ig.supersampling_vertical
+            if ig and ig.use_collision_geometry is not None:
+                props.use_collision_geometry = ig.use_collision_geometry
+
+            cam_handle = self.gym.create_camera_sensor(env_ptr, props)
+            if cam_handle < 0:
+                raise RuntimeError(f"IsaacGym failed to create camera sensor '{cam_name}' (graphics disabled?).")
+
+            local_tf = self._mount_to_isaacgym_transform(cam.mount)
+            if cam.mount.target_kind == "world":
+                # Free-floating: place at the env-local pose and leave it fixed (no body to follow).
+                # Unlike attach_camera_to_body, set_camera_transform takes a WORLD transform (the
+                # env_ptr only selects which env's camera, it does not offset the pose), so add this
+                # env's origin — otherwise every env's world camera lands near the global origin and
+                # only env 0 (origin [0,0,0]) frames its scene; envs 1..N look at empty space.
+                origin = self.env_origins[env_id]
+                world_tf = gymapi.Transform(
+                    p=gymapi.Vec3(
+                        local_tf.p.x + float(origin[0]),
+                        local_tf.p.y + float(origin[1]),
+                        local_tf.p.z + float(origin[2]),
+                    ),
+                    r=local_tf.r,
+                )
+                self.gym.set_camera_transform(cam_handle, env_ptr, world_tf)
+            else:
+                body_handle = self._resolve_mount_body_handle(env_ptr, robot_handle, cam.mount)
+                self.gym.attach_camera_to_body(cam_handle, env_ptr, body_handle, local_tf, gymapi.FOLLOW_TRANSFORM)
+            self._camera_handles[cam_name].append(cam_handle)
+
+    def _mount_to_isaacgym_transform(self, mount) -> gymapi.Transform:
+        """Mount (pos + w-first quat, -Z fwd/+Y up) to an IsaacGym local Transform.
+
+        Composes the mount orientation with the change-of-basis so the camera looks where the
+        mount intends on IsaacGym's native (+X fwd / +Z up) optical axis.
+        """
+        wxyz = torch.tensor([mount.orientation], dtype=torch.float32)  # [1,4] w,x,y,z
+        xyzw = wxyz[:, [1, 2, 3, 0]]
+        basis = torch.tensor([_CANONICAL_TO_ISAACGYM_XYZW], dtype=torch.float32)
+        native_xyzw = quat_mul(xyzw, basis, w_last=True)[0]
+        tf = gymapi.Transform()
+        tf.p = gymapi.Vec3(*mount.position)
+        tf.r = gymapi.Quat(float(native_xyzw[0]), float(native_xyzw[1]), float(native_xyzw[2]), float(native_xyzw[3]))
+        return tf
+
+    def _create_sensors(self) -> None:
+        """Register the per-env camera handles (built in the env loop) into the SensorManager."""
+        cameras = self.sensor_config
+        if not cameras:
+            return
+        from holosoma.simulator.shared.camera_sensor import SensorManager
+
+        # IsaacGym uses self.device (may be "cpu").
+        sim = self.simulator_config.sim
+        self.sensor_manager = SensorManager(self.device, control_hz=sim.fps / sim.control_decimation_steps)
+        for cam_name, cam in cameras.items():
+            self.sensor_manager.register_camera(cam_name, cam)
+
+    def render_sensors(self) -> None:
+        """Render all camera sensors once (per control step), honoring update_decimation."""
+        if self.sensor_manager is None:
+            return
+        due = self.sensor_manager.collect_due()
+        if not due:
+            return
+        # Update the graphics scene from the latest physics state, then render all camera sensors
+        # in one pass. fetch_results + step_graphics are required before render or the image is
+        # blank (same sequence the video recorder uses).
+        self.gym.fetch_results(self.sim, True)
+        self.gym.step_graphics(self.sim)
+        self.gym.render_all_camera_sensors(self.sim)
+        self.gym.start_access_image_tensors(self.sim)
+        try:
+            for runtime in due:
+                handles = self._camera_handles[runtime.name]  # per-env handles (parallel to self.envs)
+                if "rgb" in runtime.config.data_types:
+                    frames = []
+                    for e in range(self.num_envs):
+                        # IsaacGym IMAGE_COLOR is RGBA uint8 [H,W,4] on GPU (channel 0 = R); drop
+                        # alpha to get R,G,B.
+                        gpu_t = self.gym.get_camera_image_gpu_tensor(
+                            self.sim, self.envs[e], handles[e], gymapi.IMAGE_COLOR
+                        )
+                        frames.append(gymtorch.wrap_tensor(gpu_t)[..., :3].clone())  # [H,W,4] RGBA -> RGB
+                    runtime.set_buffer("rgb", torch.stack(frames, dim=0).to(self.device))  # [N,H,W,3]
+                if "depth" in runtime.config.data_types:
+                    frames = []
+                    for e in range(self.num_envs):
+                        # IsaacGym IMAGE_DEPTH is [H,W] float32, negative distance along the camera
+                        # axis (looks down -Z) with -inf for no-hit. Negate to get positive
+                        # meters; -inf becomes the +inf no-hit sentinel.
+                        gpu_t = self.gym.get_camera_image_gpu_tensor(
+                            self.sim, self.envs[e], handles[e], gymapi.IMAGE_DEPTH
+                        )
+                        frames.append((-gymtorch.wrap_tensor(gpu_t)).clone())  # [H,W] +meters, +inf no-hit
+                    runtime.set_buffer("depth", torch.stack(frames, dim=0).unsqueeze(-1).to(self.device))  # [N,H,W,1]
+        finally:
+            self.gym.end_access_image_tensors(self.sim)
 
     def _process_rigid_shape_props(self, props, env_id):
         """No-op. Randomization manager will handle friction domain randomization."""

--- a/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import copy
 import dataclasses
+import math
 import os
 import xml.etree.ElementTree as ET
 from typing import Any
@@ -23,7 +24,15 @@ from isaaclab.envs import ViewerCfg, mdp
 from isaaclab.managers import EventManager, SceneEntityCfg
 from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.scene import InteractiveScene, InteractiveSceneCfg
-from isaaclab.sensors import ContactSensor, ContactSensorCfg, RayCaster, RayCasterCfg, patterns
+from isaaclab.sensors import (
+    ContactSensor,
+    ContactSensorCfg,
+    RayCaster,
+    RayCasterCfg,
+    TiledCamera,
+    TiledCameraCfg,
+    patterns,
+)
 from isaaclab.sim import PhysxCfg, SimulationCfg, SimulationContext
 from isaaclab.sim.utils import bind_physics_material
 from isaaclab.terrains import TerrainGeneratorCfg, TerrainImporterCfg
@@ -153,18 +162,19 @@ class IsaacSim(BaseSimulator):
         # generate scene
         with Timer("[INFO]: Time taken for scene creation", "scene_creation"):
             # Narrow the type from the base class's SceneInterface (which declares only
-            # env_origins) to IsaacLab's InteractiveScene — what self.scene actually is on this
-            # backend — so the rich .rigid_objects/.articulations/.sensors/... accesses below
+            # env_origins) to IsaacLab's InteractiveScene, what self.scene actually is on this
+            # backend, so the rich .rigid_objects/.articulations/.sensors/... accesses below
             # type-check. The base protocol stays correct for MuJoCo/IsaacGym, whose scenes
-            # genuinely implement only env_origins.
+            # implement only env_origins.
             self.scene: InteractiveScene = InteractiveScene(scene_config)
             self._setup_scene()
         print("[INFO]: Scene manager: ", self.scene)
 
+        viewer_config: ViewerCfg
         if self.simulator_config.viewer.enable_tracking:
-            viewer_config: ViewerCfg = ViewerCfg(origin_type="asset_root", asset_name="robot", eye=(0.0, -1.5, 1.5))
+            viewer_config = ViewerCfg(origin_type="asset_root", asset_name="robot", eye=(0.0, -1.5, 1.5))
         else:
-            viewer_config: ViewerCfg = ViewerCfg()
+            viewer_config = ViewerCfg()
 
         if self.sim.render_mode >= self.sim.RenderMode.PARTIAL_RENDERING:
             self.viewport_camera_controller: ViewportCameraController | None = ViewportCameraController(
@@ -498,6 +508,10 @@ class IsaacSim(BaseSimulator):
             self._height_scanner = RayCaster(height_scanner_config)
             self.scene.sensors["height_scanner"] = self._height_scanner
 
+        # Perception cameras: one TiledCamera per configured camera, as a child prim of its
+        # mount body so it follows that body, created before clone so it replicates per env.
+        self._create_sensors_pre_clone()
+
         # clone, filter, and replicate
         self.scene.clone_environments(copy_from_source=False)
 
@@ -512,6 +526,122 @@ class IsaacSim(BaseSimulator):
             color=(0.98, 0.95, 0.88),
         )
         light_config1.func("/World/DomeLight", light_config1, translation=(1, 0, 10))
+
+        # Register the TiledCameras (built pre-clone above) into the shared SensorManager. Done
+        # here at the end of scene build (IsaacSim builds its scene in __init__, not load_assets).
+        self._create_sensors()
+
+    # ----- Camera sensors (TiledCamera; child prim of the mount body, auto-follow) -----
+
+    def _camera_mount_prim_path(self, mount) -> str:
+        """Resolve a sensor mount to a per-env camera prim path (parent = the mount body prim).
+
+        ``robot_link`` -> a robot link prim (name the root link to mount on the base);
+        ``actor`` -> a spawned scene-object prim. The camera prim is created as a child of this
+        path so the USD transform hierarchy makes it follow the body natively.
+        """
+        ns = "/World/envs/env_.*"
+        if mount.target_kind == "robot_link":
+            valid = self.robot_config.body_names
+            if mount.target not in valid:
+                raise ValueError(f"Camera robot_link '{mount.target}' not a robot body. Known: {valid}.")
+            return f"{ns}/Robot/{mount.target}"
+        if mount.target_kind == "actor":
+            return f"{ns}/{mount.target}"
+        if mount.target_kind == "world":
+            # Free-floating: child of the env prim itself, so the mount offset is the pose in the
+            # per-env frame (each cloned env carries its own copy at the same relative pose).
+            return ns
+        raise ValueError(f"Unknown camera mount target_kind '{mount.target_kind}'.")
+
+    def _create_sensors_pre_clone(self) -> None:
+        """Build a TiledCamera per configured camera (before clone, so each replicates per env).
+
+        The camera optical convention is OpenGL (-Z forward, +Y up), the same frame holosoma uses,
+        so the mount offset passes through with ``convention="opengl"`` and no extra rotation.
+        Mount quat is the config-layer ``[w,x,y,z]`` (IsaacLab OffsetCfg.rot is also w-first).
+        """
+        self._tiled_cameras = {}
+        for cam_name, cam in self.sensor_config.items():
+            parent = self._camera_mount_prim_path(cam.mount)
+            # Map holosoma data_types -> IsaacLab annotators.
+            annotators = [{"rgb": "rgb", "depth": "distance_to_image_plane"}[d] for d in cam.data_types]
+            cam_cfg = TiledCameraCfg(
+                prim_path=f"{parent}/{cam_name}",
+                offset=TiledCameraCfg.OffsetCfg(
+                    pos=tuple(cam.mount.position),
+                    rot=tuple(cam.mount.orientation),  # (w, x, y, z)
+                    convention="opengl",  # -Z forward / +Y up, the frame holosoma uses
+                ),
+                data_types=annotators,
+                spawn=self._pinhole_cfg_for(cam),
+                width=cam.width,
+                height=cam.height,
+                # No-hit / beyond-far depth handling, done natively by the TiledCamera.
+                depth_clipping_behavior=(cam.isaacsim.depth_clipping_behavior if cam.isaacsim is not None else "none"),
+            )
+            self._tiled_cameras[cam_name] = TiledCamera(cam_cfg)
+            self.scene.sensors[cam_name] = self._tiled_cameras[cam_name]
+
+    def _pinhole_cfg_for(self, cam):
+        """Build a PinholeCameraCfg honoring the configured vertical FOV.
+
+        IsaacLab derives the rendered FOV from the aperture/focal-length pair; for a fixed
+        focal length, vertical_aperture = 2*f*tan(vfov/2) sets the vertical FOV, and
+        horizontal_aperture = vertical_aperture * (width/height) keeps square pixels (so a
+        square sensor has equal horizontal and vertical FOV).
+        """
+        isaacsim_cfg = cam.isaacsim
+        focal_length = isaacsim_cfg.focal_length if (isaacsim_cfg and isaacsim_cfg.focal_length) else 24.0
+        v_aperture = 2.0 * focal_length * math.tan(math.radians(cam.vertical_fov) / 2)
+        h_aperture = v_aperture * (cam.width / cam.height)
+        kwargs = dict(
+            focal_length=focal_length,
+            clipping_range=(cam.near, cam.far),
+            vertical_aperture=v_aperture,
+            horizontal_aperture=h_aperture,
+        )
+        # Physically-based depth-of-field (IsaacSim-only): f_stop>0 enables defocus blur.
+        if isaacsim_cfg and isaacsim_cfg.f_stop is not None:
+            kwargs["f_stop"] = isaacsim_cfg.f_stop
+        if isaacsim_cfg and isaacsim_cfg.focus_distance is not None:
+            kwargs["focus_distance"] = isaacsim_cfg.focus_distance
+        return sim_utils.PinholeCameraCfg(**kwargs)
+
+    def _create_sensors(self) -> None:
+        """Register the TiledCameras (built pre-clone) into the shared SensorManager."""
+        cameras = self.sensor_config
+        if not cameras:
+            return
+        from holosoma.simulator.shared.camera_sensor import SensorManager
+
+        sim = self.simulator_config.sim
+        self.sensor_manager = SensorManager(self.sim_device, control_hz=sim.fps / sim.control_decimation_steps)
+        for cam_name, cam in cameras.items():
+            self.sensor_manager.register_camera(cam_name, cam)
+
+    def render_sensors(self) -> None:
+        """Cache each due TiledCamera's RGB as a ``[N,H,W,3]`` uint8 frame into its buffer.
+
+        TiledCameras are RTX sensors the sim already updates in its own render pass
+        (``scene.update`` in ``simulate_at_each_physics_step``); this reads that output, drops
+        alpha, and writes a ``[N,H,W,3]`` uint8 frame once per control step (honoring
+        ``update_decimation``), mirroring the other backends' render -> buffer -> read flow."""
+        if self.sensor_manager is None:
+            return
+        for runtime in self.sensor_manager.collect_due():
+            out = self._tiled_cameras[runtime.name].data.output
+            if "rgb" in runtime.config.data_types:
+                rgb = out["rgb"][..., :3]  # [N,H,W,3], drop alpha
+                if rgb.dtype != torch.uint8:
+                    rgb = rgb.clamp(0, 255).to(torch.uint8)
+                runtime.set_buffer("rgb", rgb)
+            if "depth" in runtime.config.data_types:
+                # distance_to_image_plane is float32 meters, image-plane. No-hit handling (raw +inf,
+                # clamp to far, or zero) is done by the TiledCamera itself via depth_clipping_behavior
+                # (see _tiled_camera_cfg). Ensure a trailing channel dim -> [N,H,W,1].
+                depth = out["distance_to_image_plane"].to(torch.float32)
+                runtime.set_buffer("depth", depth if depth.ndim == 4 else depth.unsqueeze(-1))
 
     def _get_base_body_name(self, preference_order: list[str]) -> str:
         """Get the base body name with fallback logic.

--- a/src/holosoma/holosoma/simulator/mujoco/backends/base.py
+++ b/src/holosoma/holosoma/simulator/mujoco/backends/base.py
@@ -17,6 +17,7 @@ import torch
 if TYPE_CHECKING:
     from holosoma.config_types.full_sim import FullSimConfig
     from holosoma.simulator.mujoco.tensor_views import BaseMujocoView
+    from holosoma.simulator.shared.camera_sensor import CameraRuntime
 
 
 def mj_to_holosoma_quat(quat_wxyz: np.ndarray | torch.Tensor) -> np.ndarray | torch.Tensor:
@@ -27,6 +28,26 @@ def mj_to_holosoma_quat(quat_wxyz: np.ndarray | torch.Tensor) -> np.ndarray | to
 def holosoma_to_mj_quat(quat_xyzw: np.ndarray | torch.Tensor) -> np.ndarray | torch.Tensor:
     """Convert holosoma ``[x,y,z,w]`` to MuJoCo ``[w,x,y,z]`` (last-axis permute; numpy or torch)."""
     return quat_xyzw[..., [3, 0, 1, 2]]
+
+
+def apply_sensor_scene_flags(show_camera_frusta: bool, opt: mujoco.MjvOption | None = None) -> mujoco.MjvOption:
+    """Set MuJoCo mounted-camera scene-visualization flags and return the option.
+
+    Draws each configured camera's view frustum in the spectator viewer / recorded video. Gated by
+    the simulator's ``debug_viz`` flag (this is debug visualization, not a sink config).
+
+    Parameters
+    ----------
+    show_camera_frusta : bool
+        Whether to draw the camera frusta (typically ``simulator.debug_viz_enabled``).
+    opt : mujoco.MjvOption | None
+        Option to mutate in place; ``None`` builds a fresh defaulted one. Returned either way.
+    """
+    if opt is None:
+        opt = mujoco.MjvOption()
+        mujoco.mjv_defaultOption(opt)
+    opt.flags[mujoco.mjtVisFlag.mjVIS_CAMERA] = show_camera_frusta
+    return opt
 
 
 class IMujocoBackend(abc.ABC):
@@ -377,5 +398,31 @@ class IMujocoBackend(abc.ABC):
         -------
         BaseMujocoView
             View for angular velocity [num_envs, 3]
+        """
+        ...
+
+    # Camera rendering
+    @abc.abstractmethod
+    def create_renderers(self, cameras: list[CameraRuntime]) -> None:
+        """Allocate per-backend rendering resources for the mounted cameras (called once at setup).
+
+        Parameters
+        ----------
+        cameras : list[CameraRuntime]
+            All registered cameras; the backend resolves each native resource from ``runtime.name``.
+        """
+        ...
+
+    @abc.abstractmethod
+    def render_cameras(self, cameras: list[CameraRuntime]) -> None:
+        """Render the given cameras and store each one's canonical output buffer.
+
+        Writes each modality via ``runtime.set_buffer(data_type, tensor)``:
+        ``rgb`` [N,H,W,3] uint8, ``depth`` [N,H,W,1] float32 meters (+inf no-hit), on ``self.device``.
+
+        Parameters
+        ----------
+        cameras : list[CameraRuntime]
+            The cameras due to render this step (a subset of those passed to ``create_renderers``).
         """
         ...

--- a/src/holosoma/holosoma/simulator/mujoco/backends/classic_backend.py
+++ b/src/holosoma/holosoma/simulator/mujoco/backends/classic_backend.py
@@ -18,7 +18,9 @@ from .base import IMujocoBackend, holosoma_to_mj_quat, mj_to_holosoma_quat
 
 if TYPE_CHECKING:
     from holosoma.config_types.full_sim import FullSimConfig
+    from holosoma.config_types.sensor import CameraDataType
     from holosoma.simulator.mujoco.tensor_views import BaseMujocoView
+    from holosoma.simulator.shared.camera_sensor import CameraRuntime
 
 
 class ClassicBackend(IMujocoBackend):
@@ -86,6 +88,50 @@ class ClassicBackend(IMujocoBackend):
             The backend's data structure (no copy needed)
         """
         return self.data
+
+    def create_renderers(self, cameras: list[CameraRuntime]) -> None:
+        # Per-camera renderer (classic only), keyed by camera NAME:
+        # mujoco.Renderer is RGB XOR depth, so depth cameras get a SEPARATE depth-enabled renderer
+        # (per size); MuJoCo 3.x depth is already metric meters (image-plane), so no unit scaling.
+        # Resolve each compiled <camera> id here (this backend's own name->id map); the shared
+        # CameraRuntime holds no handle.
+        self._cam_ids: dict[str, int] = {}
+        self._mj_renderers: dict[str, dict[CameraDataType, mujoco.Renderer]] = {}
+
+        for cam in cameras:
+            name = cam.name
+            cam_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_CAMERA, name)
+            if cam_id < 0:
+                raise RuntimeError(f"Camera '{name}' not found in compiled model (expected a <camera> element).")
+            self._cam_ids[name] = cam_id
+            cam_renderers = self._mj_renderers[name] = {}
+            for data_type in cam.config.data_types:
+                renderer = mujoco.Renderer(self.model, height=cam.config.height, width=cam.config.width)
+                cam_renderers[data_type] = renderer
+                if data_type == "depth":
+                    renderer.enable_depth_rendering()
+
+    def render_cameras(self, cameras: list[CameraRuntime]) -> None:
+        # per-world render via the size-shared mujoco.Renderer (num_envs==1).
+        # No-hit reads the global far-clip plane (vis.map.zfar * extent, set across all cameras in
+        # the simulator's _create_sensors); remap it to +inf. The far value comes back ~0.1% under
+        # nominal (limited depth precision), so threshold at 0.99*far.
+        far_clip = float(self.model.vis.map.zfar) * float(self.model.stat.extent)
+        for runtime in cameras:
+            name = runtime.name
+            cam_id = self._cam_ids[name]
+            for dt in runtime.config.data_types:
+                renderer = self._mj_renderers[name][dt]
+                frames = []
+                for world_id in range(self.num_envs):
+                    data = self.get_render_data(world_id=world_id)
+                    renderer.update_scene(data, camera=cam_id)
+                    frame = renderer.render()  # rgb: [H,W,3] uint8; depth: [H,W] float32 meters
+                    t = torch.from_numpy((frame[..., None] if dt == "depth" else frame).copy())
+                    if dt == "depth":
+                        t = torch.where(t >= far_clip * 0.99, torch.full_like(t, float("inf")), t)
+                    frames.append(t)
+                runtime.set_buffer(dt, torch.stack(frames, dim=0).to(self.device))  # [N,H,W,C]
 
     def get_ctrl_tensor(self) -> None:
         """Classic backend doesn't support direct tensor writes.

--- a/src/holosoma/holosoma/simulator/mujoco/backends/warp_backend.py
+++ b/src/holosoma/holosoma/simulator/mujoco/backends/warp_backend.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import mujoco
+import mujoco_warp as mjw
+import numpy as np
 import torch
 import warp as wp
 from loguru import logger
@@ -45,6 +47,7 @@ from .warp_bridge import WarpBridge
 if TYPE_CHECKING:
     from holosoma.config_types.full_sim import FullSimConfig
     from holosoma.simulator.mujoco.tensor_views import BaseMujocoView
+    from holosoma.simulator.shared.camera_sensor import CameraRuntime
 
 
 # Quaternion helpers on MuJoCo-convention (wxyz, scalar-first) quaternions, reimplemented locally so
@@ -235,7 +238,7 @@ class WarpBackend(IMujocoBackend):
         # collision kernels that read m.geom_friction / m.body_mass etc. per world) reference the
         # SAME per-world arrays the runtime writers update. expand_model_fields reallocates these
         # arrays; doing it after capture would leave the captured kernels reading the single-world
-        # copy while domain-randomization / static-move writes hit the new (orphaned) array — the
+        # copy while domain-randomization / static-move writes hit the new (orphaned) array: the
         # value would read back changed but never affect the stepped dynamics. Idempotent, so the
         # later prepare_fields()/in-place writes never reallocate.
         #
@@ -257,6 +260,12 @@ class WarpBackend(IMujocoBackend):
                 "body_inertia",
                 "body_ipos",
                 "dof_damping",  # mass/inertia/com/damping DR
+                # cam_pos so a world-mount camera (worldbody child, cam_bodyid==0) can be placed at
+                # each env's origin. The camlight kernel (inside the captured step graph) reads
+                # cam_pos per world to compute cam_xpos, so it MUST be expanded before capture;
+                # offset_world_cameras() then writes each env's origin post-capture (same pre-expand /
+                # post-write pattern as body_pos + set_static_body_world_pose).
+                "cam_pos",
             ]
             with wp.ScopedDevice(self.mjw_device):
                 expand_model_fields(self.mjw_model, nworld=self.num_envs, fields_to_expand=_PER_WORLD_FIELDS)
@@ -366,6 +375,118 @@ class WarpBackend(IMujocoBackend):
             mjw.get_data_into(self.render_data, self.model, self.mjw_data, world_id=world_id)
 
         return self.render_data
+
+    def create_renderers(self, cameras: list[CameraRuntime]) -> None:
+        # Appearance flags are GLOBAL to the shared render context (not per-camera);
+        # validate_camera_dict already rejected any cross-camera conflict, so
+        # collecting each set (non-None) value is unambiguous regardless of order. None => default.
+        render_options: dict = {}
+        for cam in cameras:
+            if cam.config.mujoco is None:
+                continue
+            for attr in ("use_shadows", "use_textures", "use_precomputed_rays"):
+                value = getattr(cam.config.mujoco, attr)
+                if value is not None:
+                    render_options[attr] = value
+
+        # Per-camera modality flags in ACTIVE-camera space. cam_active is left unset, so
+        # create_render_context keeps every model camera active and the active index equals the
+        # MuJoCo camera id. Resolve each compiled <camera> id here into this backend's own name->id
+        # map (the shared CameraRuntime holds no handle). create_render_context allocates an output
+        # buffer + write address for a (camera, modality) ONLY if its flag is True at creation
+        # (io.py: rgb_adr/depth_adr stay -1 otherwise). render_cameras() can then only toggle these
+        # flags DOWN to the due subset, not up, so this enables the UNION of every modality each
+        # camera will ever produce. render_seg stays off: holosoma cameras only produce rgb/depth.
+        ncam = self.model.ncam
+        self._cam_ids: dict[str, int] = {}
+        rgb_flags = [False] * ncam
+        depth_flags = [False] * ncam
+        for cam in cameras:
+            name = cam.name
+            cam_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_CAMERA, name)
+            if not 0 <= cam_id < ncam:
+                raise RuntimeError(
+                    f"Camera '{name}' not found in compiled model (mj_name2id -> {cam_id}); "
+                    "expected a <camera> element with active id in [0, ncam)."
+                )
+            self._cam_ids[name] = cam_id
+            if "rgb" in cam.config.data_types:
+                rgb_flags[cam_id] = True
+            if "depth" in cam.config.data_types:
+                depth_flags[cam_id] = True
+
+        with wp.ScopedDevice(self.mjw_device):
+            self._render_context = mjw.create_render_context(
+                self.model,
+                nworld=self.num_envs,
+                render_rgb=rgb_flags,
+                render_depth=depth_flags,
+                render_seg=False,
+                **render_options,
+            )
+            # Preallocate per-camera output buffers (reused each render), keyed by active id
+            # (== MuJoCo cam id, from self._cam_ids). Keyed by id, not a positional list, because
+            # camera ids need not be a contiguous 0..n-1 range (the model may hold non-sensor
+            # cameras), and only the modalities a camera actually produces get a buffer.
+            self._render_rgb_out = {
+                self._cam_ids[cam.name]: wp.zeros(
+                    (self.num_envs, cam.config.height, cam.config.width), dtype=wp.vec3, device=self.mjw_device
+                )
+                for cam in cameras
+                if "rgb" in cam.config.data_types
+            }
+            self._render_depth_out = {
+                self._cam_ids[cam.name]: wp.zeros(
+                    (self.num_envs, cam.config.height, cam.config.width), dtype=wp.float32, device=self.mjw_device
+                )
+                for cam in cameras
+                if "depth" in cam.config.data_types
+            }
+            self._depth_far = max(c.config.far for c in cameras)
+
+    def render_cameras(self, cameras: list[CameraRuntime]) -> None:
+        with wp.ScopedDevice(self.mjw_device):
+            # Ensure the step graph's writes to mjw_data are complete before rendering reads them.
+            wp.synchronize()
+
+            # Toggle the per-camera modality flags DOWN to just the cameras due this step. These are
+            # device wp.array("ncam", bool) kernel inputs (NOT wp.static), so mutating their contents
+            # here (outside any graph capture) makes mjw.render render a different subset with no
+            # recompile. wp.array has no item/slice assignment, so build host masks and .assign().
+            # Only modalities the context was CREATED with may be enabled (create_renderers enabled
+            # the union); enabling one that was False at creation would write to an unallocated (-1)
+            # address. Cameras absent from `due` keep their last buffer below; render() clears the
+            # shared output every call (render.py), so a non-due camera's slice is wiped, not stale.
+            ncam = self.model.ncam
+            rgb_mask = np.zeros(ncam, dtype=bool)
+            depth_mask = np.zeros(ncam, dtype=bool)
+            for cam in cameras:
+                cam_id = self._cam_ids[cam.name]
+                if "rgb" in cam.config.data_types:
+                    rgb_mask[cam_id] = True
+                if "depth" in cam.config.data_types:
+                    depth_mask[cam_id] = True
+            self._render_context.render_rgb.assign(rgb_mask)
+            self._render_context.render_depth.assign(depth_mask)
+
+            mjw.refit_bvh(self.mjw_model, self.mjw_data, self._render_context)
+            mjw.render(self.mjw_model, self.mjw_data, self._render_context)
+
+            for cam in cameras:
+                cam_id = self._cam_ids[cam.name]
+                if "rgb" in cam.config.data_types:
+                    mjw.get_rgb(self._render_context, cam_id, self._render_rgb_out[cam_id])
+                    rgb_f = wp.to_torch(self._render_rgb_out[cam_id])  # [N,H,W,3] float32 in [0,1]
+                    cam.set_buffer("rgb", (rgb_f.clamp(0.0, 1.0) * 255.0).round().to(torch.uint8))
+                if "depth" in cam.config.data_types:
+                    # mjw.get_depth writes clamp(val/depth_scale, 0, 1): a normalized [0,1] image,
+                    # NOT meters. Pass depth_scale=depth_far so [0,far]->[0,1], then multiply back by
+                    # far to recover meters across the full range. No-hit comes back 0 ->
+                    # remap to +inf (the no-hit sentinel).
+                    mjw.get_depth(self._render_context, cam_id, self._depth_far, self._render_depth_out[cam_id])
+                    dep = wp.to_torch(self._render_depth_out[cam_id]) * self._depth_far  # [N,H,W] meters
+                    dep = torch.where(dep <= 0, torch.full_like(dep, float("inf")), dep)
+                    cam.set_buffer("depth", dep.unsqueeze(-1))  # [N,H,W,1]
 
     def get_ctrl_tensor(self) -> torch.Tensor:
         """Return control tensor for direct zero-copy writing.
@@ -662,7 +783,7 @@ class WarpBackend(IMujocoBackend):
 
     def set_actor_state(self, env_ids: torch.Tensor, states: torch.Tensor, qpos_addr: int, qvel_addr: int) -> None:
         """Write a per-env actor freejoint state to GPU storage (not a no-op on GPU)."""
-        # qpos freejoint slice is [pos(3), quat_mj(4)]; qvel is [lin(3), ang(3)] — contiguous.
+        # qpos freejoint slice is [pos(3), quat_mj(4)]; qvel is [lin(3), ang(3)], contiguous.
         pose = torch.cat([states[:, :3], holosoma_to_mj_quat(states[:, 3:7])], dim=1)  # [N, 7]
         self.qpos_t[self._batched_slice(env_ids, qpos_addr, 7)] = pose
         self.qvel_t[self._batched_slice(env_ids, qvel_addr, 6)] = states[:, 7:13]
@@ -717,6 +838,33 @@ class WarpBackend(IMujocoBackend):
             mjw.forward(self.mjw_model, self.mjw_data)  # refresh xpos/xquat from the new body_pos/quat
 
         self._sync_static_geom_xpos(body_ids, env_ids)
+
+    def offset_world_cameras(self, cam_ids: list[int], env_origins: torch.Tensor) -> None:
+        """Shift world-mount cameras' per-world ``cam_pos`` by each env's origin.
+
+        A ``target_kind="world"`` camera is a worldbody child (``cam_bodyid==0``): unlike a
+        body-attached camera, its pose does not inherit the per-env body offset, so in a multi-env
+        run every world's camera would otherwise sit at the shared spec pose and see only env 0's
+        scene. ``cam_pos`` is expanded per world in ``__init__`` (in ``_PER_WORLD_FIELDS``, before the
+        step-graph capture), and the ``camlight`` kernel that computes ``cam_xpos`` reads it per world
+        each step, so adding ``env_origins`` here — after capture — reaches the live render exactly
+        like ``set_static_body_world_pose`` writes ``body_pos``. No-op at ``num_envs==1``.
+
+        ``cam_ids`` are compiled MuJoCo camera ids (world-mount only); ``env_origins`` is
+        ``[num_envs, 3]``.
+        """
+        if self.num_envs <= 1 or not cam_ids:
+            return
+        import warp as wp
+
+        cam_pos = wp.to_torch(self.mjw_model.cam_pos)  # [num_envs, ncam, 3], shares GPU memory
+        origins = env_origins.to(cam_pos.device, cam_pos.dtype)  # [num_envs, 3]
+        for cam_id in cam_ids:
+            cam_pos[:, cam_id, :] += origins
+        with wp.ScopedDevice(self.mjw_device):
+            import mujoco_warp as mjw
+
+            mjw.forward(self.mjw_model, self.mjw_data)  # recompute cam_xpos from the shifted cam_pos
 
     def _sync_static_geom_xpos(self, body_ids: list[int], env_ids: torch.Tensor | None) -> None:
         """Refresh ``geom_xpos``/``geom_xmat`` for the geoms of welded ``body_ids``, per world.

--- a/src/holosoma/holosoma/simulator/mujoco/mujoco.py
+++ b/src/holosoma/holosoma/simulator/mujoco/mujoco.py
@@ -19,7 +19,7 @@ from holosoma.config_types.simulator import MujocoBackend
 from holosoma.managers.terrain.manager import TerrainManager
 from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
 from holosoma.simulator.mujoco.backends import WARP_AVAILABLE, ClassicBackend, WarpBackend
-from holosoma.simulator.mujoco.backends.base import mj_to_holosoma_quat
+from holosoma.simulator.mujoco.backends.base import apply_sensor_scene_flags, mj_to_holosoma_quat
 from holosoma.simulator.mujoco.command_registry import CommandRegistry
 from holosoma.simulator.mujoco.fields import prepare_fields, prepare_manager_fields
 from holosoma.simulator.mujoco.scene_manager import MujocoSceneManager
@@ -359,6 +359,10 @@ class MuJoCo(BaseSimulator):
         # Initialize bridge system using base class helper
         self._init_bridge()
 
+        # Create mounted camera sensors (cameras were added to the spec pre-compile in
+        # _setup_scene; this resolves their compiled ids and renderers). No-op if none.
+        self._create_sensors()
+
         if self.video_config.enabled:
             self.video_recorder = MuJoCoVideoRecorder(self.video_config, self)
             self.video_recorder.setup_recording()
@@ -415,6 +419,11 @@ class MuJoCo(BaseSimulator):
                 xml_filter=self.simulator_config.robot_mjcf_filter,
                 scene_asset_root=self.scene_config.asset_root,
             )
+
+        # Add mounted cameras after all mount bodies exist but still before compile():
+        # each camera is a <camera> child of its mount body, so it follows that body natively.
+        if self.sensor_config:
+            self.scene_manager.add_cameras(self.sensor_config)
 
     def _set_robot_properties(self) -> None:
         """Set robot properties including DOF names, body names, and index mappings.
@@ -735,6 +744,12 @@ class MuJoCo(BaseSimulator):
 
         # Create Scene following SceneInterface protocol
         self.scene = MuJoCoScene(self.env_origins, self.sim_device)
+
+        # World-mount cameras are worldbody children, so (unlike body-attached cameras) they don't
+        # inherit the per-env body offset; place each env's world camera at its own origin now that
+        # env_origins exist. WarpBackend only (Classic is single-env); the backend no-ops if it has
+        # no world cameras or num_envs==1.
+        self._offset_world_cameras()
 
         # Initialize state tensors based on actual DOF count
         self.dof_pos = torch.zeros(self.num_envs, self.num_dof, device=self.sim_device)
@@ -1545,6 +1560,70 @@ class MuJoCo(BaseSimulator):
         except ValueError:
             raise RuntimeError(f"Body '{body_name}' not found in body_names: {self.body_names}")
 
+    # ----- Camera sensors (mounted, follow-by-spec-hierarchy) -----
+
+    def _create_sensors(self) -> None:
+        """Create mounted-camera runtime state and the backend's per-camera renderers.
+
+        Cameras were already added to the spec as ``<camera>`` children of their mount bodies
+        (in ``_setup_scene``, before compile), so they follow their body natively. This builds
+        the ``SensorManager`` and hands the cameras to ``backend.create_renderers`` (which resolves
+        each compiled ``<camera>`` id into its own name-keyed map). No-op without cameras.
+        """
+        cameras = self.sensor_config
+        if not cameras:
+            return
+
+        from holosoma.simulator.shared.camera_sensor import SensorManager
+
+        sim = self.simulator_config.sim
+        self.sensor_manager = SensorManager(self.sim_device, control_hz=sim.fps / sim.control_decimation_steps)
+
+        # MuJoCo clipping is a global near/far (model.vis.map.{znear,zfar}, scaled by the scene
+        # extent), not per-camera. Honor the agnostic-core near/far across all sensor cameras by
+        # widening the global range to cover them (min near / max far). This is the same global
+        # knob the spectator video recorder tweaks (video_recorder.py).
+        assert self.root_model is not None  # compiled in load_assets, before _create_sensors
+        extent = float(self.root_model.stat.extent)
+        if extent > 0:
+            self.root_model.vis.map.znear = min(c.near for c in cameras.values()) / extent
+            self.root_model.vis.map.zfar = max(c.far for c in cameras.values()) / extent
+
+        for cam_name, cam in cameras.items():
+            self.sensor_manager.register_camera(cam_name, cam)
+
+        self.backend.create_renderers(self.sensor_manager.cameras)
+
+    def _offset_world_cameras(self) -> None:
+        """Place each env's world-mount cameras at its own origin (WarpBackend multi-env only).
+
+        A ``target_kind="world"`` camera is a worldbody child, so it does not pick up the per-env
+        body offset the way a robot/actor-mounted camera does; without this every world's camera sits
+        at the shared spec pose and sees only env 0's scene. Delegates to the backend, which shifts the
+        per-world ``cam_pos``. Classic (single-env) and the no-camera / no-world-camera cases are
+        no-ops; guarded by ``hasattr`` so only the WarpBackend path runs.
+        """
+        if self.sensor_manager is None or not hasattr(self.backend, "offset_world_cameras"):
+            return
+        cam_ids = getattr(self.backend, "_cam_ids", {})
+        world_cam_ids = [
+            cam_ids[name]
+            for name, cam in self.sensor_config.items()
+            if cam.mount.target_kind == "world" and name in cam_ids
+        ]
+        if world_cam_ids:
+            self.backend.offset_world_cameras(world_cam_ids, self.env_origins)
+
+    def render_sensors(self) -> None:
+        """Render all due cameras into their cached buffers (see ``get_camera_data``)."""
+        if self.sensor_manager is None:
+            return
+        due = self.sensor_manager.collect_due()
+        if not due:
+            return
+
+        self.backend.render_cameras(due)
+
     def setup_viewer(self) -> None:
         """Set up MuJoCo viewer using official mujoco.viewer API with keyboard callback."""
         logger.info("=== Setting up MuJoCo viewer ===")
@@ -1555,6 +1634,9 @@ class MuJoCo(BaseSimulator):
             return
 
         self.viewer = mujoco.viewer.launch_passive(self.root_model, self.root_data, key_callback=self._key_callback)
+        # Native camera-frustum gizmo (mjVIS_CAMERA) on the live viewer's own MjvOption; a viewer-only
+        # decoration drawn from each <camera>'s intrinsics, separate from the sensor renders.
+        apply_sensor_scene_flags(self.debug_viz_enabled, self.viewer.opt)
         logger.info("=== Viewer setup completed with keyboard callback ===")
 
     def _add_text_overlay(

--- a/src/holosoma/holosoma/simulator/mujoco/scene_manager.py
+++ b/src/holosoma/holosoma/simulator/mujoco/scene_manager.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from holosoma.config_types.robot import RobotConfig
 from holosoma.config_types.scene import PhysicsConfig, RigidObjectConfig, SceneFileConfig
+from holosoma.config_types.sensor import CameraSensorConfig
 from holosoma.config_types.simulator import MujocoXMLFilterCfg, SimulatorConfig
 from holosoma.managers.terrain.base import TerrainTermBase
 from holosoma.simulator.shared.asset_format import select_asset_format
@@ -579,6 +580,76 @@ class MujocoSceneManager:
         for body_name, is_static in body_is_static.items():
             actor_name = f"{scene_file_name}_{body_name}"
             self.scene_file_bodies[actor_name] = (f"{prefix}{body_name}", is_static)
+
+    def add_cameras(self, cameras: dict[str, CameraSensorConfig], robot_prefix: str = "robot_") -> None:
+        """Add mounted cameras to the world spec as ``<camera>`` children, before compile.
+
+        A camera is a child of its mount body, so MuJoCo's kinematics follow that body
+        natively. MuJoCo's camera optical frame is ``-Z`` forward, ``+Y`` up, matching
+        holosoma's convention, and MjSpec quaternions are ``[w,x,y,z]`` (w-first), matching
+        the config-layer convention, so the mount offset applies with no conversion here.
+
+        Call after the robot/scene bodies are attached and before ``compile()``.
+
+        Parameters
+        ----------
+        cameras : dict[str, CameraSensorConfig]
+            Camera configs to create, keyed by sensor name (the --sensor dict keys).
+        robot_prefix : str
+            The attach prefix used for the robot (default ``"robot_"``), used to resolve a
+            ``robot_link`` mount target to its composed body name.
+        """
+        for cam_name, cam in cameras.items():
+            mount = cam.mount
+            if mount.target_kind == "world":
+                # Free-floating: child of the worldbody, so pos/quat are the pose in the env frame.
+                body = self.world_spec.worldbody
+            else:
+                body_name = self._resolve_mount_body_name(mount.target_kind, mount.target, robot_prefix)
+                body = self.world_spec.body(body_name)
+                if body is None:
+                    raise ValueError(
+                        f"Camera '{cam_name}' mounts on body '{body_name}' (kind={mount.target_kind}, "
+                        f"target='{mount.target}') which is not present in the compiled scene."
+                    )
+            # MjSpec camera: child of the mount body, fovy in degrees, resolution [W,H].
+            # pos is the mount-frame offset; quat is the w-first mount orientation as-is.
+            body.add_camera(
+                name=cam_name,
+                pos=list(mount.position),
+                quat=list(mount.orientation),  # [w,x,y,z], applied directly (MjSpec is w-first)
+                fovy=cam.vertical_fov,  # MuJoCo's fovy is the vertical FOV in degrees
+                resolution=[cam.width, cam.height],
+                mode=mujoco.mjtCamLight.mjCAMLIGHT_FIXED,
+            )
+
+    def _resolve_mount_body_name(self, target_kind: str, target: str, robot_prefix: str) -> str:
+        """Resolve a sensor mount (kind, target) to a composed-spec body name.
+
+        ``robot_link`` -> a prefixed robot link (name the root link to mount on the base);
+        ``actor`` -> a registered rigid-object / scene-file body. Robot-link membership is
+        checked against the robot's captured element inventory so a bad link name fails loud.
+        """
+        if target_kind == "robot_link":
+            meta = self.robot_spec_meta
+            if meta is None:
+                raise ValueError(f"Camera mount target_kind='robot_link' (link '{target}') but no robot was added.")
+            if target != meta.root_body and target not in meta.body_names:
+                raise ValueError(
+                    f"Camera mount robot_link '{target}' is not a robot body. "
+                    f"Known links: {[meta.root_body, *meta.body_names]}."
+                )
+            return f"{robot_prefix}{target}"
+        if target_kind == "actor":
+            if target in self.rigid_object_root_bodies:
+                return self.rigid_object_root_bodies[target]
+            if target in self.scene_file_bodies:
+                return self.scene_file_bodies[target][0]
+            raise ValueError(
+                f"Camera mount actor '{target}' is not a registered scene object. "
+                f"Known actors: {[*self.rigid_object_root_bodies, *self.scene_file_bodies]}."
+            )
+        raise ValueError(f"Unknown camera mount target_kind '{target_kind}'.")
 
     def _apply_physics_to_body(
         self, body: mujoco.MjSpec.Body, physics: PhysicsConfig | None, name: str, *, apply_mass: bool = True

--- a/src/holosoma/holosoma/simulator/mujoco/video_recorder.py
+++ b/src/holosoma/holosoma/simulator/mujoco/video_recorder.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import mujoco
 from loguru import logger
 
+from holosoma.simulator.mujoco.backends.base import apply_sensor_scene_flags
 from holosoma.simulator.shared.video_recorder import VideoRecorderInterface
 
 if TYPE_CHECKING:
@@ -41,9 +42,12 @@ class MuJoCoVideoRecorder(VideoRecorderInterface):
         # Override typing for mypy
         self.simulator: MuJoCo = simulator
 
-        # Thread-local renderer storage (created lazily via properties)
+        # Renderer/camera are created lazily via properties (the Renderer holds a GL context that is
+        # thread-affine, so it must be built on the recording thread).
         self._renderer: mujoco.Renderer | None = None
         self._camera: mujoco.MjvCamera | None = None
+
+        self.scene_option = apply_sensor_scene_flags(simulator.debug_viz_enabled)
 
         logger.info(
             f"MuJoCo video recorder initialized - {'threaded' if config.use_recording_thread else 'synchronous'} mode"
@@ -123,7 +127,7 @@ class MuJoCoVideoRecorder(VideoRecorderInterface):
         self._update_camera_position(self.camera)
 
         # Render frame using thread-appropriate renderer
-        self.renderer.update_scene(render_data, camera=self.camera)
+        self.renderer.update_scene(render_data, camera=self.camera, scene_option=self.scene_option)
         frame = self.renderer.render()
 
         if frame is None:

--- a/src/holosoma/holosoma/simulator/plugins/__init__.py
+++ b/src/holosoma/holosoma/simulator/plugins/__init__.py
@@ -1,0 +1,23 @@
+"""Simulator plugins: runtime plugin classes selected on the CLI as ``plugin.<key>:<variant>``.
+
+A plugin is any class constructed as ``cls(cfg, simulator)`` that registers hooks on
+``simulator.hooks`` — there is no base class to inherit (see
+:mod:`holosoma.config_types.plugin`). This package holds the in-tree camera-frame egress
+plugins and their shared substrate:
+
+- :class:`~holosoma.simulator.plugins.camera_consumer.CameraConsumerPlugin` — an optional shared
+  base for plugins that consume rendered camera frames each control step (ROS2 image publish, viz
+  window, mp4 recording); its ROS/cv2 impls live in ``ros2/`` and ``viz/`` and are imported only via
+  a config's ``get_cls``, so importing this package pulls in no transport dependency.
+
+The ``none`` no-op and the ROS2 example plugins (``clock_publish``/``gantry_control``/``odometry``)
+live under ``simulator/shared`` instead.
+"""
+
+from holosoma.simulator.plugins.camera_consumer import (
+    CameraConsumerPlugin,
+    CameraIntrinsics,
+    FramePacket,
+)
+
+__all__ = ["CameraConsumerPlugin", "CameraIntrinsics", "FramePacket"]

--- a/src/holosoma/holosoma/simulator/plugins/camera_consumer.py
+++ b/src/holosoma/holosoma/simulator/plugins/camera_consumer.py
@@ -1,0 +1,230 @@
+"""Backend-agnostic, ROS-free substrate for camera-frame egress plugins.
+
+Defines :class:`CameraConsumerPlugin`, the base for a plugin that consumes rendered camera frames
+(ROS2 publish, live window, mp4 recording), plus :class:`FramePacket` and :class:`CameraIntrinsics`.
+
+A consumer is a plugin (``cls(cfg, simulator)``, no base class required): it registers its per-step
+:meth:`~CameraConsumerPlugin.publish` on ``FRAME_END`` and its :meth:`~CameraConsumerPlugin.stop`
+on ``CLOSE`` in ``__init__``. The cameras' ``render_sensors`` is registered on the SAME phase first
+(in ``BaseSimulator.__init__``, before the plugins), so by registration order the buffers are
+fresh when a consumer's callback runs. Each consumer declares the streams it needs via
+:meth:`~CameraConsumerPlugin.wanted_streams`; the base validates them against the configured cameras
+at construction (fail-loud) and, each step, snapshots exactly those to host once — sharing the single
+``get_camera_data(device="cpu")`` copy across every consumer of the same (camera, modality) — and
+hands the consumer a per-step batch of just its streams.
+
+Stream identity is a :data:`StreamKey` = ``(camera, modality, env_id)``. ROS2 wants env 0 only; a
+tiling recorder may want several envs — env selection is a per-consumer lever, not a global bake-in.
+Concrete consumers live in their own modules and import heavy deps (rclpy, cv2) at module top; those
+modules are reached only via a config's ``get_cls()``, so this base and the config layer stay
+importable without those deps.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Tuple
+
+import numpy as np
+from loguru import logger
+
+from holosoma.simulator.base_simulator.hooks import Phase
+
+if TYPE_CHECKING:
+    from holosoma.config_types.plugin import PluginConfig
+    from holosoma.config_types.sensor import CameraSensorConfig
+    from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+
+# (camera_name, modality, env_id). The unit of stream identity across the egress system.
+# ``typing.Tuple`` (not the builtin ``tuple[...]``) so this runtime alias is valid on the
+# mypy target (python_version = 3.8), where builtin generics aren't subscriptable at runtime.
+StreamKey = Tuple[str, str, int]
+
+
+@dataclass(frozen=True)
+class CameraIntrinsics:
+    """Static intrinsics of one camera, carried on every :class:`FramePacket`.
+
+    Backend-agnostic core fields (the same set on every backend), sufficient to derive a
+    pinhole projection matrix ``K`` for a ``CameraInfo`` message.
+    """
+
+    width: int
+    height: int
+    vertical_fov: float
+    """Vertical field of view, degrees."""
+    near: float
+    far: float
+
+
+@dataclass
+class FramePacket:
+    """One rendered frame, already copied to host, ready for a consumer to use.
+
+    Snapshotted by :class:`CameraConsumerPlugin` (via the shared cached ``get_camera_data`` host copy)
+    and handed to :meth:`CameraConsumerPlugin.publish` for each ``(camera, modality, env_id)`` the
+    consumer wanted this step. Holds no GPU tensor, so it is safe to pass to a worker thread.
+    """
+
+    camera: str
+    modality: str
+    """``"rgb"`` or ``"depth"``."""
+    env_id: int
+    array: np.ndarray
+    """Host-side copy: ``uint8 [H, W, 3]`` R,G,B for rgb; ``float32 [H, W, 1]`` meters for depth."""
+    sim_time: float
+    """Simulation time of this frame (``simulator.time()``), for the message timestamp."""
+    intrinsics: CameraIntrinsics
+
+    @property
+    def key(self) -> StreamKey:
+        return (self.camera, self.modality, self.env_id)
+
+
+class CameraConsumerPlugin:
+    """Base for a plugin that consumes rendered camera frames each control step.
+
+    Subclass and, in ``__init__``, set any transport fields then call
+    ``super().__init__(config, simulator)`` (which validates the streams and registers the callbacks;
+    ``wanted_streams`` runs there, so fields it reads must be set first). Open the live transport lazily
+    in :meth:`start` — the base defers ``start`` to the first :meth:`publish`. Implement
+    :meth:`wanted_streams`, :meth:`start`, :meth:`publish`, and :meth:`stop`.
+
+    The base handles: fail-loud validation of the wanted streams against the configured cameras;
+    the per-step snapshot (one shared ``get_camera_data(device="cpu")`` host copy per (camera,
+    modality), sliced per wanted env) restricted to cameras that actually rendered this step; and
+    failure isolation (an exception in ``publish``/``stop`` is logged, never propagated to the sim).
+    """
+
+    def __init__(self, config: PluginConfig, simulator: BaseSimulator) -> None:
+        # A plugin is duck-typed (cls(cfg, simulator) registering on simulator.hooks); no base to call.
+        # ``config`` is typed per subclass; ``cfg`` mirrors the plugin convention (ClockPublishPlugin etc).
+        self.cfg = config
+        self.config = config
+        self.simulator = simulator
+        self._wanted = self.wanted_streams()
+        self._validate_streams()
+        self._started = False
+        simulator.hooks.add(Phase.FRAME_END, self._on_frame_end, name=f"{self._label()}.publish")
+        simulator.hooks.add(Phase.CLOSE, self._on_close, name=f"{self._label()}.stop")
+
+    def _label(self) -> str:
+        return type(self).__name__
+
+    @property
+    def sensors_config(self) -> dict[str, CameraSensorConfig]:
+        """The active mounted cameras, keyed by sensor name."""
+        return self.simulator.sensor_config
+
+    @property
+    def control_hz(self) -> float:
+        """Control-step rate (sim fps / control_decimation), the base for resolving frequency strings."""
+        sim = self.simulator.simulator_config.sim
+        return sim.fps / sim.control_decimation_steps
+
+    # ----- subclass contract -----
+
+    @abstractmethod
+    def wanted_streams(self) -> set[StreamKey]:
+        """The ``(camera, modality, env_id)`` triples this consumer needs.
+
+        The base validates these against the configured cameras and snapshots only these each step.
+        ROS2 typically returns ``{(cam, mod, 0)}``; a tiling recorder returns one triple per
+        (camera, modality, env) it watches. Called once in ``__init__``.
+        """
+
+    @abstractmethod
+    def start(self) -> None:
+        """Open the transport (node/sockets/threads/window) and publish any static/latched data.
+
+        Called by the base exactly once, lazily, just before the first :meth:`publish`."""
+
+    @abstractmethod
+    def publish(self, frames: dict[StreamKey, FramePacket]) -> None:
+        """Handle one control step's fresh frames for THIS consumer (only its wanted streams present).
+
+        ``frames`` holds an entry per wanted stream that rendered this step (slower/decimated cameras
+        are absent on steps they did not render). Called only when ``frames`` is non-empty.
+        """
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Drain/stop workers, finalize output (encode video), and close the transport/window."""
+
+    # ----- base machinery -----
+
+    def _validate_streams(self) -> None:
+        """Fail loud if a wanted stream names a camera/modality/env the sim does not provide."""
+        cams = dict(self.simulator.sensor_config)
+        # training_config.num_envs is set at __init__ on every backend; self.num_envs is not yet
+        # populated when IsaacSim builds hooks during scene setup (it lands in create_envs).
+        num_envs = self.simulator.training_config.num_envs
+        for cam, mod, env in sorted(self._wanted):
+            if cam not in cams:
+                raise ValueError(
+                    f"{self._label()} references camera '{cam}', which is not among the configured cameras "
+                    f"(cameras: {sorted(cams)}). Consumer streams must name a configured camera."
+                )
+            if mod not in cams[cam].data_types:
+                raise ValueError(
+                    f"{self._label()} wants '{mod}' from camera '{cam}', but that camera renders only "
+                    f"{list(cams[cam].data_types)}. Add '{mod}' to its data_types or fix the consumer."
+                )
+            if not 0 <= env < num_envs:
+                raise ValueError(
+                    f"{self._label()} wants env {env} of camera '{cam}', but the sim has {num_envs} env(s) "
+                    f"[0, {num_envs})."
+                )
+
+    def _intrinsics_of(self, cam: str) -> CameraIntrinsics:
+        c = self.simulator.sensor_config_by_name(cam)
+        return CameraIntrinsics(width=c.width, height=c.height, vertical_fov=c.vertical_fov, near=c.near, far=c.far)
+
+    def _on_frame_end(self) -> None:
+        """FRAME_END callback: snapshot this consumer's fresh wanted streams, then publish.
+
+        Wrapped so a failure in one consumer neither propagates to the sim nor stops sibling hooks."""
+        try:
+            if not self._started:
+                self.start()
+                self._started = True
+            batch = self._snapshot()
+            if batch:
+                self.publish(batch)
+        except Exception as exc:  # isolation: a consumer must never break the sim loop
+            logger.error(f"Camera consumer {self._label()} publish failed: {exc}")
+
+    def _snapshot(self) -> dict[StreamKey, FramePacket]:
+        """Snapshot this consumer's wanted streams that rendered this step, into host FramePackets.
+
+        One ``get_camera_data(device="cpu")`` read per (camera, modality) — the cache shares that
+        single device->host copy with every other consumer reading the same buffer this step."""
+        manager = self.simulator.sensor_manager
+        if manager is None:
+            return {}
+        fresh = manager.last_due  # set[str] of camera names rendered this step
+        sim_time = self.simulator.time()
+
+        by_cam_mod: dict[tuple[str, str], list[int]] = {}
+        for cam, mod, env in self._wanted:
+            if cam in fresh:
+                by_cam_mod.setdefault((cam, mod), []).append(env)
+
+        packets: dict[StreamKey, FramePacket] = {}
+        for (cam, mod), envs in by_cam_mod.items():
+            buf = self.simulator.get_camera_data(cam, mod, device="cpu")  # [N, H, W, C] host, cached+shared
+            intr = self._intrinsics_of(cam)
+            host = buf.detach().numpy()
+            for env in envs:
+                packets[(cam, mod, env)] = FramePacket(
+                    camera=cam, modality=mod, env_id=env, array=host[env], sim_time=sim_time, intrinsics=intr
+                )
+        return packets
+
+    def _on_close(self) -> None:
+        """CLOSE callback: tear down, isolating any failure so other close hooks still run."""
+        try:
+            self.stop()
+        except Exception as exc:
+            logger.error(f"Camera consumer {self._label()} stop failed: {exc}")

--- a/src/holosoma/holosoma/simulator/plugins/depth_color.py
+++ b/src/holosoma/holosoma/simulator/plugins/depth_color.py
@@ -1,0 +1,67 @@
+"""Depth-map colorization shared by the camera-egress plugins (ROS-free; cv2 deferred).
+
+Turns a float32 depth map (meters, ``+inf`` no-hit) into an ``HxWx3`` uint8 RGB image using a
+named OpenCV colormap. Both egress plugins consume this: the viz plugin tiles the result into its
+grid, and the ROS2 image plugin colorizes a depth route before wire-encoding it as RGB
+(jpeg/png/rgb8). It lives here — neutral ground under ``simulator/plugins`` — so neither egress
+flavor imports the other's package.
+
+cv2 is imported inside :func:`colorize_depth` (not at module top), so importing this module pulls in
+no heavy dep; the colormap names are validated against the config layer at import with plain strings.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from holosoma.config_types.plugin import _DEPTH_COLORMAPS
+
+# Default clamp/normalize range (meters) when a caller does not fix one. NEAR maps bright, FAR dark.
+DEFAULT_DEPTH_RANGE: tuple[float, float] = (0.01, 5.0)
+
+# Colormap names rendered via ``cv2.COLORMAP_<NAME>`` (looked up lazily in colorize_depth to keep cv2
+# deferred). "gray" is handled directly (grayscale, not a cv2 colormap), so the cv2-backed set is
+# exactly the config-accepted set minus "gray". Fails loud at import if the two definitions drift.
+_CV2_COLORMAP_NAMES = ("inferno", "turbo", "viridis", "magma", "jet")
+assert set(_CV2_COLORMAP_NAMES) | {"gray"} == set(_DEPTH_COLORMAPS), (
+    f"_CV2_COLORMAP_NAMES {sorted(_CV2_COLORMAP_NAMES)} + 'gray' must match _DEPTH_COLORMAPS {sorted(_DEPTH_COLORMAPS)}"
+)
+
+
+def colorize_depth(
+    depth: np.ndarray,
+    depth_range: tuple[float, float] = DEFAULT_DEPTH_RANGE,
+    colormap: str = "inferno",
+) -> np.ndarray:
+    """Colorize a depth map (meters) to an ``HxWx3`` uint8 RGB image.
+
+    Depth is float32 meters, ``+inf`` for no-hit. It is clamped to ``depth_range`` and normalized so
+    NEAR -> bright (255) and FAR -> dark (0), then a colormap is applied; ``+inf``/NaN/no-hit reads as
+    the far end (0). The output is RGB (``cv2.applyColorMap`` emits BGR, so we reorder) to match the
+    RGB-in convention of both consumers (``tile_images`` and the RGB wire encoders).
+
+    Parameters
+    ----------
+    depth : np.ndarray
+        ``[H,W]`` or ``[H,W,1]`` float depth in meters (``+inf`` = no-hit).
+    depth_range : tuple[float, float]
+        ``(min_m, max_m)`` clamp/normalize range; min maps to bright, max (and no-hit) to dark.
+    colormap : str
+        ``"gray"`` for grayscale, else a name in :data:`_CV2_COLORMAP_NAMES` (default ``"inferno"``).
+    """
+    dep = np.asarray(depth, dtype=np.float32)
+    if dep.ndim == 3:
+        dep = dep[..., 0]
+    lo, hi = depth_range
+    # +inf/no-hit and NaN -> the far plane so they read as "background", never as near.
+    dep = np.nan_to_num(dep, nan=hi, posinf=hi, neginf=hi)
+    # Clamp to range, normalize to [0,1] with near->1, then to uint8 [0,255] (near bright).
+    norm = 1.0 - (np.clip(dep, lo, hi) - lo) / (hi - lo)
+    gray = (norm * 255.0).round().astype(np.uint8)
+    if colormap == "gray":
+        return np.repeat(gray[..., None], 3, axis=2)
+
+    import cv2
+
+    bgr = cv2.applyColorMap(gray, getattr(cv2, f"COLORMAP_{colormap.upper()}"))  # cv2 outputs BGR
+    return np.ascontiguousarray(bgr[..., ::-1])  # -> RGB to match the RGB-in convention

--- a/src/holosoma/holosoma/simulator/plugins/ros2/__init__.py
+++ b/src/holosoma/holosoma/simulator/plugins/ros2/__init__.py
@@ -1,0 +1,2 @@
+"""ROS2 camera-egress plugin implementations. Imports rclpy at module top — loaded only when a
+ROS2 image plugin config's ``get_cls`` fires (i.e. when that plugin is selected)."""

--- a/src/holosoma/holosoma/simulator/plugins/ros2/camera_info.py
+++ b/src/holosoma/holosoma/simulator/plugins/ros2/camera_info.py
@@ -1,0 +1,50 @@
+"""ROS-free pinhole-intrinsics math for the ROS2 image egress CameraInfo.
+
+Derives the 3x3 K, 3x4 P, distortion D, and rectification R from a camera's agnostic intrinsics
+(``CameraIntrinsics``: width/height/vertical_fov). Kept separate from ``ros2_image_egress.py`` so
+the projection math is unit-tested without a ROS environment; the egress just copies these arrays
+into a ``sensor_msgs/CameraInfo``.
+
+Holosoma cameras are ideal pinholes (no distortion), with a symmetric vertical FOV. fy = fx
+(square pixels), principal point at the image center.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from holosoma.simulator.plugins.camera_consumer import CameraIntrinsics
+
+
+@dataclass(frozen=True)
+class CameraInfoData:
+    """Plain CameraInfo payload (lists, ROS-free) the egress copies into the message."""
+
+    width: int
+    height: int
+    k: list[float]  # 3x3 row-major
+    p: list[float]  # 3x4 row-major
+    d: list[float]  # distortion (empty model -> zeros)
+    r: list[float]  # 3x3 rectification (identity for a monocular pinhole)
+    distortion_model: str = "plumb_bob"
+
+
+def focal_length_px(height: int, vertical_fov_deg: float) -> float:
+    """Pixel focal length from image height and vertical FOV: f = (H/2) / tan(vfov/2)."""
+    half = math.radians(vertical_fov_deg) / 2.0
+    return (height / 2.0) / math.tan(half)
+
+
+def camera_info_from_intrinsics(intr: CameraIntrinsics) -> CameraInfoData:
+    """Build the CameraInfo payload for an ideal pinhole with square pixels, centered principal pt."""
+    w, h = intr.width, intr.height
+    f = focal_length_px(h, intr.vertical_fov)  # fx == fy (square pixels)
+    cx, cy = w / 2.0, h / 2.0
+
+    k = [f, 0.0, cx, 0.0, f, cy, 0.0, 0.0, 1.0]
+    # Monocular P = [K | 0] (no stereo baseline term on Tx).
+    p = [f, 0.0, cx, 0.0, 0.0, f, cy, 0.0, 0.0, 0.0, 1.0, 0.0]
+    r = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    d = [0.0, 0.0, 0.0, 0.0, 0.0]  # plumb_bob, no distortion
+    return CameraInfoData(width=w, height=h, k=k, p=p, d=d, r=r)

--- a/src/holosoma/holosoma/simulator/plugins/ros2/encode.py
+++ b/src/holosoma/holosoma/simulator/plugins/ros2/encode.py
@@ -1,0 +1,120 @@
+"""ROS-free image encoding for the ROS2 image egress.
+
+Pure numpy/cv2 (no rclpy): given a :class:`~holosoma.simulator.plugins.camera_consumer.FramePacket` array and a
+target wire format, produce the raw bytes + the ROS image fields (encoding string, dimensions,
+step, and whether it is a CompressedImage). Kept here so every encoding/format rule is unit-tested
+without a ROS environment; ``ros2_image_egress.py`` only wraps these bytes in messages.
+
+Format → wire mapping (see ``ROS2ImageFormat`` in config_types/plugin.py):
+  rgb8  -> raw sensor_msgs/Image, encoding "rgb8"      (R,G,B, NO swap — swap is a JPEG/cv2 artifact)
+  jpeg  -> sensor_msgs/CompressedImage, format "jpeg"  (cv2 wants BGR)
+  png   -> sensor_msgs/CompressedImage, format "png"   (cv2 wants BGR; lossless)
+  32FC1 -> raw sensor_msgs/Image, encoding "32FC1"     (float32 meters, as get_camera_data gives)
+  16UC1 -> raw sensor_msgs/Image, encoding "16UC1"     (uint16 millimeters; +inf/no-hit -> 0)
+
+Modality decides how the array is read before it hits a format: an ``rgb`` frame goes straight to the
+rgb encoders; a ``depth`` frame goes to the raw depth encoders for a depth format, or is COLORIZED to
+an RGB image (via :func:`~holosoma.simulator.plugins.depth_color.colorize_depth`) and then rgb-encoded for
+an rgb format. The colorized path is what gives a human-viewable depth stream over jpeg/png/rgb8.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from holosoma.simulator.plugins.depth_color import DEFAULT_DEPTH_RANGE, colorize_depth
+
+_RGB_FORMATS = ("rgb8", "jpeg", "png")
+_DEPTH_FORMATS = ("32FC1", "16UC1")
+
+
+@dataclass(frozen=True)
+class EncodedImage:
+    """Encoder output: bytes plus the ROS message fields needed to publish them.
+
+    ``compressed`` selects the message type at the publish site: True -> CompressedImage (use
+    ``compressed_format`` + ``data``); False -> Image (use ``encoding``/``height``/``width``/
+    ``step`` + ``data``).
+    """
+
+    data: bytes
+    compressed: bool
+    compressed_format: str = ""  # "jpeg" | "png" for CompressedImage; "" for raw Image
+    encoding: str = ""  # "rgb8" | "32FC1" | "16UC1" for raw Image; "" for compressed
+    height: int = 0
+    width: int = 0
+    step: int = 0  # bytes per row for raw Image; 0 for compressed
+
+
+def encode_frame(
+    array: np.ndarray,
+    fmt: str,
+    *,
+    modality: str = "rgb",
+    jpeg_quality: int = 50,
+    depth_colormap: str = "inferno",
+    depth_range: tuple[float, float] | None = None,
+) -> EncodedImage:
+    """Encode one frame array to ``fmt``. Raises ValueError on a format/array mismatch.
+
+    ``modality`` (``"rgb"`` | ``"depth"``) says how to read ``array`` before encoding: an rgb frame is
+    an ``[H,W,3]`` uint8 image; a depth frame is ``[H,W]``/``[H,W,1]`` float32 meters. A depth frame
+    bound for an rgb format is COLORIZED to RGB first (``depth_colormap``/``depth_range``); a depth
+    frame bound for a depth format is encoded raw. ``depth_range`` ``None`` uses the shared default.
+    """
+    if fmt in _RGB_FORMATS:
+        if modality == "depth":
+            # Colorize float depth to an [H,W,3] uint8 RGB image, then encode like any rgb frame.
+            array = colorize_depth(array, depth_range or DEFAULT_DEPTH_RANGE, depth_colormap)
+        return _encode_rgb(array, fmt, jpeg_quality=jpeg_quality)
+    if fmt in _DEPTH_FORMATS:
+        return _encode_depth(array, fmt)
+    raise ValueError(f"Unknown image egress format '{fmt}'. Known: {(*_RGB_FORMATS, *_DEPTH_FORMATS)}.")
+
+
+def _encode_rgb(array: np.ndarray, fmt: str, *, jpeg_quality: int) -> EncodedImage:
+    if array.ndim != 3 or array.shape[2] != 3:
+        raise ValueError(f"RGB format '{fmt}' needs an [H,W,3] array, got shape {array.shape}.")
+    rgb = np.ascontiguousarray(array, dtype=np.uint8)
+    h, w = rgb.shape[:2]
+
+    if fmt == "rgb8":
+        # Raw Image, R,G,B order preserved (NO BGR swap — that is only for cv2's JPEG/PNG encoders).
+        return EncodedImage(data=rgb.tobytes(), compressed=False, encoding="rgb8", height=h, width=w, step=3 * w)
+
+    # jpeg / png: cv2 encodes BGR, so swap channels first.
+    import cv2
+
+    bgr = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+    if fmt == "jpeg":
+        ok, buf = cv2.imencode(".jpg", bgr, [int(cv2.IMWRITE_JPEG_QUALITY), int(jpeg_quality)])
+    else:  # png
+        ok, buf = cv2.imencode(".png", bgr)
+    if not ok:
+        raise ValueError(f"cv2 failed to encode a {w}x{h} image as {fmt}.")
+    return EncodedImage(data=buf.tobytes(), compressed=True, compressed_format=fmt)
+
+
+def _encode_depth(array: np.ndarray, fmt: str) -> EncodedImage:
+    # Accept [H,W] or [H,W,1] (get_camera_data gives [H,W,1] float32 meters); squeeze the channel.
+    arr = array
+    if arr.ndim == 3 and arr.shape[2] == 1:
+        arr = arr[..., 0]
+    if arr.ndim != 2:
+        raise ValueError(f"Depth format '{fmt}' needs an [H,W] or [H,W,1] array, got shape {array.shape}.")
+    h, w = arr.shape[:2]
+
+    if fmt == "32FC1":
+        # float32 meters, verbatim (+inf no-hit preserved — the standard depth-image no-hit value).
+        depth = np.ascontiguousarray(arr, dtype=np.float32)
+        return EncodedImage(data=depth.tobytes(), compressed=False, encoding="32FC1", height=h, width=w, step=4 * w)
+
+    # 16UC1: millimeters, uint16. +inf/no-hit -> 0 (the OpenNI/REP-118 "no measurement" value),
+    # and clamp to the uint16 range so a far-but-finite hit does not wrap.
+    mm = arr.astype(np.float32) * 1000.0
+    mm[~np.isfinite(mm)] = 0.0
+    mm = np.clip(mm, 0.0, 65535.0)
+    depth_mm = np.ascontiguousarray(mm, dtype=np.uint16)
+    return EncodedImage(data=depth_mm.tobytes(), compressed=False, encoding="16UC1", height=h, width=w, step=2 * w)

--- a/src/holosoma/holosoma/simulator/plugins/ros2/ros2_image_plugin.py
+++ b/src/holosoma/holosoma/simulator/plugins/ros2/ros2_image_plugin.py
@@ -1,0 +1,228 @@
+"""ROS2 image-publishing plugin: publishes rendered sim camera frames as sensor_msgs/Image or
+CompressedImage (+ optional latched CameraInfo), one node fanning out to many camera routes.
+
+This is the only camera-egress module that touches ROS2. It is imported solely via
+``ROS2ImagePluginConfig.get_cls`` (deferred), so the rest of holosoma stays importable without
+``rclpy``. The heavy imports (rclpy, sensor_msgs) are deferred further into ``start()`` so even
+importing this module does not hard-require a ROS environment — only constructing+starting the
+plugin does. All non-ROS logic (encoding, K-matrix, drop-oldest queue) lives in sibling ROS-free
+modules (``encode``/``camera_info``/``worker``) and is unit-tested there.
+
+Per route: when ``async_publish`` the sim thread submits the encoded payload to a per-route
+drop-oldest worker (no head-of-line blocking, sim never waits); otherwise it encodes+publishes
+inline (lossless/every-frame). Timestamps come from the frame's sim_time, not wall-clock.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from holosoma.simulator.plugins.camera_consumer import CameraConsumerPlugin, CameraIntrinsics
+from holosoma.simulator.plugins.ros2.camera_info import camera_info_from_intrinsics
+from holosoma.simulator.plugins.ros2.encode import EncodedImage, encode_frame
+from holosoma.simulator.plugins.ros2.worker import PublishWorker
+
+if TYPE_CHECKING:
+    from holosoma.config_types.plugin import ROS2ImagePluginConfig, ROS2ImageRoute
+    from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+    from holosoma.simulator.plugins.camera_consumer import FramePacket, StreamKey
+
+
+def _sim_time_to_stamp(sim_time: float):
+    """Build a builtin_interfaces/Time from sim seconds (deferred import; only after start())."""
+    from builtin_interfaces.msg import Time
+
+    sec = int(sim_time)
+    nanosec = round((sim_time - sec) * 1e9)
+    if nanosec >= 1_000_000_000:  # rounding carry
+        sec += 1
+        nanosec -= 1_000_000_000
+    return Time(sec=sec, nanosec=nanosec)
+
+
+class ROS2ImagePlugin(CameraConsumerPlugin):
+    """One ROS2 node publishing the configured camera routes (a camera-consumer plugin)."""
+
+    config: ROS2ImagePluginConfig
+
+    def __init__(self, config: ROS2ImagePluginConfig, simulator: BaseSimulator) -> None:
+        # rclpy/sensor_msgs objects are typed Any: their stubs are absent in non-ROS envs (e.g. the
+        # mujoco venv), and these are only populated in start() under a real ROS environment.
+        self._node: Any = None
+        self._executor: Any = None
+        self._spin_thread: Any = None
+        self._publishers: dict[str, Any] = {}  # topic -> rclpy publisher
+        self._info_publishers: dict[str, Any] = {}  # camera -> CameraInfo publisher (latched)
+        self._workers: dict[str, PublishWorker[FramePacket]] = {}  # topic -> worker (async only)
+        # Validates routes against the configured cameras and registers the publish/close callbacks.
+        super().__init__(config, simulator)
+
+    def wanted_streams(self) -> set[StreamKey]:
+        # One env per node (config.env_id; default 0 = the single real-time robot).
+        return {(r.camera, r.modality, self.config.env_id) for r in self.config.routes.values()}
+
+    # ----- lifecycle -----
+
+    def start(self) -> None:
+        import rclpy
+        from rclpy.node import Node
+        from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+        from sensor_msgs.msg import CameraInfo, CompressedImage, Image
+
+        if not rclpy.ok():
+            rclpy.init()
+        self._node = Node(self.config.node_name)
+        self._Image = Image
+        self._CompressedImage = CompressedImage
+        self._CameraInfo = CameraInfo
+
+        reliability = ReliabilityPolicy.RELIABLE if self.config.qos == "reliable" else ReliabilityPolicy.BEST_EFFORT
+        qos = QoSProfile(reliability=reliability, history=HistoryPolicy.KEEP_LAST, depth=1)
+
+        for route in self.config.routes.values():
+            msg_type = self._CompressedImage if route.format in ("jpeg", "png") else self._Image
+            # Publish on the route's topic verbatim — no auto-suffixing. A CompressedImage topic
+            # conventionally ends in `/compressed`, but that is the config author's choice to spell
+            # out, so the configured topic is exactly the published topic.
+            self._publishers[route.topic] = self._node.create_publisher(msg_type, route.topic, qos)
+            if self.config.async_publish:
+                worker = PublishWorker(
+                    self._make_route_sender(route),
+                    maxlen=self.config.queue_maxlen,
+                    name=f"egress:{self.config.node_name}:{route.topic}",
+                )
+                worker.start()
+                self._workers[route.topic] = worker
+
+        if self.config.publish_camera_info:
+            self._start_camera_info(qos_history=HistoryPolicy.KEEP_LAST, durability=DurabilityPolicy.TRANSIENT_LOCAL)
+
+        # Spin in a daemon thread so subscriptions/QoS handshakes progress without a sim-side spin.
+        from rclpy.executors import SingleThreadedExecutor
+
+        self._executor = SingleThreadedExecutor()
+        self._executor.add_node(self._node)
+        import threading
+
+        self._spin_thread = threading.Thread(
+            target=self._executor.spin, name=f"egress-spin:{self.config.node_name}", daemon=True
+        )
+        self._spin_thread.start()
+        logger.info(f"ROS2 image egress '{self.config.node_name}' up: {len(self.config.routes)} route(s)")
+
+    def _start_camera_info(self, *, qos_history, durability) -> None:
+        from rclpy.qos import QoSProfile, ReliabilityPolicy
+
+        # CameraInfo is STATIC: derived from the camera's configured intrinsics and published ONCE
+        # here on a latched (TRANSIENT_LOCAL) topic, so late subscribers still get it and it never
+        # rides the per-frame path. Topic = the ROS-conventional sibling of the image topic: its last
+        # segment replaced by ``camera_info`` (e.g. ``/cam/head/compressed`` -> ``/cam/head/camera_info``).
+        # Image topics are validated unique within the node, so these are unique too.
+        latched = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE, history=qos_history, depth=1, durability=durability
+        )
+        cams_by_name = dict(self.sensors_config)
+        seen: set[str] = set()
+        for route in self.config.routes.values():
+            if route.camera in seen:
+                continue
+            seen.add(route.camera)
+            info_topic = f"{route.topic.rsplit('/', 1)[0]}/camera_info"
+            pub = self._node.create_publisher(self._CameraInfo, info_topic, latched)
+            self._info_publishers[route.camera] = pub
+            cam = cams_by_name[route.camera]  # present: driver validated routes against sensors_config
+            intr = CameraIntrinsics(
+                width=cam.width, height=cam.height, vertical_fov=cam.vertical_fov, near=cam.near, far=cam.far
+            )
+            pub.publish(self._build_camera_info_msg(route.camera, intr))
+
+    # ----- per-frame publish -----
+
+    def publish(self, frames: dict[StreamKey, FramePacket]) -> None:
+        # One batch per step; each route consumes its (camera, modality, 0) packet if present.
+        # Encode on the calling (sim) thread when inline; when async, hand the packet to the route's
+        # worker and encode there to keep the sim thread's per-frame cost to the snapshot only.
+        for route in self.config.routes.values():
+            packet = frames.get((route.camera, route.modality, self.config.env_id))
+            if packet is None:
+                continue
+            if self.config.async_publish:
+                self._workers[route.topic].submit(packet)
+            else:
+                self._publish_encoded(route, packet, self._encode(route, packet))
+
+    def _encode(self, route: ROS2ImageRoute, packet: FramePacket) -> EncodedImage:
+        """Encode a packet for ``route``, colorizing a depth frame when the format is an rgb one."""
+        return encode_frame(
+            packet.array,
+            route.format,
+            modality=route.modality,
+            jpeg_quality=self.config.jpeg_quality,
+            depth_colormap=route.depth_colormap,
+            depth_range=(route.depth_range[0], route.depth_range[1]) if route.depth_range is not None else None,
+        )
+
+    def _make_route_sender(self, route: ROS2ImageRoute):
+        """Return a worker callback that encodes a FramePacket and publishes it for ``route``."""
+
+        def _send(packet: FramePacket) -> None:
+            self._publish_encoded(route, packet, self._encode(route, packet))
+
+        return _send
+
+    def _publish_encoded(self, route: ROS2ImageRoute, packet: FramePacket, enc: EncodedImage) -> None:
+        pub = self._publishers.get(route.topic)
+        if pub is None:
+            return
+        stamp = _sim_time_to_stamp(packet.sim_time)
+        if enc.compressed:
+            msg = self._CompressedImage()
+            msg.header.stamp = stamp
+            msg.header.frame_id = packet.camera
+            msg.format = enc.compressed_format
+            msg.data = enc.data
+        else:
+            msg = self._Image()
+            msg.header.stamp = stamp
+            msg.header.frame_id = packet.camera
+            msg.height = enc.height
+            msg.width = enc.width
+            msg.encoding = enc.encoding
+            msg.is_bigendian = 0
+            msg.step = enc.step
+            msg.data = enc.data
+        pub.publish(msg)
+
+    def _build_camera_info_msg(self, camera: str, intr: CameraIntrinsics):
+        """Build a static CameraInfo message for ``camera`` (published once, latched, in start())."""
+        info = camera_info_from_intrinsics(intr)
+        msg = self._CameraInfo()
+        msg.header.frame_id = camera  # static: no per-frame stamp
+        msg.height = info.height
+        msg.width = info.width
+        msg.distortion_model = info.distortion_model
+        msg.d = info.d
+        msg.k = info.k
+        msg.r = info.r
+        msg.p = info.p
+        return msg
+
+    # ----- teardown -----
+
+    def stop(self) -> None:
+        for worker in self._workers.values():
+            worker.stop()
+        self._workers.clear()
+        if self._executor is not None:
+            self._executor.shutdown()
+            self._executor = None
+        if self._spin_thread is not None and self._spin_thread.is_alive():
+            self._spin_thread.join(timeout=2.0)
+        self._spin_thread = None
+        if self._node is not None:
+            self._node.destroy_node()
+            self._node = None
+        self._publishers.clear()
+        self._info_publishers.clear()

--- a/src/holosoma/holosoma/simulator/plugins/ros2/worker.py
+++ b/src/holosoma/holosoma/simulator/plugins/ros2/worker.py
@@ -1,0 +1,87 @@
+"""ROS-free drop-oldest publish worker for async sensor egress.
+
+A single-consumer worker thread fed by a bounded, drop-oldest queue. The sim thread calls
+:meth:`PublishWorker.submit` (non-blocking); the worker thread drains and runs the supplied
+``publish_fn``. When the queue is full the OLDEST item is dropped (latest-frame-wins) and a
+dropped counter is incremented — so a slow/stalled consumer never blocks the sim, and overruns are
+visible rather than silent. Pure ``threading``/``collections.deque`` (no rclpy), so the
+backpressure policy is unit-tested without a ROS environment.
+
+One worker per route (so a slow large-depth stream cannot head-of-line-block a fast RGB one); the
+egress owns a worker per route when ``async_publish`` is on, and bypasses it (inline) when off.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from typing import Callable, Generic, TypeVar
+
+from loguru import logger
+
+T = TypeVar("T")
+
+
+class PublishWorker(Generic[T]):
+    """Bounded drop-oldest queue + one consumer thread that runs ``publish_fn`` per item."""
+
+    def __init__(self, publish_fn: Callable[[T], None], *, maxlen: int, name: str) -> None:
+        self._publish_fn = publish_fn
+        self._name = name
+        self._queue: deque[T] = deque(maxlen=maxlen)
+        self._lock = threading.Lock()
+        self._wakeup = threading.Event()
+        self._stop = threading.Event()
+        self._dropped = 0
+        self._published = 0
+        self._thread = threading.Thread(target=self._run, name=name, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    @property
+    def dropped(self) -> int:
+        """Frames dropped so far due to a full queue (overrun visibility)."""
+        return self._dropped
+
+    @property
+    def published(self) -> int:
+        return self._published
+
+    def submit(self, item: T) -> None:
+        """Enqueue an item without blocking. Drops the oldest if the queue is full."""
+        with self._lock:
+            # deque(maxlen) silently evicts the oldest on append; count it as a drop so overruns
+            # are reported rather than hidden.
+            if len(self._queue) == self._queue.maxlen:
+                self._dropped += 1
+            self._queue.append(item)
+        self._wakeup.set()
+
+    def _drain_one(self) -> tuple[bool, T | None]:
+        with self._lock:
+            if self._queue:
+                return True, self._queue.popleft()
+            self._wakeup.clear()
+            return False, None
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            got, item = self._drain_one()
+            if not got or item is None:
+                self._wakeup.wait(timeout=0.5)
+                continue
+            try:
+                self._publish_fn(item)
+                self._published += 1
+            except Exception as exc:
+                logger.error(f"PublishWorker '{self._name}' publish_fn failed: {exc}")
+
+    def stop(self, *, timeout: float = 2.0) -> None:
+        """Signal stop and join the thread. Idempotent. Drains nothing further on the way out."""
+        self._stop.set()
+        self._wakeup.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+        if self._dropped:
+            logger.warning(f"PublishWorker '{self._name}' dropped {self._dropped} frame(s) under backpressure.")

--- a/src/holosoma/holosoma/simulator/plugins/tests/test_camera_consumer.py
+++ b/src/holosoma/holosoma/simulator/plugins/tests/test_camera_consumer.py
@@ -1,0 +1,226 @@
+"""Unit tests for CameraConsumerPlugin (pure, no simulator, no ROS).
+
+Covers the base-class contract the egress consumers rely on: it registers publish on
+FRAME_END and stop on CLOSE; per step it snapshots only the consumer's fresh wanted
+streams (one shared cached device->host read per (camera, modality), serving every wanted env);
+validates the wanted streams against the configured cameras at construction (fail-loud); and isolates
+a failing consumer so it neither breaks the sim loop nor its siblings. A ``FakeConsumer`` test double
+stands in for a real transport.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+
+from holosoma.config_types.sensor import CameraSensorConfig, SensorMountConfig
+from holosoma.simulator.base_simulator.hooks import HookRegistry, Phase
+from holosoma.simulator.plugins.camera_consumer import CameraConsumerPlugin, FramePacket
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+_MOUNT = SensorMountConfig(target_kind="robot_link", target="pelvis")
+
+
+# ----- test double: an in-memory camera consumer with no transport -----
+
+
+class FakeConsumer(CameraConsumerPlugin):
+    """Records every per-step batch it receives. ``wanted_streams`` comes from a passed-in set."""
+
+    def __init__(self, config, simulator, *, streams, fail=False):
+        self._streams = set(streams)
+        self._fail = fail
+        self.started = False
+        self.stopped = False
+        self.batches: list[dict] = []  # each control step's frames dict
+        super().__init__(config, simulator)
+
+    @property
+    def received(self) -> list[FramePacket]:
+        return [pkt for batch in self.batches for pkt in batch.values()]
+
+    def wanted_streams(self):
+        return self._streams
+
+    def start(self):
+        self.started = True
+
+    def publish(self, frames):
+        if self._fail:
+            raise RuntimeError("boom")
+        self.batches.append(frames)
+
+    def stop(self):
+        self.stopped = True
+
+
+# ----- a minimal fake simulator exposing only what the hook base touches -----
+
+
+class _FakeSensorManager:
+    def __init__(self):
+        self.last_due: set[str] = set()
+
+
+class _FakeSimEngineCfg:
+    fps = 200.0
+    control_decimation_steps = 4  # control_hz = 50
+
+
+class _FakeSimulatorConfig:
+    sim = _FakeSimEngineCfg()
+
+
+class _FakeTrainingConfig:
+    def __init__(self, num_envs: int):
+        self.num_envs = num_envs
+
+
+class _FakeSimulator:
+    """Minimal stand-in exposing only what CameraConsumerPlugin touches on the simulator."""
+
+    def __init__(self, sensors_config: dict[str, CameraSensorConfig], frames, num_envs: int = 1):
+        self.hooks = HookRegistry()
+        self.sensor_config = sensors_config
+        self.sensor_manager = _FakeSensorManager()
+        self.training_config = _FakeTrainingConfig(num_envs)
+        self.headless = True
+        self.simulator_config = _FakeSimulatorConfig()
+        self._frames = frames  # (camera, modality) -> [N, H, W, C] numpy
+        self._t = 0.0
+        self.reads: list[tuple[str, str]] = []
+
+    def time(self) -> float:
+        return self._t
+
+    def sensor_config_by_name(self, name):
+        return self.sensor_config[name]
+
+    def get_camera_data(self, name, data_type="rgb", env_ids=None, device=None):
+        # The hook base reads the full [N, ...] host buffer once (device="cpu") and indexes envs
+        # itself; frames here are already host numpy, so device is accepted and ignored.
+        self.reads.append((name, data_type))
+        return torch.from_numpy(self._frames[(name, data_type)])
+
+
+def _cam(data_types=("rgb",)) -> CameraSensorConfig:
+    return CameraSensorConfig(mount=_MOUNT, data_types=list(data_types))
+
+
+def _sensors(*names, data_types=("rgb",)) -> dict[str, CameraSensorConfig]:
+    return {n: _cam(data_types) for n in names}
+
+
+def _rgb(h=2, w=2, n=1):
+    return np.zeros((n, h, w, 3), dtype=np.uint8)
+
+
+def _step(sim: _FakeSimulator) -> None:
+    """Emit one FRAME_END — the phase every consumer registers its publish on."""
+    sim.hooks.emit(Phase.FRAME_END)
+
+
+# ----- tests -----
+
+
+def test_registers_publish_and_close_callbacks():
+    sim = _FakeSimulator(_sensors("head"), {("head", "rgb"): _rgb()})
+    FakeConsumer(None, sim, streams=[("head", "rgb", 0)])
+    # One FRAME_END hook (publish) and one CLOSE hook (stop) were registered.
+    assert len(sim.hooks._snapshots[Phase.FRAME_END]) == 1
+    assert len(sim.hooks._snapshots[Phase.CLOSE]) == 1
+
+
+def test_publishes_only_fresh_wanted_streams():
+    sim = _FakeSimulator(_sensors("head", "wrist"), {("head", "rgb"): _rgb(), ("wrist", "rgb"): _rgb()})
+    c = FakeConsumer(None, sim, streams=[("head", "rgb", 0), ("wrist", "rgb", 0)])
+    # Only 'head' rendered this step -> only head is published, wrist is not read.
+    sim.sensor_manager.last_due = {"head"}
+    _step(sim)
+    assert c.started  # lazily started on first publish
+    assert [(p.camera, p.modality) for p in c.received] == [("head", "rgb")]
+    assert ("wrist", "rgb") not in sim.reads
+
+
+def test_snapshot_gives_each_consumer_its_frame():
+    sim = _FakeSimulator(_sensors("head"), {("head", "rgb"): _rgb()})
+    a = FakeConsumer(None, sim, streams=[("head", "rgb", 0)])
+    b = FakeConsumer(None, sim, streams=[("head", "rgb", 0)])
+    sim.sensor_manager.last_due = {"head"}
+    _step(sim)
+    # Both consumers got the frame. Each self-serves get_camera_data(device="cpu"); the FULL-buffer
+    # cache dedups the device->host copy across them at the runtime layer (covered in the runtime
+    # cache tests) — here we assert both received exactly one packet.
+    assert len(a.received) == 1
+    assert len(b.received) == 1
+
+
+def test_one_read_serves_multiple_envs():
+    sim = _FakeSimulator(_sensors("head"), {("head", "rgb"): _rgb(n=3)}, num_envs=3)
+    c = FakeConsumer(None, sim, streams=[("head", "rgb", 0), ("head", "rgb", 2)])
+    sim.sensor_manager.last_due = {"head"}
+    _step(sim)
+    assert sim.reads == [("head", "rgb")]  # ONE read for both envs
+    assert sorted(p.env_id for p in c.received) == [0, 2]
+
+
+def test_packet_carries_intrinsics_sim_time_and_env():
+    sim = _FakeSimulator(_sensors("head"), {("head", "rgb"): _rgb(h=4, w=6)})
+    sim._t = 1.25
+    c = FakeConsumer(None, sim, streams=[("head", "rgb", 0)])
+    sim.sensor_manager.last_due = {"head"}
+    _step(sim)
+    pkt = c.received[0]
+    assert pkt.sim_time == 1.25
+    assert pkt.env_id == 0
+    assert (pkt.intrinsics.width, pkt.intrinsics.height) == (128, 128)  # config defaults
+    assert pkt.array.shape == (4, 6, 3) and pkt.array.dtype == np.uint8
+
+
+def test_failing_consumer_is_isolated():
+    sim = _FakeSimulator(_sensors("head"), {("head", "rgb"): _rgb()})
+    FakeConsumer(None, sim, streams=[("head", "rgb", 0)], fail=True)
+    good = FakeConsumer(None, sim, streams=[("head", "rgb", 0)])
+    sim.sensor_manager.last_due = {"head"}
+    _step(sim)  # must NOT raise despite the failing consumer
+    assert len(good.received) == 1  # the good consumer (registered second) still got its frame
+
+
+def test_stop_runs_on_close():
+    sim = _FakeSimulator(_sensors("head"), {("head", "rgb"): _rgb()})
+    c = FakeConsumer(None, sim, streams=[("head", "rgb", 0)])
+    sim.hooks.emit(Phase.CLOSE)
+    assert c.stopped
+
+
+def test_validation_rejects_unknown_camera():
+    sim = _FakeSimulator(_sensors("head"), {("head", "rgb"): _rgb()})
+    with pytest.raises(ValueError, match="not among the configured cameras"):
+        FakeConsumer(None, sim, streams=[("nonexistent", "rgb", 0)])
+
+
+def test_validation_rejects_unrendered_modality():
+    sim = _FakeSimulator(_sensors("head", data_types=("rgb",)), {("head", "rgb"): _rgb()})
+    with pytest.raises(ValueError, match="renders only"):
+        FakeConsumer(None, sim, streams=[("head", "depth", 0)])
+
+
+def test_validation_rejects_out_of_range_env():
+    sim = _FakeSimulator(_sensors("head"), {("head", "rgb"): _rgb()}, num_envs=1)
+    with pytest.raises(ValueError, match="env 5"):
+        FakeConsumer(None, sim, streams=[("head", "rgb", 5)])
+
+
+def test_config_layer_imports_without_rclpy():
+    # The optional-dependency guarantee: importing the config + config_values + plugins package must
+    # not import rclpy (the deferred get_cls import is the only path that would). Guards against a
+    # regression where someone top-level-imports a transport dep in the ROS-free layer.
+    import holosoma.config_types.plugin
+    import holosoma.config_values.plugin
+    import holosoma.simulator.plugins  # noqa: F401
+
+    assert "rclpy" not in sys.modules, "config/plugins layer must stay ROS-free; rclpy leaked in."

--- a/src/holosoma/holosoma/simulator/plugins/tests/test_image_grid.py
+++ b/src/holosoma/holosoma/simulator/plugins/tests/test_image_grid.py
@@ -1,0 +1,150 @@
+"""Unit tests for tile_images (pure numpy/cv2; no simulator)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from holosoma.simulator.plugins.viz.image_grid import _BORDER, _draw_label, colorize_depth, tile_images
+
+pytestmark = pytest.mark.no_sim
+
+_B = 2 * _BORDER  # per-cell growth in each dimension from the white border
+
+
+def test_single_image_unchanged_size():
+    g = tile_images([np.zeros((10, 12, 3), np.uint8)])
+    assert g.shape == (10 + _B, 12 + _B, 3)
+    assert g.dtype == np.uint8
+
+
+def test_two_equal_images_row():
+    g = tile_images([np.zeros((8, 8, 3), np.uint8), np.full((8, 8, 3), 255, np.uint8)])
+    assert g.shape == (8 + _B, 2 * (8 + _B), 3)  # auto near-square: cols=ceil(sqrt(2))=2 -> 1 row
+
+
+def test_three_images_padded_grid():
+    g = tile_images([np.zeros((8, 8, 3), np.uint8)] * 3)
+    assert g.shape == (2 * (8 + _B), 2 * (8 + _B), 3)  # 2x2 grid, 1 padded cell
+
+
+def test_mixed_sizes_resized_to_common_cell():
+    imgs = [
+        np.zeros((6, 10, 3), np.uint8),
+        np.zeros((12, 4, 3), np.uint8),
+        np.zeros((8, 8, 3), np.uint8),
+        np.zeros((5, 5, 3), np.uint8),
+    ]
+    g = tile_images(imgs)  # cell = max(h)=12, max(w)=10; 2x2 -> 2*(12+_B) x 2*(10+_B)
+    assert g.shape == (2 * (12 + _B), 2 * (10 + _B), 3)
+
+
+def test_explicit_layout():
+    g = tile_images([np.zeros((8, 8, 3), np.uint8)] * 2, layout=(1, 3))
+    assert g.shape == (8 + _B, 3 * (8 + _B), 3)
+
+
+def test_letterbox_preserves_aspect_with_pad_bars():
+    # A wide image (4x12) tiled with a tall one (12x4) -> 12x12 cells. The wide image keeps its
+    # 1:3 aspect: scaled to 4x12 inside a 12x12 cell, leaving pad_value bars above and below.
+    wide = np.full((4, 12, 3), 200, np.uint8)
+    tall = np.full((12, 4, 3), 200, np.uint8)
+    g = tile_images([wide, tall], layout=(1, 2), pad_value=0)
+    cell = 12 + _B
+    # First cell interior (drop the white border): the wide image fills the full 12 width but only
+    # the middle 4 rows; the top rows are pad_value (0) letterbox bars, the centre band is the image.
+    interior = g[_BORDER : cell - _BORDER, _BORDER : cell - _BORDER]  # 12x12 cell interior
+    assert int(interior[0].max()) == 0  # top row is a letterbox bar (would be 200 if stretched)
+    assert int(interior[6].max()) == 200  # centre band holds the (aspect-preserved) image
+
+
+def test_pad_value_fills_trailing_cells():
+    g = tile_images([np.full((4, 4, 3), 100, np.uint8)] * 3, layout=(2, 2), pad_value=7)
+    # The 4th (padded) cell is bottom-right; its interior pixels (inside the border) equal pad_value.
+    cell = 4 + _B
+    interior = g[cell + _BORDER : 2 * cell - _BORDER, cell + _BORDER : 2 * cell - _BORDER]
+    assert int(interior.min()) == 7 and int(interior.max()) == 7
+
+
+def test_labels_none_matches_no_labels():
+    imgs = [np.full((8, 8, 3), 50, np.uint8), np.full((8, 8, 3), 200, np.uint8)]
+    assert np.array_equal(tile_images(imgs), tile_images(imgs, labels=None))
+
+
+def test_wrong_length_labels_raises():
+    with pytest.raises(ValueError, match="labels has 1 entries but there are 2 images"):
+        tile_images([np.zeros((8, 8, 3), np.uint8)] * 2, labels=["only_one"])
+
+
+def test_labels_draw_pixels():
+    # Drawing a label must alter the cell (text is white-on-black over a mid-grey fill).
+    img = np.full((40, 80, 3), 128, np.uint8)
+    plain = tile_images([img.copy()])
+    labeled = tile_images([img.copy()], labels=["cam0"])
+    assert not np.array_equal(plain, labeled)
+
+
+def test_short_label_stays_one_line():
+    # A continuous label that fits draws on a single line (only the top band has text).
+    cell = np.full((48, 240, 3), 0, np.uint8)
+    _draw_label(cell, "env0/front")
+    assert cell[4:18].max() > 200  # first line drawn
+    assert cell[22:].max() == 0  # nothing wrapped onto a second line
+
+
+def test_label_wraps_at_delimiter_when_too_wide():
+    # Too wide for one line -> wraps at "/"/":" onto stacked lines (text in two bands).
+    cell = np.full((64, 90, 3), 0, np.uint8)
+    _draw_label(cell, "env0/front_camera:rgb")
+    assert cell[4:18].max() > 200 and cell[20:40].max() > 200  # two lines present
+
+
+def test_label_never_clips_right_edge():
+    # An unbreakable over-long segment must shrink to fit, never clip past the right edge.
+    cell = np.full((40, 60, 3), 0, np.uint8)
+    _draw_label(cell, "env12/extremely_long_camera_name_xyz")
+    assert not (cell[:, -2:] > 50).any()  # rightmost columns untouched by text
+
+
+def test_colorize_depth_shape_dtype_and_flows_through_tile():
+    # A [H,W,1] float depth -> HxWx3 uint8, usable as a tile_images panel like an RGB image.
+    dep = np.full((12, 20, 1), 1.0, np.float32)
+    out = colorize_depth(dep, (0.1, 5.0), "inferno")
+    assert out.shape == (12, 20, 3) and out.dtype == np.uint8
+    tile_images([out])  # must not raise (valid HxWx3 panel)
+
+
+def test_colorize_depth_near_brighter_than_far_grayscale():
+    # Grayscale: NEAR maps bright (255), FAR maps dark (0).
+    near = colorize_depth(np.full((4, 4), 0.1, np.float32), (0.1, 5.0), "gray")
+    far = colorize_depth(np.full((4, 4), 5.0, np.float32), (0.1, 5.0), "gray")
+    assert int(near.mean()) > 240 and int(far.mean()) < 15
+
+
+def test_colorize_depth_inf_no_hit_maps_to_far():
+    # +inf / no-hit must read as the far plane (background), identical to an at-far pixel.
+    inf = colorize_depth(np.full((4, 4), np.inf, np.float32), (0.1, 5.0), "gray")
+    far = colorize_depth(np.full((4, 4), 5.0, np.float32), (0.1, 5.0), "gray")
+    assert np.array_equal(inf, far)
+
+
+def test_colorize_depth_clamps_out_of_range():
+    # Beyond the range clamps (nearer-than-min -> brightest, farther-than-max -> darkest).
+    nearer = colorize_depth(np.full((4, 4), 0.0, np.float32), (0.1, 5.0), "gray")
+    farther = colorize_depth(np.full((4, 4), 99.0, np.float32), (0.1, 5.0), "gray")
+    assert int(nearer.mean()) == 255 and int(farther.mean()) == 0
+
+
+def test_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        tile_images([])
+
+
+def test_wrong_shape_raises():
+    with pytest.raises(ValueError, match="H.W.3"):
+        tile_images([np.zeros((8, 8), np.uint8)])
+
+
+def test_layout_too_small_raises():
+    with pytest.raises(ValueError, match="cells"):
+        tile_images([np.zeros((4, 4, 3), np.uint8)] * 5, layout=(2, 2))

--- a/src/holosoma/holosoma/simulator/plugins/tests/test_presets.py
+++ b/src/holosoma/holosoma/simulator/plugins/tests/test_presets.py
@@ -1,0 +1,193 @@
+"""Tests for the core camera-egress plugin presets and the real ROS2ImagePlugin wiring (no ROS env).
+
+Egress sinks are plugins: each preset is a single ``ROS2ImagePluginConfig`` / ``CameraVizPluginConfig``
+(a ``PluginConfig``) registered in ``PLUGIN_REGISTRY``, selected per-key as ``plugin.<key>:<variant>``.
+The ROS2ImagePlugin impl defers rclpy to start(), so we can construct it (which validates streams +
+registers callbacks, no rclpy) and inspect wiring — only start()/publish() would need a ROS env. This
+pins the preset / topic guarantees (incl. the rfmpi teleop topics the removed holosoma_sim_stereo
+sidecar published).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+
+from holosoma.config_types.plugin import ROS2ImagePluginConfig, ROS2ImageRoute
+from holosoma.config_types.sensor import CameraSensorConfig, SensorMountConfig
+from holosoma.config_values.plugin import PLUGIN_REGISTRY
+from holosoma.config_values.wbt.g1 import sensor as g1_cameras
+from holosoma.simulator.base_simulator.hooks import HookRegistry
+from holosoma.simulator.plugins.camera_consumer import CameraIntrinsics, FramePacket
+
+pytestmark = pytest.mark.no_sim
+
+# Camera rigs are composed per-key on the CLI (``--sensor.<name>:<variant>``), so a rig is just a
+# ``{sensor_name: CameraSensorConfig}`` dict. The egress presets reference cameras by conventional
+# names (``head_cam_left``, ``waist_front_cam``, ...); these rigs pair those names with the G1 camera
+# building blocks, exactly as a user would key them to line up with the egress routes.
+_G1_STEREO_RIG = {
+    "head_cam_left": g1_cameras.stereo_head_camera_left,
+    "head_cam_right": g1_cameras.stereo_head_camera_right,
+}
+_G1_STEREO_WRISTS_RIG = {
+    **_G1_STEREO_RIG,
+    "left_wrist_cam": g1_cameras.left_wrist_camera,
+    "right_wrist_cam": g1_cameras.right_wrist_camera,
+}
+_G1_WAIST_RIG = {
+    "waist_front_cam": g1_cameras.waist_front_camera,
+    "waist_back_cam": g1_cameras.waist_back_camera,
+}
+
+
+class _FakeSimEngineCfg:
+    fps = 200.0
+    control_decimation_steps = 4
+
+
+class _FakeSimulatorConfig:
+    sim = _FakeSimEngineCfg()
+
+
+class _FakeVideoConfig:
+    save_dir = None
+
+
+class _FakeTrainingConfig:
+    def __init__(self, num_envs: int):
+        self.num_envs = num_envs
+
+
+class _FakeSimulator:
+    """Minimal stand-in exposing what a camera-consumer hook reads/registers on (no backend)."""
+
+    def __init__(self, sensors_config, num_envs=1):
+        self.hooks = HookRegistry()
+        self.sensor_config = sensors_config
+        self.training_config = _FakeTrainingConfig(num_envs)
+        self.headless = True
+        self.simulator_config = _FakeSimulatorConfig()
+        self.video_config = _FakeVideoConfig()
+        self.sensor_manager = None
+
+    def sensor_config_by_name(self, name):
+        return self.sensor_config[name]
+
+
+def test_core_presets_present():
+    assert set(PLUGIN_REGISTRY) >= {"none", "ros2-image", "ros2-stereo", "viz", "viz-record"}
+
+
+def test_presets_resolve_get_cls_without_rclpy():
+    # Resolving get_cls imports the ros2_image_egress MODULE but must NOT import rclpy (deferred to
+    # start()), so presets are inspectable in a non-ROS env.
+    for name in ("ros2-image", "ros2-stereo"):
+        cls = PLUGIN_REGISTRY[name].get_cls()
+        assert cls.__name__ == "ROS2ImagePlugin"
+    assert "rclpy" not in sys.modules
+
+
+def test_stereo_preset_publishes_rfmpi_teleop_topics():
+    # The rfmpi teleop stack subscribes to /ros_camera/rgb/{left,right}/compressed. Topics are
+    # published VERBATIM (no auto-suffix), so the preset spells the full topics out.
+    inst = PLUGIN_REGISTRY["ros2-stereo"]
+    assert isinstance(inst, ROS2ImagePluginConfig)
+    topics = {r.topic for r in inst.routes.values()}
+    assert topics == {"/ros_camera/rgb/left/compressed", "/ros_camera/rgb/right/compressed"}
+    cams = {r.camera for r in inst.routes.values()}
+    assert cams == {"head_cam_left", "head_cam_right"}
+
+
+def test_stereo_egress_cameras_exist_in_g1_stereo_rig():
+    # The egress route cameras must exist in a rig you'd pair it with, else the hook fails loud at
+    # construction. Pin that ros2-stereo lines up with a stereo head rig keyed head_cam_left/right.
+    stereo_cams = set(_G1_STEREO_RIG)
+    route_cams = {r.camera for r in PLUGIN_REGISTRY["ros2-stereo"].routes.values()}
+    assert route_cams <= stereo_cams
+
+
+def test_g1_stereo_wrists_rig_composes_from_building_blocks():
+    # The stereo-head-plus-wrists rig (previously a whole-config preset) now composes from the G1
+    # camera building blocks, keyed to the names the egress routes reference.
+    cams = set(_G1_STEREO_WRISTS_RIG)
+    assert {"head_cam_left", "head_cam_right", "left_wrist_cam", "right_wrist_cam"} <= cams
+
+
+def test_waist_depth_color_preset_colorizes_depth_over_rgb_format():
+    # The colorized-depth preset publishes DEPTH cameras on an RGB (jpeg) format => colorized to RGB.
+    # Cameras must exist in the paired waist rig (else the hook fails loud at construction).
+    inst = PLUGIN_REGISTRY["ros2-waist-depth-color"]
+    assert isinstance(inst, ROS2ImagePluginConfig)
+    for route in inst.routes.values():
+        assert route.modality == "depth" and route.format == "jpeg"  # depth + rgb format = colorize
+        assert route.depth_colormap == "turbo"
+    assert {r.camera for r in inst.routes.values()} <= set(_G1_WAIST_RIG)
+
+
+def test_waist_depth_raw_and_color_preset_shares_one_snapshot_per_camera():
+    # The combined preset publishes each waist camera BOTH ways (raw 32FC1 + colorized jpeg) from a
+    # single node. The two routes per camera share the same (camera, "depth", env) stream key, so
+    # wanted_streams collapses to one triple per camera => ONE cached device->host copy each, not two.
+    inst = PLUGIN_REGISTRY["ros2-waist-depth-raw+color"]
+    assert isinstance(inst, ROS2ImagePluginConfig)
+    # Four distinct topics (2 cameras x 2 formats), all unique (the config validator also enforces).
+    topics = {r.topic for r in inst.routes.values()}
+    assert len(topics) == len(inst.routes) == 4
+    # Both a raw depth-format route and a colorized rgb-format route are present.
+    formats = {r.format for r in inst.routes.values()}
+    assert "32FC1" in formats and "jpeg" in formats
+    assert any(r.format == "jpeg" and r.depth_colormap == "turbo" for r in inst.routes.values())
+    assert {r.camera for r in inst.routes.values()} <= set(_G1_WAIST_RIG)
+    # The single-copy guarantee: 4 routes but only 2 wanted streams (one per camera).
+    egress = inst.get_cls()(inst, _FakeSimulator(_G1_WAIST_RIG))
+    assert egress.wanted_streams() == {("waist_front_cam", "depth", 0), ("waist_back_cam", "depth", 0)}
+    assert "rclpy" not in sys.modules
+
+
+def test_real_egress_wanted_streams_and_async_default():
+    # Construct the REAL ROS2ImagePlugin (no start -> no ROS) and check its wiring: wanted_streams
+    # from routes, and async_publish on by default.
+    inst = PLUGIN_REGISTRY["ros2-stereo"]
+    egress = inst.get_cls()(inst, _FakeSimulator(_G1_STEREO_RIG))
+    assert egress.wanted_streams() == {("head_cam_left", "rgb", 0), ("head_cam_right", "rgb", 0)}
+    assert inst.async_publish is True
+    assert "rclpy" not in sys.modules
+
+
+def _depth_frame(camera, value=2.0, h=6, w=6):
+    arr = np.full((h, w, 1), value, np.float32)  # [H,W,1] float meters, as get_camera_data gives
+    intr = CameraIntrinsics(width=w, height=h, vertical_fov=45.0, near=0.01, far=100.0)
+    return FramePacket(camera=camera, modality="depth", env_id=0, array=arr, sim_time=0.0, intrinsics=intr)
+
+
+def test_encode_threads_route_colormap_and_range_without_ros():
+    # ROS2ImagePlugin._encode is ROS-free (never touches the node/simulator), so we can verify the
+    # route's depth_colormap/depth_range actually reach encode_frame WITHOUT an rclpy env. Each knob
+    # is isolated (routes differing in ONLY that field) so the test guards BOTH independently.
+    mount = SensorMountConfig(target_kind="robot_link", target="torso_link")
+    sensors = {"waist": CameraSensorConfig(mount=mount, data_types=["depth"])}
+
+    def _route(topic, colormap, drange):
+        return ROS2ImageRoute(
+            camera="waist", topic=topic, modality="depth", format="rgb8", depth_colormap=colormap, depth_range=drange
+        )
+
+    # Same range, different colormap -> isolates route.depth_colormap threading.
+    cmap_a = _route("/t/turbo", "turbo", [0.1, 5.0])
+    cmap_b = _route("/t/gray", "gray", [0.1, 5.0])
+    # Same colormap, different range -> isolates route.depth_range threading.
+    range_a = _route("/t/tight", "gray", [0.1, 3.0])
+    range_b = _route("/t/wide", "gray", [0.1, 20.0])
+    cfg = ROS2ImagePluginConfig(
+        publish_camera_info=False,
+        routes={"ca": cmap_a, "cb": cmap_b, "ra": range_a, "rb": range_b},
+    )
+    egress = cfg.get_cls()(cfg, _FakeSimulator(sensors))  # no start() -> no rclpy
+    frame = _depth_frame("waist")
+    enc = {k: egress._encode(r, frame).data for k, r in cfg.routes.items()}
+    assert enc["ca"] != enc["cb"]  # colormap reaches encode_frame (would collide if defaulted)
+    assert enc["ra"] != enc["rb"]  # depth_range reaches encode_frame (would collide if defaulted)
+    assert "rclpy" not in sys.modules

--- a/src/holosoma/holosoma/simulator/plugins/tests/test_ros2_helpers.py
+++ b/src/holosoma/holosoma/simulator/plugins/tests/test_ros2_helpers.py
@@ -1,0 +1,208 @@
+"""Unit tests for the ROS-free ROS2-egress helpers (encode / camera_info / worker).
+
+These cover the parts of the ROS2 image egress that carry real logic but need no ROS environment:
+wire encoding + format rules, pinhole-K math, and the drop-oldest backpressure worker. The thin
+``ros2_image_egress.py`` rclpy shell is exercised on the cluster (Phase 4), not here.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+
+import numpy as np
+import pytest
+
+from holosoma.simulator.plugins.camera_consumer import CameraIntrinsics
+from holosoma.simulator.plugins.ros2.camera_info import camera_info_from_intrinsics, focal_length_px
+from holosoma.simulator.plugins.ros2.encode import encode_frame
+from holosoma.simulator.plugins.ros2.worker import PublishWorker
+
+pytestmark = pytest.mark.no_sim
+
+
+# ----- encode -----
+
+
+def _rgb(h=4, w=6):
+    a = np.zeros((h, w, 3), dtype=np.uint8)
+    a[..., 0] = 10  # R
+    a[..., 1] = 20  # G
+    a[..., 2] = 30  # B
+    return a
+
+
+def test_rgb8_is_raw_rgb_no_swap():
+    enc = encode_frame(_rgb(2, 2), "rgb8")
+    assert not enc.compressed
+    assert enc.encoding == "rgb8"
+    assert (enc.height, enc.width, enc.step) == (2, 2, 6)  # step = 3*w
+    # R,G,B order preserved (first pixel = 10,20,30), proving NO BGR swap on the raw path.
+    assert list(enc.data[:3]) == [10, 20, 30]
+
+
+def test_jpeg_is_compressed_and_decodes_back_to_rgb():
+    import cv2
+
+    enc = encode_frame(_rgb(8, 8), "jpeg", jpeg_quality=95)
+    assert enc.compressed and enc.compressed_format == "jpeg"
+    # Decode: cv2 gives BGR; the original solid color round-trips (B≈30,G≈20,R≈10) within JPEG noise.
+    bgr = cv2.imdecode(np.frombuffer(enc.data, np.uint8), cv2.IMREAD_COLOR)
+    assert bgr.shape == (8, 8, 3)
+    b, g, r = bgr[0, 0]
+    assert abs(int(b) - 30) <= 3 and abs(int(g) - 20) <= 3 and abs(int(r) - 10) <= 3
+
+
+def test_png_is_lossless_compressed():
+    import cv2
+
+    enc = encode_frame(_rgb(8, 8), "png")
+    assert enc.compressed and enc.compressed_format == "png"
+    bgr = cv2.imdecode(np.frombuffer(enc.data, np.uint8), cv2.IMREAD_COLOR)
+    assert list(map(int, bgr[0, 0])) == [30, 20, 10]  # exact: lossless, BGR
+
+
+def test_depth_32fc1_preserves_meters_and_inf():
+    depth = np.array([[1.5, np.inf], [0.0, 3.25]], dtype=np.float32)[..., None]  # [H,W,1]
+    enc = encode_frame(depth, "32FC1")
+    assert not enc.compressed and enc.encoding == "32FC1"
+    assert (enc.height, enc.width, enc.step) == (2, 2, 8)  # step = 4*w
+    out = np.frombuffer(enc.data, dtype=np.float32).reshape(2, 2)
+    assert out[0, 0] == 1.5 and out[1, 1] == 3.25
+    assert math.isinf(out[0, 1])  # +inf no-hit preserved verbatim
+
+
+def test_depth_16uc1_millimeters_and_nohit_zero():
+    depth = np.array([[1.5, np.inf], [0.001, 100.0]], dtype=np.float32)
+    enc = encode_frame(depth, "16UC1")
+    assert enc.encoding == "16UC1" and enc.step == 4  # 2 bytes * 2 cols
+    out = np.frombuffer(enc.data, dtype=np.uint16).reshape(2, 2)
+    assert out[0, 0] == 1500  # 1.5 m -> 1500 mm
+    assert out[0, 1] == 0  # +inf no-hit -> 0
+    assert out[1, 0] == 1  # 0.001 m -> 1 mm
+    assert out[1, 1] == 65535  # 100 m = 100000 mm clamped to uint16 max
+
+
+def test_format_array_mismatch_raises():
+    with pytest.raises(ValueError, match="needs an"):
+        encode_frame(np.zeros((4, 4), np.uint8), "rgb8")  # 2-D into an rgb format
+    with pytest.raises(ValueError, match="Unknown image egress format"):
+        encode_frame(_rgb(), "bogus")
+
+
+def test_depth_colorized_to_rgb8_is_raw_rgb_image():
+    # A depth frame in an rgb format is colorized to an [H,W,3] uint8 RGB image, then rgb-encoded.
+    depth = np.full((5, 7, 1), 1.0, np.float32)  # [H,W,1] float meters, as get_camera_data gives
+    enc = encode_frame(depth, "rgb8", modality="depth", depth_range=(0.1, 5.0))
+    assert not enc.compressed and enc.encoding == "rgb8"
+    assert (enc.height, enc.width, enc.step) == (5, 7, 21)  # 3*w; colorized to 3 channels
+    assert len(enc.data) == 5 * 7 * 3
+
+
+def test_depth_colorized_to_jpeg_is_compressed():
+    depth = np.full((8, 8), 1.0, np.float32)
+    enc = encode_frame(depth, "jpeg", modality="depth", jpeg_quality=90, depth_colormap="turbo")
+    assert enc.compressed and enc.compressed_format == "jpeg"
+    assert len(enc.data) > 0
+
+
+def test_depth_colormap_changes_encoded_bytes():
+    # Different colormaps colorize the same depth differently, so the raw rgb bytes differ.
+    depth = np.linspace(0.2, 4.0, 64, dtype=np.float32).reshape(8, 8)
+    turbo = encode_frame(depth, "rgb8", modality="depth", depth_colormap="turbo").data
+    gray = encode_frame(depth, "rgb8", modality="depth", depth_colormap="gray").data
+    assert turbo != gray
+
+
+def test_depth_colorized_near_brighter_than_far_grayscale():
+    # Sanity that the colorization scale reaches the encoder: near reads brighter than far (gray).
+    kw = {"modality": "depth", "depth_colormap": "gray", "depth_range": (0.1, 5.0)}
+    near = encode_frame(np.full((4, 4), 0.1, np.float32), "rgb8", **kw)
+    far = encode_frame(np.full((4, 4), 5.0, np.float32), "rgb8", **kw)
+    near_mean = np.frombuffer(near.data, np.uint8).mean()
+    far_mean = np.frombuffer(far.data, np.uint8).mean()
+    assert near_mean > far_mean
+
+
+def test_depth_range_value_changes_encoded_bytes():
+    # depth_range must actually drive normalization: the SAME depth normalizes differently under two
+    # ranges, so the encoded bytes differ. Guards against depth_range being threaded but ignored.
+    depth = np.full((4, 4), 2.0, np.float32)  # a mid-scene depth, well inside both ranges
+    kw = {"modality": "depth", "depth_colormap": "gray"}
+    tight = np.frombuffer(encode_frame(depth, "rgb8", depth_range=(0.1, 3.0), **kw).data, np.uint8)
+    wide = np.frombuffer(encode_frame(depth, "rgb8", depth_range=(0.1, 20.0), **kw).data, np.uint8)
+    # Nearer end of a tight range => 2m sits darker; in a wide range 2m is close to bright. Different.
+    assert not np.array_equal(tight, wide)
+    assert tight.mean() != wide.mean()
+
+
+# ----- camera_info -----
+
+
+def test_focal_length_matches_fov():
+    # 90deg vertical FOV over 200px -> f = 100 (since tan(45deg)=1).
+    assert focal_length_px(200, 90.0) == pytest.approx(100.0)
+
+
+def test_camera_info_k_p_layout():
+    intr = CameraIntrinsics(width=320, height=240, vertical_fov=60.0, near=0.01, far=100.0)
+    info = camera_info_from_intrinsics(intr)
+    f = focal_length_px(240, 60.0)
+    assert info.width == 320 and info.height == 240
+    # K = [f 0 cx; 0 f cy; 0 0 1]; principal point centered.
+    assert info.k[0] == pytest.approx(f) and info.k[4] == pytest.approx(f)
+    assert info.k[2] == pytest.approx(160.0) and info.k[5] == pytest.approx(120.0)
+    assert info.k[8] == 1.0
+    # P = [K | 0]: first 3 cols match K rows, 4th col is zero.
+    assert info.p[3] == 0.0 and info.p[7] == 0.0 and info.p[11] == 0.0
+    assert info.p[0] == pytest.approx(f)
+    assert info.r == [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    assert info.d == [0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+# ----- worker (drop-oldest backpressure) -----
+#
+# submit() only appends to the deque (and signals), so it works before start(). Queuing all items
+# BEFORE starting the consumer thread makes these tests deterministic (no producer/consumer race),
+# then we poll w.published to know the worker has drained before stop().
+
+
+def _wait_published(w: PublishWorker, n: int, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while w.published < n and time.monotonic() < deadline:
+        time.sleep(0.005)
+
+
+def test_worker_publishes_all_when_not_overflowing():
+    seen: list[int] = []
+    # maxlen >= count, so nothing is dropped even though everything is queued before draining.
+    w = PublishWorker(seen.append, maxlen=64, name="t")
+    for i in range(20):
+        w.submit(i)
+    w.start()
+    _wait_published(w, 20)
+    w.stop()
+    assert seen == list(range(20))
+    assert w.dropped == 0
+    assert w.published == 20
+
+
+def test_worker_drops_oldest_keeps_latest():
+    # Queue 10 items into a maxlen=2 queue BEFORE starting the consumer: deque(maxlen) evicts the
+    # oldest on each append, so only [8, 9] remain and 0..7 are counted as drops. Deterministic.
+    received: list[int] = []
+    w = PublishWorker(received.append, maxlen=2, name="t")
+    for i in range(10):
+        w.submit(i)
+    assert w.dropped == 8  # 0..7 evicted, counted (not silent)
+    w.start()
+    _wait_published(w, 2)
+    w.stop()
+    assert received == [8, 9]  # the two NEWEST survived; oldest dropped, order preserved
+
+
+def test_worker_stop_is_idempotent():
+    w = PublishWorker(lambda _: None, maxlen=2, name="t")
+    w.start()
+    w.stop()
+    w.stop()  # must not raise

--- a/src/holosoma/holosoma/simulator/plugins/tests/test_ros2_image_plugin.py
+++ b/src/holosoma/holosoma/simulator/plugins/tests/test_ros2_image_plugin.py
@@ -1,0 +1,384 @@
+"""Offline behavior tests for ROS2ImagePlugin message construction (no DDS, no sim, no spin).
+
+ROS2-behavior is tested the way PR #124 does it: ``pytest.importorskip("rclpy")`` so the test runs
+in the ROS env (bazel/RoboStack) and skips cleanly on a host without ROS. The production code is
+left untouched — it always creates and spins its own node (nothing in holosoma shares a node with
+it, so adding an inject-a-node hook would be test-only contamination). Instead the FIXTURE
+monkeypatches the rclpy pieces ``start()`` reaches for (``Node`` -> a fake that records publishers;
+the executor + spin thread -> no-ops), so publishers are captured and no real DDS graph / spin /
+``rclpy.init`` happens. We then drive ``publish()`` / start-time CameraInfo directly and assert the
+exact messages built (topic, type, encoding, frame_id, stamp, K) — the logic the ROS-free helpers
+(encode/camera_info) cannot cover on their own.
+
+Live end-to-end publishing over DDS is validated manually on the cluster (see
+``../ros2/INTEGRATION_TEST.md``), not in this suite.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("rclpy")
+pytest.importorskip("sensor_msgs")
+
+from holosoma.config_types.plugin import ROS2ImagePluginConfig, ROS2ImageRoute
+from holosoma.config_types.sensor import CameraSensorConfig, SensorMountConfig
+from holosoma.simulator.base_simulator.hooks import HookRegistry
+from holosoma.simulator.plugins.camera_consumer import CameraIntrinsics, FramePacket
+
+_MOUNT = SensorMountConfig(target_kind="robot_link", target="torso_link")
+
+
+class _FakeSimEngineCfg:
+    fps = 200.0
+    control_decimation_steps = 4
+
+
+class _FakeSimulatorConfig:
+    sim = _FakeSimEngineCfg()
+
+
+class _FakeVideoConfig:
+    save_dir = None
+
+
+class _FakeTrainingConfig:
+    num_envs = 1
+
+
+class _FakeSimulator:
+    """Minimal stand-in exposing what the egress hook reads/registers on (no backend, no DDS)."""
+
+    def __init__(self, *cams):
+        self.hooks = HookRegistry()
+        self.sensor_config = dict(cams)
+        self.training_config = _FakeTrainingConfig()
+        self.num_envs = 1
+        self.headless = True
+        self.simulator_config = _FakeSimulatorConfig()
+        self.video_config = _FakeVideoConfig()
+        self.sensor_manager = None
+
+    def sensor_config_by_name(self, name):
+        return self.sensor_config[name]
+
+
+class _FakePublisher:
+    """Captures every published message instead of sending it on DDS."""
+
+    def __init__(self, msg_type, topic):
+        self.msg_type = msg_type
+        self.topic = topic
+        self.published: list = []
+
+    def publish(self, msg):
+        self.published.append(msg)
+
+
+class _FakeNode:
+    """Stand-in for an rclpy Node: records publishers, never touches DDS."""
+
+    def __init__(self, *args, **kwargs):
+        self.publishers: list[_FakePublisher] = []
+
+    def create_publisher(self, msg_type, topic, qos):
+        pub = _FakePublisher(msg_type, topic)
+        self.publishers.append(pub)
+        return pub
+
+    def destroy_node(self):
+        pass
+
+
+class _NoopExecutor:
+    def add_node(self, node):
+        pass
+
+    def spin(self):  # referenced as the spin-thread target; never actually run (thread is a no-op)
+        pass
+
+    def shutdown(self):
+        pass
+
+
+class _NoopThread:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+    def is_alive(self):
+        return False
+
+
+@pytest.fixture
+def fake_ros(monkeypatch):
+    """Monkeypatch the rclpy pieces ``ROS2ImagePlugin.start`` uses so no real node/spin/DDS runs.
+
+    Patches at the egress module's import sites (``start`` does ``from rclpy.node import Node`` etc.
+    at call time, so we patch the source modules). Captures the constructed fake node on the
+    returned holder so tests can inspect the publishers.
+    """
+    import threading
+
+    import rclpy
+    import rclpy.executors
+    import rclpy.node
+
+    holder = {}
+
+    def _node_factory(*args, **kwargs):
+        node = _FakeNode(*args, **kwargs)
+        holder["node"] = node
+        return node
+
+    # start() does `from rclpy.node import Node`, `from rclpy.executors import SingleThreadedExecutor`
+    # and `import threading` at call time, so patching these source modules covers those binds.
+    monkeypatch.setattr(rclpy.node, "Node", _node_factory)
+    monkeypatch.setattr(rclpy, "ok", lambda: True)  # skip rclpy.init()
+    monkeypatch.setattr(rclpy.executors, "SingleThreadedExecutor", _NoopExecutor)
+    monkeypatch.setattr(threading, "Thread", _NoopThread)
+    return holder
+
+
+def _make(cfg, *cams):
+    """Construct the egress hook with a fake simulator built from the given cameras."""
+    return cfg.get_cls()(cfg, _FakeSimulator(*cams))
+
+
+def _cam(name, **kw):
+    """Return a ``(name, CameraSensorConfig)`` pair for building the fake sim's cameras dict."""
+    return name, CameraSensorConfig(mount=_MOUNT, **kw)
+
+
+def _rgb_packet(camera, h=8, w=8, sim_time=1.5):
+    arr = np.zeros((h, w, 3), dtype=np.uint8)
+    arr[..., 0] = 200  # distinctive R so we can tell the decode apart
+    intr = CameraIntrinsics(width=w, height=h, vertical_fov=45.0, near=0.01, far=100.0)
+    return FramePacket(camera=camera, modality="rgb", env_id=0, array=arr, sim_time=sim_time, intrinsics=intr)
+
+
+def _depth_packet(camera, h=8, w=8, sim_time=1.5):
+    arr = np.full((h, w, 1), 1.0, dtype=np.float32)  # [H,W,1] float meters, as get_camera_data gives
+    intr = CameraIntrinsics(width=w, height=h, vertical_fov=45.0, near=0.01, far=100.0)
+    return FramePacket(camera=camera, modality="depth", env_id=0, array=arr, sim_time=sim_time, intrinsics=intr)
+
+
+def _publish(egress, packet):
+    """Hand the egress a single-packet batch (publish always takes a StreamKey->packet dict)."""
+    egress.publish({packet.key: packet})
+
+
+def _start(egress, fake_ros):
+    """Start the egress under the monkeypatched rclpy; return the captured fake node."""
+    egress.start()
+    return fake_ros["node"]
+
+
+def _pub_for(node, topic):
+    for p in node.publishers:
+        if p.topic == topic:
+            return p
+    raise AssertionError(f"no publisher created for topic {topic}; have {[p.topic for p in node.publishers]}")
+
+
+# ----- topic + type wiring -----
+
+
+def test_jpeg_route_publishes_compressedimage_on_verbatim_topic(fake_ros):
+    from sensor_msgs.msg import CompressedImage
+
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=False,
+        routes={"head": ROS2ImageRoute(camera="head", topic="/cam/head/compressed", modality="rgb", format="jpeg")},
+    )
+    egress = _make(cfg, _cam("head"))
+    node = _start(egress, fake_ros)
+    # jpeg => CompressedImage on the VERBATIM configured topic (no auto-suffixing).
+    pub = _pub_for(node, "/cam/head/compressed")
+    assert pub.msg_type is CompressedImage
+
+    _publish(egress, _rgb_packet("head"))
+    assert len(pub.published) == 1
+    msg = pub.published[0]
+    assert msg.format == "jpeg"
+    assert msg.header.frame_id == "head"
+    assert len(msg.data) > 0
+    egress.stop()
+
+
+def test_raw_rgb8_route_publishes_image_with_dimensions(fake_ros):
+    from sensor_msgs.msg import Image
+
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=False,
+        routes={"head": ROS2ImageRoute(camera="head", topic="/cam/head/image_raw", modality="rgb", format="rgb8")},
+    )
+    egress = _make(cfg, _cam("head"))
+    node = _start(egress, fake_ros)
+    # rgb8 => raw Image on the un-suffixed topic.
+    pub = _pub_for(node, "/cam/head/image_raw")
+    assert pub.msg_type is Image
+
+    _publish(egress, _rgb_packet("head", h=8, w=8))
+    msg = pub.published[0]
+    assert msg.encoding == "rgb8"
+    assert (msg.height, msg.width, msg.step) == (8, 8, 24)  # step = 3*w
+    assert msg.is_bigendian == 0
+    assert len(msg.data) == 8 * 8 * 3
+    egress.stop()
+
+
+def test_sim_time_becomes_message_stamp(fake_ros):
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=False,
+        routes={"head": ROS2ImageRoute(camera="head", topic="/cam/head/compressed", modality="rgb", format="jpeg")},
+    )
+    egress = _make(cfg, _cam("head"))
+    node = _start(egress, fake_ros)
+    _publish(egress, _rgb_packet("head", sim_time=2.25))
+    stamp = _pub_for(node, "/cam/head/compressed").published[0].header.stamp
+    # 2.25 s -> sec=2, nanosec=0.25e9. Stamp is built from sim_time, NOT wall-clock.
+    assert stamp.sec == 2
+    assert stamp.nanosec == 250_000_000
+    egress.stop()
+
+
+def test_publish_routes_only_matching_camera_modality(fake_ros):
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=False,
+        routes={
+            "head": ROS2ImageRoute(camera="head", topic="/cam/head/compressed", modality="rgb", format="jpeg"),
+            "wrist": ROS2ImageRoute(camera="wrist", topic="/cam/wrist/compressed", modality="rgb", format="jpeg"),
+        },
+    )
+    egress = _make(cfg, _cam("head"), _cam("wrist"))
+    node = _start(egress, fake_ros)
+    _publish(egress, _rgb_packet("head"))  # only the head packet
+    assert len(_pub_for(node, "/cam/head/compressed").published) == 1
+    assert len(_pub_for(node, "/cam/wrist/compressed").published) == 0
+    egress.stop()
+
+
+# ----- colorized depth (depth modality + rgb format) -----
+
+
+def test_depth_route_colorized_publishes_compressed_rgb(fake_ros):
+    import cv2
+    from sensor_msgs.msg import CompressedImage
+
+    # A depth camera routed on an rgb (jpeg) format => the depth map is colorized to RGB, then
+    # published as CompressedImage. The raw float32 depth never reaches the wire on this route.
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=False,
+        routes={
+            "waist": ROS2ImageRoute(
+                camera="waist",
+                topic="/cam/waist/depth_color/compressed",
+                modality="depth",
+                format="jpeg",
+                depth_colormap="turbo",
+                depth_range=[0.1, 4.0],
+            )
+        },
+    )
+    egress = _make(cfg, _cam("waist", data_types=["depth"]))
+    node = _start(egress, fake_ros)
+    pub = _pub_for(node, "/cam/waist/depth_color/compressed")
+    assert pub.msg_type is CompressedImage
+
+    egress.publish({("waist", "depth", 0): _depth_packet("waist")})
+    assert len(pub.published) == 1
+    msg = pub.published[0]
+    assert msg.format == "jpeg"
+    assert msg.header.frame_id == "waist"
+    # Decodes back to a 3-channel RGB image (colorized), not raw depth.
+    bgr = cv2.imdecode(np.frombuffer(msg.data, np.uint8), cv2.IMREAD_COLOR)
+    assert bgr.shape == (8, 8, 3)
+    egress.stop()
+
+
+def test_depth_route_raw_still_publishes_float_image(fake_ros):
+    from sensor_msgs.msg import Image
+
+    # A depth route on a depth format (32FC1) is unchanged: raw float32-meter Image, not colorized.
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=False,
+        routes={"waist": ROS2ImageRoute(camera="waist", topic="/cam/waist/depth", modality="depth", format="32FC1")},
+    )
+    egress = _make(cfg, _cam("waist", data_types=["depth"]))
+    node = _start(egress, fake_ros)
+    pub = _pub_for(node, "/cam/waist/depth")
+    assert pub.msg_type is Image
+
+    egress.publish({("waist", "depth", 0): _depth_packet("waist", h=8, w=8)})
+    msg = pub.published[0]
+    assert msg.encoding == "32FC1"
+    assert (msg.height, msg.width, msg.step) == (8, 8, 32)  # 4 bytes * w
+    assert len(msg.data) == 8 * 8 * 4
+    egress.stop()
+
+
+# ----- latched CameraInfo (published once at start, not per-frame) -----
+
+
+def test_camera_info_published_once_at_start_with_correct_k(fake_ros):
+    import math
+
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=True,
+        routes={"head": ROS2ImageRoute(camera="head", topic="/cam/head/image", modality="rgb", format="rgb8")},
+    )
+    egress = _make(cfg, _cam("head", width=320, height=240, vertical_fov=60.0))
+    node = _start(egress, fake_ros)
+    # CameraInfo topic is the ROS-conventional sibling of the image topic (last segment -> camera_info).
+    info_pub = _pub_for(node, "/cam/head/camera_info")
+    # Published exactly once, during start() — before any frame.
+    assert len(info_pub.published) == 1
+    info = info_pub.published[0]
+    assert (info.width, info.height) == (320, 240)
+    f = (240 / 2.0) / math.tan(math.radians(60.0) / 2.0)
+    assert info.k[0] == pytest.approx(f) and info.k[4] == pytest.approx(f)
+    assert info.k[2] == pytest.approx(160.0) and info.k[5] == pytest.approx(120.0)
+
+    # A frame must NOT add another CameraInfo (it is static/latched, off the per-frame path).
+    _publish(egress, _rgb_packet("head", h=240, w=320))
+    assert len(info_pub.published) == 1
+    egress.stop()
+
+
+def test_no_camera_info_when_disabled(fake_ros):
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=False,
+        routes={"head": ROS2ImageRoute(camera="head", topic="/cam/head", modality="rgb", format="jpeg")},
+    )
+    egress = _make(cfg, _cam("head"))
+    node = _start(egress, fake_ros)
+    assert not any(p.topic.endswith("/camera_info") for p in node.publishers)
+    egress.stop()
+
+
+# ----- teardown -----
+
+
+def test_stop_tears_down_cleanly(fake_ros):
+    cfg = ROS2ImagePluginConfig(
+        async_publish=False,
+        publish_camera_info=False,
+        routes={"head": ROS2ImageRoute(camera="head", topic="/cam/head", modality="rgb", format="jpeg")},
+    )
+    egress = _make(cfg, _cam("head"))
+    _start(egress, fake_ros)
+    egress.stop()  # must not raise; clears node/executor/publishers
+    assert egress._node is None
+    assert egress._publishers == {}

--- a/src/holosoma/holosoma/simulator/plugins/viz/__init__.py
+++ b/src/holosoma/holosoma/simulator/plugins/viz/__init__.py
@@ -1,0 +1,5 @@
+"""Local-visualization camera-egress plugin (cv2 window / mp4).
+
+Imports cv2 + video utils at module top — loaded only when a ``CameraVizPluginConfig.get_cls``
+fires (i.e. when the viz plugin is selected), so the plugins package stays cv2-free otherwise.
+"""

--- a/src/holosoma/holosoma/simulator/plugins/viz/image_grid.py
+++ b/src/holosoma/holosoma/simulator/plugins/viz/image_grid.py
@@ -1,0 +1,155 @@
+"""Tile a flat list of images into a single grid image (pure numpy + cv2).
+
+Used by the viz egress to show several mounted-camera views in one window/frame. It tiles whatever
+flat list it is handed, in order; the caller decides which cameras and in what order. RGB in, RGB
+out (the display/encode boundary converts to BGR). Lives under the viz package since that is its
+only consumer. Depth colorization is shared with the ROS2 egress in
+``holosoma.simulator.plugins.depth_color``; :func:`colorize_depth` is re-exported here for callers that
+still import it from this module.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+
+import cv2
+import numpy as np
+
+from holosoma.simulator.plugins.depth_color import colorize_depth
+
+__all__ = ["colorize_depth", "tile_images"]
+
+_BORDER = 2  # white gutter (px) added around every cell, so adjacent views are visibly separated
+_BORDER_COLOR = (255, 255, 255)  # white; symmetric in RGB/BGR so the display boundary needn't care
+
+
+def _letterbox(img: np.ndarray, cell_h: int, cell_w: int, pad_value: int) -> np.ndarray:
+    """Scale ``img`` to fit a ``cell_h x cell_w`` cell preserving aspect ratio, centered.
+
+    The image is resized by the largest factor that keeps it inside the cell (so neither axis
+    overflows), then centered on a ``pad_value`` background; letterbox/pillarbox bars fill the
+    leftover. A camera whose aspect already matches the cell fills it exactly with no bars.
+    """
+    h, w = img.shape[:2]
+    scale = min(cell_w / w, cell_h / h)
+    new_w, new_h = max(1, round(w * scale)), max(1, round(h * scale))
+    resized = cv2.resize(img, (new_w, new_h)).astype(np.uint8)  # cv2 takes (width, height)
+    canvas = np.full((cell_h, cell_w, 3), pad_value, dtype=np.uint8)
+    y0, x0 = (cell_h - new_h) // 2, (cell_w - new_w) // 2
+    canvas[y0 : y0 + new_h, x0 : x0 + new_w] = resized
+    return canvas
+
+
+def _wrap_label(text: str, font: int, scale: float, thickness: int, avail: int) -> list[str]:
+    """Greedily wrap ``text`` to lines that fit ``avail`` px, breaking only at ``/`` and ``:``.
+
+    Splits at the natural delimiters (keeping each delimiter on the segment it ends) and packs as
+    many segments per line as fit, so ``env0/front_camera:rgb`` becomes one line when it fits and
+    breaks at ``/``/``:`` only when it would clip, never mid-word. A single segment that is itself
+    too wide is left on its own line (the caller's shrink-to-fit handles that residual case).
+    """
+    segments = [s for s in re.split(r"(?<=[/:])", text) if s]  # keep delimiter with its segment
+    lines, cur = [], ""
+    for seg in segments:
+        candidate = cur + seg
+        if cur and cv2.getTextSize(candidate, font, scale, thickness)[0][0] > avail:
+            lines.append(cur)
+            cur = seg
+        else:
+            cur = candidate
+    if cur:
+        lines.append(cur)
+    return lines or [text]
+
+
+def _draw_label(cell: np.ndarray, text: str) -> None:
+    """Draw ``text`` in the top-left corner of ``cell`` in place (black outline + white fill).
+
+    cv2.putText neither wraps nor honors newlines, so ``text`` is one continuous label that is
+    wrapped here only when it would clip: first at ``/``/``:`` delimiters (:func:`_wrap_label`), then
+    (only if a single unbreakable segment is still too wide) the font is shrunk to fit. So a label
+    stays one line when it fits, breaks at natural boundaries when it doesn't, and never clips.
+    """
+    font, margin, base_scale, thickness = cv2.FONT_HERSHEY_SIMPLEX, 4, 0.4, 1
+    avail = max(1, cell.shape[1] - 2 * margin)
+    lines = _wrap_label(text, font, base_scale, thickness, avail)
+    line_widths = [cv2.getTextSize(ln, font, base_scale, thickness)[0][0] for ln in lines]
+    widest = max([1, *line_widths])  # floor of 1 px guards the avail/widest division below
+    scale = base_scale * min(1.0, avail / widest)  # shrink only if an unbreakable line still overflows
+    (_, text_h), baseline = cv2.getTextSize("Ag", font, scale, thickness)
+    line_h = text_h + baseline + 2
+    y = margin + text_h  # baseline of the first line, a few px below the top edge
+    for ln in lines:
+        # Black outline under white text keeps the label legible over any background.
+        cv2.putText(cell, ln, (margin, y), font, scale, (0, 0, 0), thickness + 1, cv2.LINE_AA)
+        cv2.putText(cell, ln, (margin, y), font, scale, _BORDER_COLOR, thickness, cv2.LINE_AA)
+        y += line_h
+
+
+def tile_images(
+    images: list[np.ndarray],
+    layout: tuple[int, int] | None = None,
+    pad_value: int = 0,
+    labels: list[str] | None = None,
+) -> np.ndarray:
+    """Tile ``images`` into one ``HxWx3`` uint8 grid.
+
+    Every cell is a common size (the max H and max W across the list) so the grid lines up. Each
+    image is LETTERBOXED into its cell (scaled to fit while preserving its aspect ratio, then
+    centered on ``pad_value`` bars) so a mix of differently-shaped cameras is never stretched.
+    Each cell is wrapped in a thin white border so adjacent views are separated; trailing empty
+    cells (when the count doesn't fill the grid) are filled with ``pad_value`` and bordered to match.
+
+    Parameters
+    ----------
+    images : list[np.ndarray]
+        Non-empty list of ``HxWx3`` uint8 RGB images.
+    layout : tuple[int, int] | None
+        ``(rows, cols)``; ``None`` picks a near-square layout (cols = ceil(sqrt(n))).
+    pad_value : int
+        Fill value (0-255) for padding trailing cells.
+    labels : list[str] | None
+        One label per image (same order), drawn in each cell's corner; ``None`` draws no labels.
+
+    Returns
+    -------
+    np.ndarray
+        Contiguous ``(rows*(cell_h+2*border)) x (cols*(cell_w+2*border)) x 3`` uint8 RGB grid.
+    """
+    if not images:
+        raise ValueError("tile_images requires at least one image.")
+    for i, img in enumerate(images):
+        if img.ndim != 3 or img.shape[2] != 3:
+            raise ValueError(f"image {i} must be HxWx3, got shape {img.shape}.")
+
+    n = len(images)
+    if labels is not None and len(labels) != n:
+        raise ValueError(f"labels has {len(labels)} entries but there are {n} images.")
+    if layout is None:
+        cols = math.ceil(math.sqrt(n))
+        rows = math.ceil(n / cols)
+    else:
+        rows, cols = layout
+        if rows * cols < n:
+            raise ValueError(f"layout {layout} has {rows * cols} cells < {n} images.")
+
+    cell_h = max(img.shape[0] for img in images)
+    cell_w = max(img.shape[1] for img in images)
+
+    # Letterbox each image into the common cell (aspect-preserving), label it, then wrap it in a
+    # white border. _letterbox returns a fresh array, so the in-place label/border touch the cell
+    # only, never the caller's source images.
+    cells = [_letterbox(img, cell_h, cell_w, pad_value) for img in images]
+    if labels is not None:
+        for cell, label in zip(cells, labels):
+            _draw_label(cell, label)
+    t = _BORDER
+    cells = [cv2.copyMakeBorder(c, t, t, t, t, cv2.BORDER_CONSTANT, value=_BORDER_COLOR) for c in cells]
+    blank = cv2.copyMakeBorder(
+        np.full((cell_h, cell_w, 3), pad_value, dtype=np.uint8), t, t, t, t, cv2.BORDER_CONSTANT, value=_BORDER_COLOR
+    )
+    cells += [blank] * (rows * cols - n)  # pad trailing cells
+
+    grid_rows = [np.hstack(cells[r * cols : (r + 1) * cols]) for r in range(rows)]
+    return np.ascontiguousarray(np.vstack(grid_rows))

--- a/src/holosoma/holosoma/simulator/plugins/viz/viz_plugin.py
+++ b/src/holosoma/holosoma/simulator/plugins/viz/viz_plugin.py
@@ -1,0 +1,176 @@
+"""Local-visualization plugin: tile mounted-camera views into a live cv2 window and/or mp4.
+
+A :class:`CameraConsumerPlugin`: the base snapshots its wanted ``(camera, modality, env)`` streams
+once per control step (the single, shared GPU→host copy via the cached ``get_camera_data``) and hands
+them to :meth:`publish` as a batch; this class colorizes depth, tiles the panels into one grid
+(rows = envs, cols = (camera, modality)), and shows it live and/or buffers it for an H.264 file at
+:meth:`stop`. cv2 + video utils are imported at module top — this module is reached only via
+``CameraVizPluginConfig.get_cls``, so importing the plugins package stays cv2-free.
+
+Inherently inline (composes + shows/buffers on the calling thread) — no async worker path: a live
+cv2 window must be driven where the loop runs, and the per-step grid is cheap.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import cv2
+import numpy as np
+from loguru import logger
+
+from holosoma.config_types.frequency import is_frequency_string, resolve_decimation
+from holosoma.simulator.plugins.camera_consumer import CameraConsumerPlugin
+from holosoma.simulator.plugins.viz.image_grid import colorize_depth, tile_images
+from holosoma.utils.video_utils import create_video
+
+if TYPE_CHECKING:
+    from holosoma.config_types.plugin import CameraVizPluginConfig
+    from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+    from holosoma.simulator.plugins.camera_consumer import FramePacket, StreamKey
+
+_WINDOW = "holosoma camera sensors"
+
+
+class CameraVizPlugin(CameraConsumerPlugin):
+    """Tiling cv2-window / mp4 sink over mounted-camera frames (a camera-consumer plugin)."""
+
+    config: CameraVizPluginConfig
+
+    def __init__(self, config: CameraVizPluginConfig, simulator: BaseSimulator) -> None:
+        self._frames_video: list[np.ndarray] = []  # buffered grids for the mp4
+        self._step = -1  # batches seen (proxy for the fastest watched camera's render count)
+        self._last_captured = -1
+
+        # Cameras to watch: configured selection or all cameras in the active camera dict. Read the
+        # sim's camera dict directly (the sensors_config property needs self.simulator, set by super
+        # below — but wanted_streams runs inside super().__init__, so the panels must exist first).
+        cams_by_name = dict(simulator.sensor_config)
+        all_cams = list(cams_by_name)
+        self._cam_names = config.cameras if config.cameras is not None else all_cams
+
+        # A PANEL is one (camera, modality): its own grid column. For each watched camera take the
+        # modalities it actually produces, intersected with the config's modality selection.
+        self._panels: list[tuple[str, str]] = []
+        for name in self._cam_names:
+            cam_mods = list(cams_by_name[name].data_types)
+            mods = cam_mods if config.modalities is None else [m for m in config.modalities if m in cam_mods]
+            self._panels.extend((name, m) for m in mods)
+        if not self._panels:
+            logger.warning(f"CameraVizPlugin: selected modalities {config.modalities} match no camera output.")
+
+        # Panel label disambiguation: append ":modality" only for cameras shown with >1 modality.
+        per_cam = Counter(name for name, _ in self._panels)
+        self._multi_modality = {name for name, n in per_cam.items() if n > 1}
+
+        self._env_ids = list(config.env_ids)
+        self._depth_range = (config.depth_range[0], config.depth_range[1]) if config.depth_range else (0.01, 5.0)
+
+        # Panels + env_ids are set, so wanted_streams() works: validate streams and register the
+        # publish/close callbacks. Fields below use self.config / self.control_hz (set by super).
+        super().__init__(config, simulator)
+
+        self._frame_decimation = self._resolve_frame_decimation()
+
+        # Live window viable only with a non-headless sim AND a usable display.
+        self._show_live = config.live_window and not simulator.headless and bool(os.environ.get("DISPLAY"))
+        if config.live_window and not self._show_live:
+            logger.warning("CameraVizPlugin: live_window requested but no display; window disabled.")
+        self._window_open = False
+        self._cell_wh = {name: (c.width, c.height) for name, c in cams_by_name.items()}
+
+    def _resolve_frame_decimation(self) -> int:
+        # update_decimation is in units of the fastest watched camera's RENDERED frames. An int is
+        # already that; a frequency string is a target against the control rate, converted to frames
+        # via the fastest watched camera's render decimation (d_min control steps between its frames).
+        cfg = self.config
+        if not is_frequency_string(cfg.update_decimation):
+            return int(cfg.update_decimation)
+        # We do not see SensorManager here; approximate d_min as 1 (publish() already only fires on
+        # steps a panel rendered, so the batch cadence is the fastest camera's frame cadence).
+        n_viz = resolve_decimation(cfg.update_decimation, self.control_hz, field="recorder update_decimation")
+        return max(1, n_viz)
+
+    def wanted_streams(self) -> set[StreamKey]:
+        return {(cam, mod, env) for (cam, mod) in self._panels for env in self._env_ids}
+
+    def start(self) -> None:
+        logger.info(
+            f"CameraVizPlugin active: panels={[f'{n}:{m}' for n, m in self._panels]} "
+            f"envs={self._env_ids} live_window={self._show_live} record_video={self.config.record_video}"
+        )
+
+    def publish(self, frames: dict[StreamKey, FramePacket]) -> None:
+        if not self._panels or not (self._show_live or self.config.record_video):
+            return
+        # Batch arrival == this step's fastest watched camera rendered. Gate by frame-decimation.
+        self._step += 1
+        if self._step - self._last_captured < self._frame_decimation:
+            return
+        self._last_captured = self._step
+
+        views: list[np.ndarray] = []
+        labels: list[str] = []
+        for env in self._env_ids:
+            for name, modality in self._panels:
+                packet = frames.get((name, modality, env))
+                if packet is None:
+                    w, h = self._cell_wh.get(name, (128, 128))
+                    views.append(self._missing_tile(w, h))
+                else:
+                    img = packet.array
+                    if modality == "depth":
+                        img = colorize_depth(img, self._depth_range, self.config.depth_colormap)
+                    views.append(img)
+                label = f"env{env}/{name}"
+                labels.append(f"{label}:{modality}" if name in self._multi_modality else label)
+        grid = tile_images(views, layout=(len(self._env_ids), len(self._panels)), labels=labels)  # RGB
+
+        if self._show_live:
+            self._show(grid)
+        if self.config.record_video:
+            self._frames_video.append(grid)
+
+    def _show(self, grid: np.ndarray) -> None:
+        cv2.imshow(_WINDOW, cv2.cvtColor(grid, cv2.COLOR_RGB2BGR))
+        cv2.pollKey()  # non-blocking HighGUI pump (unlike waitKey(1))
+        if self._window_open and cv2.getWindowProperty(_WINDOW, cv2.WND_PROP_VISIBLE) < 1:
+            self._show_live = False  # user closed it -> stop drawing live for the rest of the run
+            self._window_open = False
+        else:
+            self._window_open = True
+
+    @staticmethod
+    def _missing_tile(width: int, height: int, cell: int = 16) -> np.ndarray:
+        """Source-style magenta/black 'missing texture' for a panel with no frame yet (RGB)."""
+        ys = (np.arange(height) // cell)[:, None]
+        xs = (np.arange(width) // cell)[None, :]
+        tile = np.zeros((height, width, 3), dtype=np.uint8)
+        tile[(ys + xs) % 2 == 1] = (255, 0, 255)
+        return tile
+
+    def stop(self) -> None:
+        if self.config.record_video and self._frames_video:
+            # Capture cadence = the recorder's frame-decimation (batches already track the fastest
+            # camera's render rate). Encode fps so the video plays at true wall-clock speed.
+            fps = self.control_hz / self._frame_decimation * self.config.playback_rate
+            create_video(
+                np.array(self._frames_video, dtype=np.uint8),
+                fps=fps,
+                save_dir=str(self._save_dir()),
+                output_format="h264",
+                wandb_logging=False,
+            )
+            self._frames_video = []
+        if self._window_open:
+            cv2.destroyWindow(_WINDOW)
+            self._window_open = False
+
+    def _save_dir(self) -> Path:
+        if self.config.save_dir is not None:
+            return Path(self.config.save_dir)
+        spectator_dir = self.simulator.video_config.save_dir
+        return Path(spectator_dir) if spectator_dir else Path("logs/camera_sensors")

--- a/src/holosoma/holosoma/simulator/shared/camera_sensor.py
+++ b/src/holosoma/holosoma/simulator/shared/camera_sensor.py
@@ -1,0 +1,154 @@
+"""Shared, backend-agnostic camera-sensor substrate.
+
+Holds the :class:`SensorManager`, a read-only camera registry. It owns one
+:class:`CameraRuntime` per configured camera and the decimation lifecycle
+(:meth:`SensorManager.collect_due`).
+
+The camera optical frame is -Z forward, +Y up: a camera at an identity mount quaternion looks down
+its own -Z. IsaacGym converts the mount orientation to its own camera basis at its boundary.
+
+See ``BaseSimulator.get_camera_data`` for the full public data format.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from holosoma.config_types.frequency import resolve_decimation
+from holosoma.utils.safe_torch_import import torch
+
+if TYPE_CHECKING:
+    from holosoma.config_types.sensor import CameraSensorConfig
+
+
+@dataclass
+class CameraRuntime:
+    """Per-camera runtime record held by :class:`SensorManager`.
+
+    Backend-agnostic bookkeeping only; holds no native camera handle. Each backend resolves its own
+    native resource from a name-keyed map using ``name`` (the sensor key).
+    """
+
+    name: str
+    """Sensor name (the --sensor dict key); the backend's native-resource lookup key."""
+
+    config: CameraSensorConfig
+
+    buffers: dict[str, torch.Tensor] = field(default_factory=dict)
+    """Most recent render per data_type on the SIM device (e.g. {"rgb": [N,H,W,3] uint8}). Write via
+    :meth:`set_buffer` (never assign directly) so the cross-device cache stays consistent."""
+
+    step_counter: int = -1
+    """Render counter for decimation gating (``step_counter % decimation == 0``). Advanced by
+    :meth:`SensorManager.collect_due`; starts at -1 so the gate fires on the first render."""
+
+    effective_decimation: int = 1
+    """Control-step decimation as an int, resolved from ``config.update_decimation`` (which may be
+    a frequency string) at registration."""
+
+    _device_cache: dict[tuple[str, str], torch.Tensor] = field(default_factory=dict)
+    """Cross-device copies of ``buffers``, keyed by ``(data_type, str(device))``. Populated lazily by
+    :meth:`buffer_on` (e.g. the host copy every off-GPU consumer shares), cleared by :meth:`set_buffer`
+    when a fresh render lands. Never a copy of the sim-device buffer itself (that is served directly)."""
+
+    def set_buffer(self, data_type: str, tensor: torch.Tensor) -> None:
+        """Store the latest render for ``data_type`` and drop any now-stale cross-device copies of it.
+
+        The single write path for a rendered frame: invalidation is co-located with the mutation, so
+        a cached host copy can never outlive the sim-device buffer it was derived from. Called by each
+        backend's ``render_sensors`` (once per due camera per step) in place of a raw ``buffers[...] =``."""
+        self.buffers[data_type] = tensor
+        for key in [k for k in self._device_cache if k[0] == data_type]:
+            del self._device_cache[key]
+
+    def buffer_on(self, data_type: str, device: torch.device | str | None = None) -> torch.Tensor:
+        """Return the full ``[N, ...]`` buffer for ``data_type`` on ``device`` (cross-device copies cached).
+
+        ``device=None`` (or the sim device the buffer already lives on) returns the buffer directly —
+        no copy, no cache entry. Any other device returns a cached ``.to(device)`` copy: the FIRST
+        caller for a given ``(data_type, device)`` pays the transfer (one device->host sync for
+        ``"cpu"``), every later caller this render reuses it. The cache is invalidated by
+        :meth:`set_buffer` on the next render, so a slow (decimated) camera keeps serving cheap cached
+        reads across the steps it does not re-render."""
+        buf = self.buffers[data_type]
+        if device is None:
+            return buf
+        dev = torch.device(device)
+        if buf.device == dev:
+            return buf
+        key = (data_type, str(dev))
+        cached = self._device_cache.get(key)
+        if cached is None:
+            cached = buf.to(dev)
+            self._device_cache[key] = cached
+        return cached
+
+
+class SensorManager:
+    """Read-only registry of mounted cameras for one simulator instance.
+
+    Holds :class:`CameraRuntime` records keyed by sensor name and exposes name-keyed lookups. Owns
+    no settable pose state.
+    """
+
+    def __init__(self, device: str, control_hz: float) -> None:
+        self.device = device
+        self.control_hz = control_hz
+        """Control-step rate (fps/control_decimation), the base for per-camera update_decimation."""
+        self._cameras: dict[str, CameraRuntime] = {}
+        self._last_due: set[str] = set()
+        """Names of cameras that rendered on the most recent ``collect_due`` call. Empty until the
+        first ``collect_due``."""
+
+    # ----- registration (called by the backend during its sensor setup) -----
+
+    def register_camera(self, name: str, config: CameraSensorConfig) -> CameraRuntime:
+        """Register one camera under ``name``. data_types are already validated by ``CameraSensorConfig``."""
+        if name in self._cameras:
+            raise ValueError(f"Camera '{name}' already registered.")
+        eff = resolve_decimation(config.update_decimation, self.control_hz, field=f"camera '{name}' update_decimation")
+        runtime = CameraRuntime(name=name, config=config, effective_decimation=eff)
+        self._cameras[name] = runtime
+        return runtime
+
+    # ----- lookups -----
+
+    def has_camera(self, name: str) -> bool:
+        return name in self._cameras
+
+    def get(self, name: str) -> CameraRuntime:
+        if name not in self._cameras:
+            raise KeyError(f"No camera named '{name}'. Registered cameras: {sorted(self._cameras)}.")
+        return self._cameras[name]
+
+    @property
+    def names(self) -> list[str]:
+        return list(self._cameras)
+
+    @property
+    def cameras(self) -> list[CameraRuntime]:
+        return list(self._cameras.values())
+
+    def collect_due(self) -> list[CameraRuntime]:
+        """Advance every camera's render counter and return those due to render this step.
+
+        Called once per control step by a backend's ``render_sensors`` before the native render.
+        """
+        due = []
+        for runtime in self._cameras.values():
+            runtime.step_counter += 1
+            if runtime.step_counter % runtime.effective_decimation == 0:
+                due.append(runtime)
+        self._last_due = {rt.name for rt in due}
+        return due
+
+    @property
+    def last_due(self) -> set[str]:
+        """Camera names that rendered on the most recent ``collect_due`` (empty before the first)."""
+        return self._last_due
+
+    def frames_produced(self, name: str) -> int:
+        """Number of frames a camera has rendered so far (0 before its first render)."""
+        runtime = self.get(name)
+        return runtime.step_counter // runtime.effective_decimation + 1  # -1 -> 0 (floor div)

--- a/src/holosoma/holosoma/simulator/shared/image_transform.py
+++ b/src/holosoma/holosoma/simulator/shared/image_transform.py
@@ -1,0 +1,73 @@
+"""Shared image-transform helper for camera observation terms.
+
+Turns a ``get_camera_data`` frame (``[N, H, W, C]``, rgb uint8 [0,255] or depth float32 meters
+with a ``+inf`` no-hit) into the layout/dtype a visual policy expects, applied in a fixed order:
+resize, scale, layout, flatten. Each step is opt-in via :class:`ImageTransformConfig`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from holosoma.utils.safe_torch_import import torch
+
+if TYPE_CHECKING:
+    from holosoma.config_types.sensor import ImageTransformConfig
+
+
+def apply_image_transform(image: torch.Tensor, config: ImageTransformConfig, modality: str) -> torch.Tensor:
+    """Apply ``config`` to a ``[N, H, W, C]`` camera frame.
+
+    Parameters
+    ----------
+    image : torch.Tensor
+        ``[N, H, W, C]``, rgb uint8 [0,255] or depth float32 meters (``+inf`` no-hit).
+    config : ImageTransformConfig
+        The transform spec (resize / scale / layout / flatten / depth_range).
+    modality : str
+        ``"rgb"`` or ``"depth"``; selects bilinear vs nearest resize and the scaling rule.
+
+    Returns
+    -------
+    torch.Tensor
+        ``[N, H', W', C]`` (HWC), ``[N, C, H', W']`` (CHW), or ``[N, C*H'*W']`` (CHW + flatten),
+        dtype per ``config.scale``.
+    """
+    if config.resize is not None:
+        image = _resize(image, config.resize, modality)
+    image = _scale(image, config, modality)  # before layout: _scale assumes HWC channel-last
+    if config.layout == "CHW":
+        image = image.permute(0, 3, 1, 2).contiguous()
+    if config.flatten:
+        image = image.reshape(image.shape[0], -1)
+    return image
+
+
+def _resize(image: torch.Tensor, size: list[int], modality: str) -> torch.Tensor:
+    """Resize ``[N, H, W, C]`` to ``[N, size[0], size[1], C]`` (bilinear rgb, nearest depth).
+
+    Depth uses nearest to keep the +inf no-hit sentinel; bilinear would blend it into finite
+    distances.
+    """
+    # interpolate wants NCHW; round-trip the channel axis.
+    nchw = image.permute(0, 3, 1, 2).float()
+    mode = "nearest" if modality == "depth" else "bilinear"
+    kwargs = {"align_corners": False} if mode == "bilinear" else {}
+    resized = torch.nn.functional.interpolate(nchw, size=(size[0], size[1]), mode=mode, **kwargs)
+    out = resized.permute(0, 2, 3, 1)
+    return out.round().to(image.dtype) if modality == "rgb" else out
+
+
+def _scale(image: torch.Tensor, config: ImageTransformConfig, modality: str) -> torch.Tensor:
+    """Map a frame to ``config.scale`` (uint8 passthrough, float [0,1], or float [-1,1])."""
+    if config.scale == "native":
+        return image
+    if modality == "rgb":
+        unit = image.float() / 255.0  # [0,1]
+    else:
+        if config.depth_range is None:
+            raise ValueError("ImageTransformConfig.depth_range is required to scale depth to a float range.")
+        lo, hi = config.depth_range
+        # Clamp to range and normalize to [0,1]; +inf no-hit clamps to the far end (1.0).
+        unit = (image.float().clamp(lo, hi) - lo) / (hi - lo)
+    return unit if config.scale == "float01" else unit * 2.0 - 1.0

--- a/src/holosoma/holosoma/simulator/shared/simulator_bridge.py
+++ b/src/holosoma/holosoma/simulator/shared/simulator_bridge.py
@@ -80,10 +80,6 @@ class SimulatorBridge:
         hooks.add(Phase.PRE_STEP, self.step, name="bridge.step")
         hooks.add(Phase.CLOSE, self.close, name="bridge.close")
 
-    def close(self) -> None:
-        """Tear down bridge-owned resources (clock publisher ZMQ socket)."""
-        self.clock_pub.close()
-
     def _init_robot_bridge(self):
         """Initialize the robot bridge using the copied factory function."""
         try:
@@ -184,3 +180,13 @@ class SimulatorBridge:
             "robot_bridge_initialized": self.robot_bridge is not None,
             "has_joystick": self.robot_bridge is not None and self.robot_bridge.joystick is not None,
         }
+
+    def close(self) -> None:
+        """Tear down the bridge and its resources.
+
+        Stops the clock publisher and, for the multiprocess Unitree bridge, joins its spawned DDS
+        child (a plain in-process bridge has no ``close`` and is skipped). Safe to call more than once.
+        """
+        if self.robot_bridge is not None and hasattr(self.robot_bridge, "close"):
+            self.robot_bridge.close()
+        self.clock_pub.close()

--- a/src/holosoma/holosoma/simulator/shared/tests/test_camera_runtime_cache.py
+++ b/src/holosoma/holosoma/simulator/shared/tests/test_camera_runtime_cache.py
@@ -1,0 +1,95 @@
+"""Unit tests for CameraRuntime's cross-device buffer cache (pure, no simulator, CPU-only).
+
+``set_buffer`` is the single write path for a rendered frame and co-locates cache invalidation with
+the mutation; ``buffer_on`` serves cross-device copies, caching the first transfer per
+``(data_type, device)`` so several consumers reading the same frame on host cost one copy. These pin
+the caching + invalidation contract without a GPU by counting ``.to`` calls on a wrapper tensor.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from holosoma.simulator.shared.camera_sensor import CameraRuntime
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+
+class _CountingTensor(torch.Tensor):
+    """A Tensor that counts ``.to(device)`` calls, to assert cross-device copies happen once.
+
+    ``.to("cpu")`` on a cpu tensor is normally a no-op that returns self; here we force it to mint a
+    fresh (plain) tensor and bump a counter so a test in a CPU-only env can still prove the cache
+    collapses N reads into one copy. The returned copy is a plain Tensor, so it is not itself counted.
+    """
+
+    to_calls: int
+
+    @staticmethod
+    def wrap(data: torch.Tensor) -> _CountingTensor:
+        t = data.as_subclass(_CountingTensor)
+        t.to_calls = 0
+        return t
+
+    def to(self, *args, **kwargs):  # type: ignore[override]
+        self.to_calls += 1
+        # Return a distinct plain tensor so identity checks distinguish "the copy" from "the buffer".
+        return torch.Tensor.clone(torch.Tensor.as_subclass(self, torch.Tensor))
+
+
+def _rt(buf: torch.Tensor) -> CameraRuntime:
+    rt = CameraRuntime(name="c", config=None)  # type: ignore[arg-type]  # test stub: buffer-only runtime, no real config
+    rt.set_buffer("rgb", buf)
+    return rt
+
+
+def test_device_none_returns_buffer_without_copy():
+    buf = _CountingTensor.wrap(torch.zeros(1, 2, 2, 3, dtype=torch.uint8))
+    rt = _rt(buf)
+    assert rt.buffer_on("rgb", None) is buf
+    assert buf.to_calls == 0
+    assert rt._device_cache == {}
+
+
+def test_cross_device_copy_is_cached_across_reads():
+    # Force a "different device" path via a fake device str so .to() actually fires in a CPU env.
+    buf = _CountingTensor.wrap(torch.zeros(1, 2, 2, 3, dtype=torch.uint8))
+    rt = CameraRuntime(name="c", config=None)  # type: ignore[arg-type]  # test stub: buffer-only runtime, no real config
+    rt.set_buffer("rgb", buf)
+    a = rt.buffer_on("rgb", "meta")  # a non-cpu device string -> triggers .to
+    b = rt.buffer_on("rgb", "meta")  # second read reuses the cache
+    assert buf.to_calls == 1  # only the first read paid the copy
+    assert a is b  # same cached object handed to both consumers
+
+
+def test_set_buffer_invalidates_stale_cross_device_copies():
+    buf1 = _CountingTensor.wrap(torch.zeros(1, 2, 2, 3, dtype=torch.uint8))
+    rt = CameraRuntime(name="c", config=None)  # type: ignore[arg-type]  # test stub: buffer-only runtime, no real config
+    rt.set_buffer("rgb", buf1)
+    first = rt.buffer_on("rgb", "meta")
+    assert buf1.to_calls == 1
+
+    # A fresh render replaces the buffer -> the old host copy must be dropped, next read re-copies.
+    buf2 = _CountingTensor.wrap(torch.ones(1, 2, 2, 3, dtype=torch.uint8))
+    rt.set_buffer("rgb", buf2)
+    assert rt._device_cache == {}  # invalidated at the write site
+    second = rt.buffer_on("rgb", "meta")
+    assert buf2.to_calls == 1  # copied from the NEW buffer
+    assert second is not first
+
+
+def test_set_buffer_only_invalidates_its_own_modality():
+    # A depth render must not evict a cached rgb copy (different data_type keys).
+    rgb = _CountingTensor.wrap(torch.zeros(1, 2, 2, 3, dtype=torch.uint8))
+    depth = _CountingTensor.wrap(torch.zeros(1, 2, 2, 1, dtype=torch.float32))
+    rt = CameraRuntime(name="c", config=None)  # type: ignore[arg-type]  # test stub: buffer-only runtime, no real config
+    rt.set_buffer("rgb", rgb)
+    rt.set_buffer("depth", depth)
+    rt.buffer_on("rgb", "meta")
+    rt.buffer_on("depth", "meta")
+    assert set(rt._device_cache) == {("rgb", "meta"), ("depth", "meta")}
+
+    # Re-render ONLY depth: rgb's cached copy survives, depth's is dropped.
+    rt.set_buffer("depth", _CountingTensor.wrap(torch.ones(1, 2, 2, 1, dtype=torch.float32)))
+    assert set(rt._device_cache) == {("rgb", "meta")}

--- a/src/holosoma/holosoma/simulator/shared/tests/test_get_camera_data.py
+++ b/src/holosoma/holosoma/simulator/shared/tests/test_get_camera_data.py
@@ -1,0 +1,95 @@
+"""Unit tests for the shared ``BaseSimulator.get_camera_data`` accessor (pure, no simulator).
+
+The accessor lives once on the base class and reads buffers filled by a backend's ``render_sensors``.
+These pin its two sim-free failure modes and the env-id slicing, on a minimal stub, so the behavior
+holds identically regardless of backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from holosoma.simulator.base_simulator.base_simulator import BaseSimulator
+from holosoma.simulator.shared.camera_sensor import CameraRuntime
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+
+class _Manager:
+    """Minimal SensorManager-shaped stub: name -> CameraRuntime with prefilled buffers."""
+
+    def __init__(self, runtimes: dict[str, CameraRuntime]):
+        self._runtimes = runtimes
+
+    def has_camera(self, name: str) -> bool:
+        return name in self._runtimes
+
+    def get(self, name: str) -> CameraRuntime:
+        return self._runtimes[name]
+
+    @property
+    def names(self) -> list[str]:
+        return list(self._runtimes)
+
+
+def _sim(manager) -> BaseSimulator:
+    sim = BaseSimulator.__new__(BaseSimulator)  # skip __init__ (needs a full config)
+    sim.sensor_manager = manager
+    return sim
+
+
+def test_no_sensor_manager_raises_not_implemented():
+    sim = _sim(None)
+    with pytest.raises(NotImplementedError, match="no camera 'head'"):
+        sim.get_camera_data("head", "rgb")
+
+
+def test_missing_camera_raises_not_implemented():
+    sim = _sim(_Manager({}))
+    with pytest.raises(NotImplementedError, match="no camera 'head'"):
+        sim.get_camera_data("head", "rgb")
+
+
+def test_missing_buffer_raises_runtime_error():
+    # test stub: buffer-only runtime, no real config; no buffers filled (render_sensors never ran).
+    rt = CameraRuntime(name="head", config=None)  # type: ignore[arg-type]
+    sim = _sim(_Manager({"head": rt}))
+    with pytest.raises(RuntimeError, match="no 'rgb' frame"):
+        sim.get_camera_data("head", "rgb")
+
+
+def test_returns_full_buffer_and_env_subset():
+    buf = torch.arange(3 * 2 * 2 * 3, dtype=torch.uint8).reshape(3, 2, 2, 3)
+    rt = CameraRuntime(name="head", config=None, buffers={"rgb": buf})  # type: ignore[arg-type]  # test stub: buffer-only runtime, no real config
+    sim = _sim(_Manager({"head": rt}))
+    assert torch.equal(sim.get_camera_data("head", "rgb"), buf)  # env_ids=None -> all
+    subset = sim.get_camera_data("head", "rgb", env_ids=[0, 2])
+    assert torch.equal(subset, buf[[0, 2]])
+
+
+def test_device_none_returns_sim_buffer_directly_no_cache():
+    # device=None (default) is the identity path: the sim-device buffer itself, no cross-device copy.
+    buf = torch.arange(2 * 2 * 2 * 3, dtype=torch.uint8).reshape(2, 2, 2, 3)  # already cpu in this env
+    rt = CameraRuntime(name="head", config=None, buffers={"rgb": buf})  # type: ignore[arg-type]  # test stub: buffer-only runtime, no real config
+    sim = _sim(_Manager({"head": rt}))
+    assert sim.get_camera_data("head", "rgb", device=None) is buf  # no copy
+    assert rt._device_cache == {}  # nothing cached
+
+
+def test_same_device_as_buffer_is_passthrough():
+    # Asking for the device the buffer already lives on returns it directly (no cache entry).
+    buf = torch.zeros(1, 2, 2, 3, dtype=torch.uint8)  # cpu
+    rt = CameraRuntime(name="head", config=None, buffers={"rgb": buf})  # type: ignore[arg-type]  # test stub: buffer-only runtime, no real config
+    sim = _sim(_Manager({"head": rt}))
+    assert sim.get_camera_data("head", "rgb", device="cpu") is buf
+    assert rt._device_cache == {}
+
+
+def test_env_subset_slices_the_device_buffer():
+    buf = torch.arange(3 * 1 * 1 * 3, dtype=torch.uint8).reshape(3, 1, 1, 3)
+    rt = CameraRuntime(name="head", config=None, buffers={"rgb": buf})  # type: ignore[arg-type]  # test stub: buffer-only runtime, no real config
+    sim = _sim(_Manager({"head": rt}))
+    # device + env_ids compose: slice the (cached) full buffer for that device.
+    subset = sim.get_camera_data("head", "rgb", env_ids=[1, 2], device="cpu")
+    assert torch.equal(subset, buf[[1, 2]])

--- a/src/holosoma/holosoma/simulator/shared/tests/test_image_transform.py
+++ b/src/holosoma/holosoma/simulator/shared/tests/test_image_transform.py
@@ -1,0 +1,126 @@
+"""Unit tests for the camera image-transform helper (pure torch, no simulator).
+
+Pins the fixed transform order (resize -> layout -> scale) and the frame semantics a
+visual policy depends on: HWC<->CHW layout, uint8/float[0,1]/float[-1,1] scaling, depth range
+normalization with the +inf no-hit mapped to the far end.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from holosoma.config_types.sensor import ImageTransformConfig
+from holosoma.simulator.shared.image_transform import apply_image_transform
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+
+def _rgb(n=2, h=8, w=6):
+    return torch.randint(0, 256, (n, h, w, 3), dtype=torch.uint8)
+
+
+def test_default_is_identity_passthrough():
+    rgb = _rgb()
+    out = apply_image_transform(rgb, ImageTransformConfig(), "rgb")
+    assert out.dtype == torch.uint8 and tuple(out.shape) == (2, 8, 6, 3)
+    assert torch.equal(out, rgb)
+
+
+def test_chw_layout_permutes():
+    out = apply_image_transform(_rgb(), ImageTransformConfig(layout="CHW"), "rgb")
+    assert tuple(out.shape) == (2, 3, 8, 6)  # [N, C, H, W]
+
+
+def test_flatten_produces_1d_per_env():
+    out = apply_image_transform(_rgb(n=2, h=8, w=6), ImageTransformConfig(layout="CHW", flatten=True), "rgb")
+    assert tuple(out.shape) == (2, 3 * 8 * 6)  # [N, C*H*W]
+
+
+def test_flatten_roundtrips_through_cnnwrapper_view():
+    # The flat vector must be CHW-ordered so CNNWrapper's view(N, C, H, W) reconstructs the image.
+    rgb = _rgb(n=2, h=8, w=6)
+    chw = apply_image_transform(rgb, ImageTransformConfig(layout="CHW"), "rgb")  # [N, C, H, W]
+    flat = apply_image_transform(rgb, ImageTransformConfig(layout="CHW", flatten=True), "rgb")
+    reconstructed = flat.view(2, 3, 8, 6)  # exactly what CNNWrapper.forward does
+    assert torch.equal(reconstructed, chw)
+
+
+def test_flatten_requires_chw_layout():
+    with pytest.raises(ValueError, match="flatten requires layout='CHW'"):
+        ImageTransformConfig(layout="HWC", flatten=True)
+
+
+def test_resize_rgb_bilinear_keeps_uint8():
+    out = apply_image_transform(_rgb(), ImageTransformConfig(resize=[4, 4]), "rgb")
+    assert tuple(out.shape) == (2, 4, 4, 3) and out.dtype == torch.uint8
+
+
+def test_resize_nonsquare_target_and_axis_order():
+    # Non-square target [H=4, W=8] from a non-square input [6, 10]: a (W, H) axis swap in the
+    # interpolate call would yield (2, 8, 4, 3) and fail. A vertical brightness ramp (rows differ,
+    # columns constant) also catches a transpose by VALUE: after resize the gradient must stay
+    # along rows (row 0 darkest, last row brightest), not along columns.
+    ramp = torch.zeros((2, 6, 10, 3), dtype=torch.uint8)
+    for r in range(6):
+        ramp[:, r, :, :] = r * 40  # brightness increases down the rows, constant across columns
+    out = apply_image_transform(ramp, ImageTransformConfig(resize=[4, 8]), "rgb")
+    assert tuple(out.shape) == (2, 4, 8, 3)
+    col_mean = out[0, :, :, 0].float().mean(dim=1)  # mean per row
+    assert torch.all(col_mean[1:] >= col_mean[:-1])  # ramp preserved along rows (no transpose)
+    assert float(out[0, :, 0, 0].float().std()) > 1.0  # rows vary
+    assert float(out[0, 0, :, 0].float().std()) < 1e-3  # columns constant within a row
+
+
+def test_float01_scaling_range():
+    rgb = torch.full((1, 2, 2, 3), 255, dtype=torch.uint8)
+    out = apply_image_transform(rgb, ImageTransformConfig(scale="float01"), "rgb")
+    assert out.dtype == torch.float32 and float(out.max()) == 1.0 and float(out.min()) == 1.0
+
+
+def test_float_pm1_scaling_range():
+    rgb = torch.zeros((1, 2, 2, 3), dtype=torch.uint8)
+    out = apply_image_transform(rgb, ImageTransformConfig(scale="float_pm1"), "rgb")
+    assert float(out.min()) == -1.0  # 0 -> -1
+
+
+def test_full_chain_chw_resize_float01():
+    out = apply_image_transform(_rgb(), ImageTransformConfig(resize=[4, 4], layout="CHW", scale="float01"), "rgb")
+    assert tuple(out.shape) == (2, 3, 4, 4) and out.dtype == torch.float32
+    assert float(out.min()) >= 0.0 and float(out.max()) <= 1.0
+
+
+def test_depth_float01_maps_range_and_inf_to_far():
+    depth = torch.full((1, 4, 4, 1), 2.0)
+    depth[0, 0, 0, 0] = float("inf")  # no-hit
+    out = apply_image_transform(depth, ImageTransformConfig(scale="float01", depth_range=[0.5, 5.0]), "depth")
+    assert float(out[0, 0, 0, 0]) == 1.0  # +inf -> far end
+    assert abs(float(out[0, 1, 1, 0]) - (2.0 - 0.5) / 4.5) < 1e-5  # mid distance normalized
+
+
+def test_depth_float_pm1_maps_range_and_inf_to_plus1():
+    depth = torch.full((1, 4, 4, 1), 0.5)  # at the near end of [0.5, 5.0] -> -1
+    depth[0, 0, 0, 0] = float("inf")  # no-hit -> far end -> +1
+    out = apply_image_transform(depth, ImageTransformConfig(scale="float_pm1", depth_range=[0.5, 5.0]), "depth")
+    assert abs(float(out[0, 1, 1, 0]) - (-1.0)) < 1e-5  # near distance -> -1
+    assert abs(float(out[0, 0, 0, 0]) - 1.0) < 1e-5  # +inf -> far end -> +1
+
+
+def test_depth_resize_nearest_preserves_inf():
+    depth = torch.full((1, 8, 8, 1), 3.0)
+    depth[0, 0, 0, 0] = float("inf")
+    out = apply_image_transform(depth, ImageTransformConfig(resize=[4, 4]), "depth")
+    assert tuple(out.shape) == (1, 4, 4, 1)
+    assert torch.isinf(out).any()  # nearest keeps the no-hit sentinel (bilinear would blend it away)
+
+
+def test_depth_float_without_range_raises():
+    with pytest.raises(ValueError, match="depth_range is required"):
+        apply_image_transform(torch.zeros((1, 2, 2, 1)), ImageTransformConfig(scale="float01"), "depth")
+
+
+def test_config_rejects_bad_resize_and_range():
+    with pytest.raises(ValueError, match="resize must be positive"):
+        ImageTransformConfig(resize=[0, 4])
+    with pytest.raises(ValueError, match="depth_range must be"):
+        ImageTransformConfig(depth_range=[5.0, 1.0])

--- a/src/holosoma/holosoma/simulator/shared/tests/test_optical_frame.py
+++ b/src/holosoma/holosoma/simulator/shared/tests/test_optical_frame.py
@@ -1,0 +1,59 @@
+"""Unit test for the IsaacGym camera optical-axis change-of-basis (pure torch, no simulator).
+
+The invariant: composing the optical mount orientation with the optical->IsaacGym basis and
+applying it to IsaacGym's native axes (+X fwd / +Z up) yields the SAME world forward AND up as
+applying the mount directly to the optical axes (-Z fwd / +Y up), which is what MuJoCo/IsaacSim
+do natively. The basis is defined in ``simulator/isaacgym/isaacgym.py``; it is duplicated here as a
+literal so the convention can be checked without importing the IsaacGym SDK.
+
+The cases include roll-bearing mounts (upright forward, pitched-down): a forward-only
+basis check passes a pure-pitch-about-Y mount but misses an optical-axis roll (up -> -Y instead of
++Y), so up is asserted explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from holosoma.utils.rotations import quat_apply, quat_mul
+
+pytestmark = pytest.mark.no_sim
+
+# Optical->IsaacGym change-of-basis (xyzw); mirrors _CANONICAL_TO_ISAACGYM_XYZW in the backend.
+_CANONICAL_TO_ISAACGYM_XYZW = (0.5, -0.5, -0.5, -0.5)
+
+# Optical-frame axes (-Z fwd / +Y up) and IsaacGym's native camera axes (+X fwd / +Z up).
+_CANON_FWD = torch.tensor([0.0, 0.0, -1.0])  # -Z forward
+_CANON_UP = torch.tensor([0.0, 1.0, 0.0])  # +Y up
+_IG_FWD = torch.tensor([1.0, 0.0, 0.0])  # +X forward
+_IG_UP = torch.tensor([0.0, 0.0, 1.0])  # +Z up
+
+# Mount orientations (w, x, y, z). Includes the production g1 presets (which carry real roll) plus a
+# pure-pitch case (forward-only checks cannot detect roll on it).
+_MOUNTS_WXYZ = {
+    "identity": [1.0, 0.0, 0.0, 0.0],
+    "look_forward_upright": [0.5, 0.5, -0.5, -0.5],  # g1 head_cam: fwd +X, up +Z
+    "look_forward_down": [0.61237244, 0.35355339, -0.35355339, -0.61237244],  # g1 wrist grasp view
+    "pure_pitch_-90_about_y": [0.70710678, 0.0, -0.70710678, 0.0],
+}
+
+
+@pytest.mark.parametrize("name", list(_MOUNTS_WXYZ))
+def test_isaacgym_basis_matches_canonical_forward_and_up(name: str) -> None:
+    """IsaacGym's converted mount must yield the SAME world forward AND up as the optical frame."""
+    wxyz = torch.tensor([_MOUNTS_WXYZ[name]])
+    xyzw = wxyz[:, [1, 2, 3, 0]]
+
+    # MuJoCo/IsaacSim: mount applied directly to the optical axes.
+    canon_fwd = quat_apply(xyzw, _CANON_FWD, w_last=True)
+    canon_up = quat_apply(xyzw, _CANON_UP, w_last=True)
+    # IsaacGym: composed mount applied to IsaacGym's native axes.
+    basis = torch.tensor([_CANONICAL_TO_ISAACGYM_XYZW])
+    native = quat_mul(xyzw, basis, w_last=True)
+    ig_fwd = quat_apply(native, _IG_FWD, w_last=True)
+    ig_up = quat_apply(native, _IG_UP, w_last=True)
+
+    torch.testing.assert_close(ig_fwd, canon_fwd, atol=1e-5, rtol=0, msg=f"{name}: forward axis differs")
+    # Up must also match: a forward-only basis check passes but leaves an optical-axis roll.
+    torch.testing.assert_close(ig_up, canon_up, atol=1e-5, rtol=0, msg=f"{name}: up axis differs (optical-axis roll)")

--- a/src/holosoma/holosoma/simulator/shared/tests/test_sensor_manager.py
+++ b/src/holosoma/holosoma/simulator/shared/tests/test_sensor_manager.py
@@ -1,0 +1,109 @@
+"""Unit tests for the SensorManager decimation lifecycle and modality gating (pure, no simulator).
+
+Every backend's ``render_sensors`` drives ``collect_due`` (increment + gate), so the first frame
+renders even at ``decimation > 1`` and ``frames_produced`` is an exact render count. Also pins that
+an unknown modality is rejected at config construction, so a backend never silently diverges on an
+unsupported data_type.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from holosoma.config_types.sensor import CameraSensorConfig, SensorMountConfig
+from holosoma.simulator.shared.camera_sensor import SensorManager
+
+pytestmark = pytest.mark.no_sim
+
+_MOUNT = SensorMountConfig(target_kind="robot_link", target="pelvis")
+
+
+def _cam(*, update_decimation=1, data_types=None) -> CameraSensorConfig:
+    return CameraSensorConfig(mount=_MOUNT, update_decimation=update_decimation, data_types=data_types or ["rgb"])
+
+
+def _drive(manager: SensorManager, steps: int) -> dict[str, list[bool]]:
+    """Drive ``collect_due`` for ``steps`` steps; return per-camera due/not-due sequences."""
+    seq: dict[str, list[bool]] = {name: [] for name in manager.names}
+    for _ in range(steps):
+        due_names = {rt.name for rt in manager.collect_due()}
+        for name in manager.names:
+            seq[name].append(name in due_names)
+    return seq
+
+
+def test_decimation_one_renders_every_step():
+    sm = SensorManager(device="cpu", control_hz=200.0)
+    sm.register_camera("c", _cam(update_decimation=1))
+    assert _drive(sm, 4)["c"] == [True, True, True, True]
+
+
+def test_decimation_two_renders_on_first_step_then_every_other():
+    # A dec>1 camera renders on its FIRST step (counter -1 -> 0), not skipping until step `dec`.
+    # So the sequence is [True, False, True, False, ...].
+    sm = SensorManager(device="cpu", control_hz=200.0)
+    sm.register_camera("c", _cam(update_decimation=2))
+    assert _drive(sm, 5)["c"] == [True, False, True, False, True]
+
+
+def test_frequency_string_resolves_and_gates():
+    # "50Hz" against a 200Hz control rate floors to decimation 4: render on step 0, then every 4th.
+    sm = SensorManager(device="cpu", control_hz=200.0)
+    sm.register_camera("c", _cam(update_decimation="50Hz"))
+    assert sm.get("c").effective_decimation == 4
+    assert _drive(sm, 9)["c"] == [True, False, False, False, True, False, False, False, True]
+
+
+def test_frames_produced_counts_renders():
+    sm = SensorManager(device="cpu", control_hz=200.0)
+    sm.register_camera("c", _cam(update_decimation=2))
+    assert sm.frames_produced("c") == 0  # nothing rendered yet
+    sm.collect_due()  # step 0 -> renders frame 1
+    assert sm.frames_produced("c") == 1
+    sm.collect_due()  # step 1 -> not due
+    assert sm.frames_produced("c") == 1
+    sm.collect_due()  # step 2 -> renders frame 2
+    assert sm.frames_produced("c") == 2
+
+
+def test_frames_produced_dec3_holds_within_window():
+    # The realistic slow-camera case: dec=3 over 7 steps. frames_produced must stay flat across the
+    # two non-due steps of each window and increment exactly on the due step.
+    sm = SensorManager(device="cpu", control_hz=200.0)
+    sm.register_camera("c", _cam(update_decimation=3))
+    counts = []
+    for _ in range(7):
+        sm.collect_due()
+        counts.append(sm.frames_produced("c"))
+    assert counts == [1, 1, 1, 2, 2, 2, 3]
+
+
+def test_mixed_decimation_cameras_independent():
+    sm = SensorManager(device="cpu", control_hz=200.0)
+    sm.register_camera("fast", _cam(update_decimation=1))
+    sm.register_camera("slow", _cam(update_decimation=3))
+    seq = _drive(sm, 4)
+    assert seq["fast"] == [True, True, True, True]
+    assert seq["slow"] == [True, False, False, True]
+
+
+@pytest.mark.parametrize("bad", ["thermal", "segmentation"])
+def test_unimplemented_modality_rejected_at_config_construction(bad):
+    # rgb/depth are the only implemented modalities; anything else (a typo, or the not-yet-built
+    # segmentation) fails loud at CameraSensorConfig construction (the CameraDataType literal),
+    # before reaching a backend.
+    with pytest.raises(ValueError, match="should be 'rgb' or 'depth'"):
+        _cam(data_types=["rgb", bad])
+
+
+def test_duplicate_name_rejected():
+    sm = SensorManager(device="cpu", control_hz=200.0)
+    sm.register_camera("c", _cam())
+    with pytest.raises(ValueError, match="already registered"):
+        sm.register_camera("c", _cam())
+
+
+def test_depth_modality_supported():
+    sm = SensorManager(device="cpu", control_hz=200.0)
+    sm.register_camera("c", _cam(data_types=["rgb", "depth"]))  # must not raise
+    assert sm.names == ["c"]

--- a/src/holosoma/holosoma/utils/sim_utils.py
+++ b/src/holosoma/holosoma/utils/sim_utils.py
@@ -21,6 +21,7 @@ from holosoma.config_types.env import get_tyro_env_config
 from holosoma.config_types.experiment import ExperimentConfig
 from holosoma.config_types.full_sim import FullSimConfig
 from holosoma.config_types.run_sim import RunSimConfig
+from holosoma.config_types.sensor import validate_camera_dict
 from holosoma.managers.terrain.manager import TerrainManager
 from holosoma.simulator.base_simulator.hooks import Phase
 from holosoma.utils.common import seeding
@@ -101,9 +102,12 @@ def setup_isaaclab_launcher(config: ExperimentConfig | RunSimConfig, device: str
     else:  # AppLauncher auto-detects
         pass
 
-    # Check if video recording is enabled and add --enable_cameras flag
+    # Enable the IsaacSim renderer when cameras are needed: video recording OR any configured
+    # perception sensor (a TiledCamera fails to spawn without --enable_cameras). ``sensor`` is the
+    # per-key camera dict on RunSimConfig/ExperimentConfig.
     video_enabled = config.logger.video.enabled or config.logger.headless_recording
-    if video_enabled:
+    cameras_enabled = bool(getattr(config, "sensor", None))
+    if video_enabled or cameras_enabled:
         args_cli.enable_cameras = True
 
     app_launcher = AppLauncher(args_cli)
@@ -225,11 +229,16 @@ def setup_simulation_environment(
         # For run_sim.py, we'll create the simulator directly instead of using environment wrapper
         logger.info("Direct simulation mode - creating simulator directly, without experiment config")
 
+        # Cross-camera validation (Warp render-flag agreement) across the assembled camera dict.
+        validate_camera_dict(config.sensor)
+
         # Create FullSimConfig from RunSimConfig.
         full_config = FullSimConfig(
             simulator=config.simulator.config,
             robot=config.robot,
             scene=config.scene,
+            # The CLI declares cameras per-key in the dynamic ``sensor`` dict (key = sensor name).
+            sensors=dict(config.sensor),
             training=config.training,
             logger=config.logger,
             plugin=config.plugin,
@@ -406,8 +415,9 @@ class DirectSimulation:
         """
         logger.debug("Initializing simulator...")
 
-        # Need to manually set headless since it's in training config currently
-        self.simulator.set_headless(False)
+        # Headless lives in training config; honor it (was hardcoded False, which forced the viewer
+        # on and pulled in isaacsim.util.debug_draw even under --training.headless True).
+        self.simulator.set_headless(self.config.training.headless)
 
         # Step 1: Basic setup
         self.simulator.setup()
@@ -501,6 +511,9 @@ class DirectSimulation:
                 self.simulator.simulate_at_each_physics_step()
                 self.simulator.hooks.emit(Phase.POST_STEP)
 
+                # Mounted cameras render and egress consumers publish here, as FRAME_END plugins
+                # (once per control step). render_sensors registered before any consumer, so
+                # buffers are fresh; both no-op when no cameras/consumers are configured.
                 if step_count % control_decimation == 0:
                     self.simulator.hooks.emit(Phase.FRAME_END)
 
@@ -531,11 +544,15 @@ class DirectSimulation:
 
     def cleanup(self) -> None:
         """Handle simulation cleanup."""
-        # Fire the simulator CLOSE phase (bridge/video teardown), via env.close() if defined else direct.
+        # Fire the simulator CLOSE phase (via env.close() if defined, else direct): runs every hook's
+        # close in reverse registration order — bridge/video teardown and camera-consumer stop()
+        # (encode video, close ROS nodes/windows).
         if hasattr(self.env, "close"):
             self.env.close()
         else:
             self.simulator.close()
+
+        self.simulator._stop_bridge()
 
         # Cleanup simulation app
         if self.simulation_app:

--- a/src/holosoma/pyproject.toml
+++ b/src/holosoma/pyproject.toml
@@ -46,7 +46,11 @@ dependencies = [
     "types-tqdm",
     "tyro>=1.0.0",
     "wandb==0.22.0", # pin version until https://github.com/wandb/wandb/issues/10647 is fixed
-    "warp-lang==1.10.0",
+    # Floor, not a hard pin: public PyPI only publishes warp-lang up to 1.10.1, so the base holosoma
+    # install (holosoma/isaacgym images, plain pip, no NVIDIA index) resolves 1.10.1. In the mujoco
+    # image, mujoco_warp[cuda] (installed after, from pypi.nvidia.com) upgrades this to >=1.14 for the
+    # 3.10.0 batched camera renderer. A hard ==1.14.0 breaks the non-mujoco images (not on PyPI).
+    "warp-lang>=1.10",
     "yourdfpy>=0.0.58",
     "zmq",
 ]
@@ -56,8 +60,9 @@ dependencies = [
 dynamic = ["optional-dependencies"]
 
 [project.entry-points."holosoma.bridge"]
-unitree = "holosoma.bridge.unitree:UnitreeSdk2Bridge"
-booster = "holosoma.bridge.booster:BoosterSdk2Bridge"
+unitree = "holosoma.bridge.unitree.unitree_sdk2py_bridge:UnitreeSdk2Bridge"
+unitree_mp = "holosoma.bridge.unitree.unitree_sdk2py_bridge_mp:UnitreeMpSdk2Bridge"
+booster = "holosoma.bridge.booster.booster_sdk2py_bridge:BoosterSdk2Bridge"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/src/holosoma/tests/simulators/_camera_presets.py
+++ b/src/holosoma/tests/simulators/_camera_presets.py
@@ -1,0 +1,241 @@
+"""Test-only scene and sensor presets for the camera assertion harness.
+
+Scene presets are registered into the production ``scene:`` CLI menu at test time (so
+``scene:camera-target`` resolves on the lazy tyro path). Sensor presets are plain camera dicts
+(``dict[str, CameraSensorConfig]``, keyed by sensor name) injected directly into the parsed config
+by the harness — they exercise camera *behavior*, not the per-key ``--sensor`` CLI (covered
+elsewhere), and a multi-camera rig can't be named by a single CLI token.
+
+Geometry: robot base frame is +X forward, +Z up. An identity mount orientation looks down the
+optical axis (-Z). A -90 deg pitch about body Y rotates -Z to +X (look forward); quaternion
+(w,x,y,z) = (cos45, 0, -sin45, 0).
+"""
+
+from __future__ import annotations
+
+import math
+
+from holosoma.config_types.scene import PhysicsConfig, RigidObjectConfig, SceneConfig
+from holosoma.config_types.sensor import CameraSensorConfig, SensorMountConfig
+
+_SMALL_BOX = "holosoma/data/scene_objects/boxes/small_box.urdf"
+_SMALL_BOX_USD = "holosoma/data/scene_objects/boxes/small_box.usda"
+
+# -90 deg about body +Y: rotates the camera's optical -Z (down) to point along body +X (forward).
+_C = math.cos(-math.pi / 4)
+_S = math.sin(-math.pi / 4)
+_LOOK_FORWARD_WXYZ = [_C, 0.0, _S, 0.0]  # (w, x, y, z)
+
+# Bright static box 0.5 m in front of the robot at camera height; fills the center of a
+# forward-looking camera. urdf and usd for the respective backends.
+_BASE_Z = 0.79  # g1 base/pelvis spawn height (init_state.pos z); camera mounts here.
+camera_target = SceneConfig(
+    rigid_objects={
+        "target": RigidObjectConfig(
+            urdf_file=_SMALL_BOX,
+            usd_file=_SMALL_BOX_USD,
+            position=[0.5, 0.0, _BASE_Z],
+            fixed=True,
+            physics=PhysicsConfig(),
+        )
+    }
+)
+
+# One camera on the robot base, pitched to look forward (+X), framing the target box at base
+# height. Mount pushed 0.1 m forward to clear the robot torso.
+front_cam = {
+    "front_cam": CameraSensorConfig(
+        mount=SensorMountConfig(
+            target_kind="robot_link", target="pelvis", position=[0.1, 0.0, 0.0], orientation=_LOOK_FORWARD_WXYZ
+        ),
+        width=64,
+        height=64,
+        vertical_fov=60.0,
+        data_types=["rgb"],
+    )
+}
+
+# Forward camera producing both rgb and depth, used by the depth test.
+front_cam_depth = {
+    "front_cam": CameraSensorConfig(
+        mount=SensorMountConfig(
+            target_kind="robot_link", target="pelvis", position=[0.1, 0.0, 0.0], orientation=_LOOK_FORWARD_WXYZ
+        ),
+        width=64,
+        height=64,
+        vertical_fov=60.0,
+        data_types=["rgb", "depth"],
+    )
+}
+
+# Forward camera with a non-square resolution (width 96 != height 64) to catch a width/height
+# transpose. width > height widens the horizontal FOV (from vertical_fov).
+_WIDE_W = 96
+_WIDE_H = 64
+front_cam_wide = {
+    "front_cam": CameraSensorConfig(
+        mount=SensorMountConfig(
+            target_kind="robot_link", target="pelvis", position=[0.1, 0.0, 0.0], orientation=_LOOK_FORWARD_WXYZ
+        ),
+        width=_WIDE_W,
+        height=_WIDE_H,
+        vertical_fov=60.0,
+        data_types=["rgb"],
+    )
+}
+
+# Two cameras at the same mount: fast_cam renders every control step (decimation=1), slow_cam every
+# 3rd (decimation=3). Exercises the per-camera update_decimation gate.
+slow_fast_cam = {
+    "fast_cam": CameraSensorConfig(
+        mount=SensorMountConfig(
+            target_kind="robot_link", target="pelvis", position=[0.1, 0.0, 0.0], orientation=_LOOK_FORWARD_WXYZ
+        ),
+        width=64,
+        height=64,
+        vertical_fov=60.0,
+        data_types=["rgb"],
+        update_decimation=1,
+    ),
+    "slow_cam": CameraSensorConfig(
+        mount=SensorMountConfig(
+            target_kind="robot_link", target="pelvis", position=[0.1, 0.0, 0.0], orientation=_LOOK_FORWARD_WXYZ
+        ),
+        width=64,
+        height=64,
+        vertical_fov=60.0,
+        data_types=["rgb"],
+        update_decimation=3,
+    ),
+}
+
+# Flat bright-red panel (0.4 m x 0.4 m, thin) facing the camera, centered on the forward axis at a
+# known distance. The geometry test measures its silhouette (centroid, pixel extent vs FOV).
+_PANEL = "holosoma/data/scene_objects/panels/red_panel.urdf"
+_PANEL_XML = "holosoma/data/scene_objects/panels/red_panel.xml"
+_PANEL_USD = "holosoma/data/scene_objects/panels/red_panel.usda"
+_PANEL_HALF_SIZE = 0.2  # meters (half of the 0.4 m panel height/width)
+_PANEL_DISTANCE = 1.0  # meters from the robot base (camera mounts ~0.1 m forward of base)
+
+panel_target = SceneConfig(
+    rigid_objects={
+        "panel": RigidObjectConfig(
+            urdf_file=_PANEL,
+            xml_file=_PANEL_XML,
+            usd_file=_PANEL_USD,
+            position=[_PANEL_DISTANCE, 0.0, _BASE_Z],
+            fixed=True,
+            physics=PhysicsConfig(),
+        )
+    }
+)
+
+# Panel offset off the forward axis: to the robot's left (+Y) and up (+Z), so the red silhouette
+# lands in one image quadrant. The orientation test uses this to catch a mirror, flip, or H/W
+# transpose.
+_PANEL_OFFSET_Y = 0.20  # meters to the robot's left (+Y body)
+_PANEL_OFFSET_Z = 0.20  # meters up (+Z body)
+panel_offaxis = SceneConfig(
+    rigid_objects={
+        "panel": RigidObjectConfig(
+            urdf_file=_PANEL,
+            xml_file=_PANEL_XML,
+            usd_file=_PANEL_USD,
+            position=[_PANEL_DISTANCE, _PANEL_OFFSET_Y, _BASE_Z + _PANEL_OFFSET_Z],
+            fixed=True,
+            physics=PhysicsConfig(),
+        )
+    }
+)
+
+# Two cameras on the robot base seeing different content: "front_cam" frames the panel ahead (+X),
+# "down_cam" (identity mount) looks straight down. Used to assert per-camera attribution.
+dual_cam = {
+    "front_cam": CameraSensorConfig(
+        mount=SensorMountConfig(
+            target_kind="robot_link", target="pelvis", position=[0.1, 0.0, 0.0], orientation=_LOOK_FORWARD_WXYZ
+        ),
+        width=64,
+        height=64,
+        vertical_fov=60.0,
+        data_types=["rgb"],
+    ),
+    "down_cam": CameraSensorConfig(
+        mount=SensorMountConfig(target_kind="robot_link", target="pelvis", position=[0.1, 0.0, 0.0]),
+        width=64,
+        height=64,
+        vertical_fov=60.0,
+        data_types=["rgb"],
+    ),
+}
+
+# One camera mounted on the scene object "panel" (target_kind="actor"), exercising the actor-mount
+# resolver. Identity mount looks down the panel's local -Z.
+actor_cam = {
+    "panel_cam": CameraSensorConfig(
+        mount=SensorMountConfig(target_kind="actor", target="panel", position=[0.0, 0.0, 0.0]),
+        width=64,
+        height=64,
+        vertical_fov=60.0,
+        data_types=["rgb"],
+    )
+}
+
+# One FREE-FLOATING camera (target_kind="world", no body to follow), fixed in each env's frame at
+# the robot's spawn spot, pitched to look forward (+X) at the panel. It anchors to the env frame,
+# NOT the robot, so moving/yawing the robot must NOT change what it sees. Mirrors the `panel-target`
+# scene geometry (panel 1.0 m ahead at base height); mounted like `front_cam` but on the world.
+world_cam = {
+    "world_cam": CameraSensorConfig(
+        mount=SensorMountConfig(target_kind="world", position=[0.1, 0.0, _BASE_Z], orientation=_LOOK_FORWARD_WXYZ),
+        width=64,
+        height=64,
+        vertical_fov=60.0,
+        data_types=["rgb", "depth"],
+    )
+}
+
+SCENE_PRESETS = {
+    "camera-target": camera_target,
+    "panel-target": panel_target,
+    "panel-offaxis": panel_offaxis,
+}
+# Named camera-dict presets, for harnesses that take a ``--sensors`` NAME on the command line
+# (e.g. camera_assert.py) and inject the resolved dict onto the config's ``sensor`` field.
+SENSOR_PRESETS = {
+    "front-cam": front_cam,
+    "front-cam-depth": front_cam_depth,
+    "front-cam-wide": front_cam_wide,
+    "dual-cam": dual_cam,
+    "actor-cam": actor_cam,
+    "slow-fast-cam": slow_fast_cam,
+    "world-cam": world_cam,
+}
+
+
+def register() -> None:
+    """Merge the camera test SCENE presets into the production ``scene:`` CLI menu (idempotent).
+
+    Sensor presets are NOT registered: they are plain camera dicts injected directly by the harness
+    (see module docstring), so there is nothing to add to a CLI menu.
+    """
+    from holosoma.config_values import scene
+
+    scene.SCENE_REGISTRY.update(SCENE_PRESETS)
+
+
+def as_mjwarp(config):
+    """Switch a MuJoCo ``RunSimConfig`` to the Warp backend (GPU, multi-env capable)."""
+    import dataclasses
+
+    from holosoma.config_types.simulator import MujocoBackend
+
+    sim_cfg = dataclasses.replace(
+        config.simulator,
+        config=dataclasses.replace(config.simulator.config, mujoco_backend=MujocoBackend.WARP),
+    )
+    return dataclasses.replace(config, simulator=sim_cfg)
+
+
+# Register on import so `import _camera_presets` installs the presets without an explicit call.
+register()

--- a/src/holosoma/tests/simulators/_scene_presets.py
+++ b/src/holosoma/tests/simulators/_scene_presets.py
@@ -106,7 +106,7 @@ physics_box = SceneConfig(
         "pbox": RigidObjectConfig(
             urdf_file=_SMALL_BOX,
             usd_file=_SMALL_BOX_USD,
-            position=[0.0, 0.0, 0.6],
+            position=[0.0, 1.5, 0.6],  # y=1.5 clears the origin robot's collapse footprint (see g1_largebox)
             physics=PhysicsConfig(
                 mass=3.0,
                 isaacgym=IsaacGymPhysicsConfig(friction=0.4),
@@ -157,13 +157,16 @@ friction_slide = SceneConfig(
 # known +0.5m-x relative offset. Tri-format so each backend loads its own (MuJoCo xml,
 # IsaacGym urdf, IsaacSim usd); registered bodies are 'scene_free_box' (free) and
 # 'scene_static_post' (static). Placed at a non-trivial world pose to exercise composition.
+# y=1.5 clears the un-actuated harness robot at the origin (which collapses under gravity and
+# would strike the free body, contaminating the fall check — see g1_largebox); the +0.5m-x
+# body-to-body offset the tests assert is translation-invariant, so the move is inert to it.
 multibody = SceneConfig(
     scene_files={
         "scene": SceneFileConfig(
             xml_path="holosoma/data/scene_objects/multibody/multibody.xml",
             urdf_path="holosoma/data/scene_objects/multibody/multibody.urdf",
             usd_path="holosoma/data/scene_objects/multibody/multibody.usda",
-            position=[0.4, 0.0, 0.6],
+            position=[0.4, 1.5, 0.6],
         )
     }
 )
@@ -177,7 +180,7 @@ multibody_override = SceneConfig(
             xml_path="holosoma/data/scene_objects/multibody/multibody.xml",
             urdf_path="holosoma/data/scene_objects/multibody/multibody.urdf",
             usd_path="holosoma/data/scene_objects/multibody/multibody.usda",
-            position=[0.4, 0.0, 0.6],
+            position=[0.4, 1.5, 0.6],  # y=1.5 clears the origin robot's collapse footprint (see multibody)
             object_configs={
                 "free_box": ObjectPatternConfig(fixed=True),
                 "static_post": ObjectPatternConfig(fixed=False),

--- a/src/holosoma/tests/simulators/_sim_harness.py
+++ b/src/holosoma/tests/simulators/_sim_harness.py
@@ -48,6 +48,7 @@ def build_run_sim_config(
     robot: str,
     terrain: str,
     *,
+    sensors: dict[str, Any] | None = None,
     record_dir: str | None = None,
     video_camera: Any = None,
     show_command_overlay: bool = True,
@@ -58,14 +59,19 @@ def build_run_sim_config(
     applies a robot-only force tensor that errors once a scene adds bodies — neither is relevant to a
     spawn/behavior check, so both are turned off.
 
-    When ``record_dir`` is set, enable video recording every episode to that dir (mp4, no wandb).
-    ``video_camera`` overrides the camera config (e.g. an object-framing camera); ``show_command_overlay``
-    toggles the robot-command text overlay (off for object scenarios where it is irrelevant).
+    ``sensors`` is a mounted-camera dict (``{name: CameraSensorConfig}``) injected directly onto the
+    parsed config's ``sensor`` field — the harness builds rigs in Python rather than through the
+    per-key ``--sensor`` CLI (a multi-camera rig can't be named by one token). When ``record_dir`` is
+    set, enable video recording every episode to that dir (mp4, no wandb). ``video_camera`` overrides
+    the camera config (e.g. an object-framing camera); ``show_command_overlay`` toggles the
+    robot-command text overlay (off for object scenarios where it is irrelevant).
     """
     from holosoma.config_types.simulator import BridgeConfig, VirtualGantryCfg
 
     argv = [f"simulator:{simulator}", f"robot:{robot}", f"terrain:{terrain}", f"scene:{scene}"]
     config = tyro.cli(RunSimConfig, args=argv)
+    if sensors is not None:
+        config = dataclasses.replace(config, sensor=dict(sensors))
     sim_cfg = dataclasses.replace(
         config.simulator,
         config=dataclasses.replace(

--- a/src/holosoma/tests/simulators/camera_actor_mount_assert.py
+++ b/src/holosoma/tests/simulators/camera_actor_mount_assert.py
@@ -1,0 +1,105 @@
+"""Cross-backend actor-mount camera assertion harness.
+
+Exercises the ``target_kind="actor"`` mount resolver (a camera mounted on a spawned scene
+object rather than a robot link). Mounts a camera on the spawned ``panel`` object and asserts
+the frame has the expected shape/dtype and is non-blank. Then moves the panel and asserts the
+rendered frame changes, confirming the camera follows the actor. Exits 0 PASS, 1 FAIL, 77 SKIP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+SKIP_EXIT_CODE = 77
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument("--result-file", default=None, help="write OK/FAIL here before teardown")
+    args = parser.parse_args()
+
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    config = build_run_sim_config(sim_arg, "panel-target", args.robot, args.terrain, sensors=_camera_presets.actor_cam)
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config, device=device, training=dataclasses.replace(config.training, num_envs=args.num_envs)
+    )
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import torch
+
+    n = args.num_envs
+    env_origins = torch.zeros(n, 3, device=device)
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel), device=device, dtype=torch.float32
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    names = sim.get_sensor_names()
+    if names != ["panel_cam"]:
+        print(f"[{args.simulator}] FAIL: actor-mount camera not created (got {names})")
+        return 1
+
+    step(sim, max(2, steps_for_seconds(sim, 0.05)))
+    sim.render_sensors()
+
+    fails: list[str] = []
+    img = sim.get_camera_data("panel_cam", "rgb")  # [N,H,W,3] uint8
+    cam = next(iter(config.sensor.values()))
+    if tuple(img.shape) != (n, cam.height, cam.width, 3) or img.dtype != torch.uint8:
+        fails.append(f"{args.simulator}: actor-mount frame shape/dtype {tuple(img.shape)} {img.dtype}")
+    for e in range(n):
+        lum = img[e].float().mean(dim=-1)
+        if float(lum.max()) - float(lum.min()) < 1.0:
+            fails.append(f"{args.simulator}/env{e}: actor-mount frame ~uniform; renderer saw nothing")
+
+    # Follow: move the panel and confirm the panel-mounted camera's frame changes.
+    before = img.clone()
+    panel_states = sim.get_actor_states(["panel"], torch.arange(n, device=device)).clone()
+    panel_states[:, 2] += 0.5  # lift the panel 0.5 m
+    sim.set_actor_states(["panel"], torch.arange(n, device=device), panel_states)
+    step(sim, max(2, steps_for_seconds(sim, 0.05)))
+    sim.render_sensors()
+    after = sim.get_camera_data("panel_cam", "rgb")
+    if torch.equal(before, after):
+        fails.append(f"{args.simulator}: panel-mounted camera frame unchanged after moving the panel (not following)")
+
+    if args.result_file:
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        for f in fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        return 1
+    print(f"[{args.simulator}] PASS: actor-mounted camera resolves, renders, and follows across {n} env(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/camera_assert.py
+++ b/src/holosoma/tests/simulators/camera_assert.py
@@ -1,0 +1,187 @@
+"""Cross-backend camera-sensor assertion harness.
+
+Builds a sim under one backend, creates the mounted camera(s) from the ``--sensors`` preset,
+renders, and asserts:
+
+  1. ``get_camera_data`` returns shape ``[num_envs, H, W, 3]``, dtype uint8,
+     values in ``[0, 255]``;
+  2. the rendered frame is not uniformly blank;
+  3. the visualization recorder wiring, when ``--check-recorder`` is set.
+
+Centering, optical-axis, and FOV validation live in ``camera_geometry_assert.py``.
+
+Run per backend (each in its own env):
+    python tests/simulators/camera_assert.py --simulator mujoco --scene <preset> --sensors <preset>
+    python tests/simulators/camera_assert.py --simulator {mjwarp,isaacgym,isaacsim} ...
+
+Exits 0 on PASS, 1 on FAIL, 77 on SKIP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+
+# Pop this dir off sys.path[0] so tests/simulators/isaacsim/ can't shadow the real isaacsim pkg.
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+SKIP_EXIT_CODE = 77
+
+
+def _check_contract(img, num_envs: int, width: int, height: int, label: str) -> list[str]:
+    """Shape/dtype/range assertions on a get_camera_data tensor. Returns failure messages."""
+    import torch
+
+    fails = []
+    if not isinstance(img, torch.Tensor):
+        return [f"{label}: get_camera_data did not return a torch.Tensor (got {type(img)})"]
+    if tuple(img.shape) != (num_envs, height, width, 3):
+        fails.append(f"{label}: shape {tuple(img.shape)} != expected ({num_envs},{height},{width},3)")
+    if img.dtype != torch.uint8:
+        fails.append(f"{label}: dtype {img.dtype} != torch.uint8")
+    if img.numel() and (int(img.min()) < 0 or int(img.max()) > 255):
+        fails.append(f"{label}: values out of [0,255] (min={int(img.min())}, max={int(img.max())})")
+    return fails
+
+
+def _check_not_blank(img, label: str) -> list[str]:
+    """Return a failure message if the frame is ~uniform. Returns failure messages."""
+    lum = img[0].float().mean(dim=-1)  # [H, W]
+    spread = float(lum.max()) - float(lum.min())
+    if spread < 1.0:
+        return [f"{label}: frame is ~uniform (max-min lum {spread:.2f}); renderer saw nothing"]
+    return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--scene", default="camera-target", help="scene preset (front-facing bright object)")
+    parser.add_argument("--sensors", default="front-cam", help="sensors preset (one robot-base camera)")
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--steps", type=int, default=2)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument(
+        "--check-recorder",
+        action="store_true",
+        help="install a CameraVizPlugin recorder hook (record_video) and assert it was installed + buffered "
+        "a frame, regardless of backend; guards that camera-consumer hooks fire on FRAME_END.",
+    )
+    parser.add_argument("--result-file", default=None, help="write PASS/FAIL here before teardown")
+    args = parser.parse_args()
+
+    # Register the test-only camera scene/sensor presets into the CLI DEFAULTS.
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    config = build_run_sim_config(
+        sim_arg, args.scene, args.robot, args.terrain, sensors=_camera_presets.SENSOR_PRESETS[args.sensors]
+    )
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config,
+        device=device,
+        training=dataclasses.replace(config.training, num_envs=args.num_envs),
+    )
+
+    if args.check_recorder:
+        # Attach a CameraVizPlugin recorder as a hook plugin with record_video (not live_window) so the
+        # check runs without a DISPLAY. Keyed by an arbitrary label ("rec"); the simulator builds it
+        # in __init__ and it registers its publish on FRAME_END (after the render hook).
+        from holosoma.config_types.plugin import CameraVizPluginConfig
+
+        config = dataclasses.replace(config, plugin={**config.plugin, "rec": CameraVizPluginConfig(record_video=True)})
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import torch
+
+    n = args.num_envs
+    env_origins = torch.zeros(n, 3, device=device)
+    if n > 1:
+        env_origins[:, 0] = torch.arange(n, device=device, dtype=torch.float32) * 5.0
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel),
+        device=device,
+        dtype=torch.float32,
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    # Hooks (incl. the --check-recorder CameraVizPlugin) were installed by the simulator in __init__ from
+    # FullSimConfig.plugin; nothing to install here.
+    from holosoma.simulator.base_simulator.hooks import Phase
+
+    names = sim.get_sensor_names()
+    print(f"[{args.simulator}] sensors created: {names}")
+    if not names:
+        print(f"[{args.simulator}] FAIL: no sensors created from preset '{args.sensors}'")
+        return 1
+
+    # Step so the renderer warms up and body poses settle, then fire the control-post-refresh hooks
+    # (cameras render, egress consumers publish) once — the same emission the task loop drives.
+    step(sim, max(args.steps, steps_for_seconds(sim, 0.05)))
+    sim.hooks.emit(Phase.FRAME_END)
+
+    fails: list[str] = []
+    cam_cfgs = dict(config.sensor)
+    for name in names:
+        cam = cam_cfgs[name]
+        img = sim.get_camera_data(name, "rgb")
+        print(
+            f"[{args.simulator}] {name}: shape={tuple(img.shape)} dtype={img.dtype} "
+            f"min={int(img.min())} max={int(img.max())}"
+        )
+        fails += _check_contract(img, n, cam.width, cam.height, f"{args.simulator}/{name}")
+        fails += _check_not_blank(img, f"{args.simulator}/{name}")
+
+    if args.check_recorder:
+        # The CameraVizPlugin recorder hook (installed from the `plugin` dict) must have registered on
+        # FRAME_END and buffered a frame from the emission above. Find it among the
+        # installed hooks and assert it captured at least one grid.
+        from holosoma.simulator.plugins.viz.viz_plugin import CameraVizPlugin
+
+        recorders = [h for h in sim.installed_plugins.values() if isinstance(h, CameraVizPlugin)]
+        if not recorders:
+            fails.append(
+                f"{args.simulator}: recorder requested (plugin.rec:viz-record) but no CameraVizPlugin was "
+                f"installed; the simulator did not build hooks from FullSimConfig.plugin in __init__."
+            )
+        else:
+            n_frames = max(len(getattr(r, "_frames_video", [])) for r in recorders)
+            print(f"[{args.simulator}] recorder buffered {n_frames} frame(s) after one emission")
+            if n_frames < 1:
+                fails.append(f"{args.simulator}: recorder hook installed but buffered no frame ({n_frames}).")
+
+    if args.result_file:
+        # Persist the verdict before teardown: IsaacSim teardown can hard-kill the process and
+        # swallow the exit code. "OK" on success per the run_harness sentinel convention.
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        for f in fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        return 1
+    print(f"[{args.simulator}] PASS: {len(names)} camera(s) satisfy the shape/dtype + non-blank check")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/camera_follow_assert.py
+++ b/src/holosoma/tests/simulators/camera_follow_assert.py
@@ -1,0 +1,209 @@
+"""Cross-backend camera-follow behavioral assertion harness.
+
+Asserts a mounted camera tracks its mount body (MuJoCo spec child, IsaacGym
+FOLLOW_TRANSFORM, IsaacSim child prim).
+
+A depth camera is mounted on the robot base looking forward at a red panel at a known
+distance. Render, move the robot a known ``d`` toward the panel via ``set_actor_states``,
+re-render, and assert the panel's median depth drops by ~``d``. Depth is sign-independent
+across backends. Exits 0 PASS, 1 FAIL, 77 SKIP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+SKIP_EXIT_CODE = 77
+
+
+def _red_mask(rgb):
+    return (rgb[..., 0].to(int) > rgb[..., 1].to(int) + 40) & (rgb[..., 0].to(int) > rgb[..., 2].to(int) + 40)
+
+
+def _panel_median_depth(rgb, depth):
+    """Median depth (meters) over the red-panel pixels of one env frame, or None if not visible."""
+    import torch
+
+    mask = _red_mask(rgb)
+    if int(mask.sum()) < 0.02 * rgb.shape[0] * rgb.shape[1]:
+        return None
+    panel = depth[..., 0][mask]
+    finite = panel[torch.isfinite(panel)]
+    return float(finite.median()) if finite.numel() else None
+
+
+def _red_fraction(rgb):
+    """Fraction of red-panel pixels in one [H,W,3] frame."""
+    return float(_red_mask(rgb).float().mean())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument("--result-file", default=None, help="write OK/FAIL here before teardown")
+    args = parser.parse_args()
+
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    config = build_run_sim_config(
+        sim_arg, "panel-target", args.robot, args.terrain, sensors=_camera_presets.front_cam_depth
+    )
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config, device=device, training=dataclasses.replace(config.training, num_envs=args.num_envs)
+    )
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import torch
+
+    n = args.num_envs
+    # Spread envs along +X so each gets its own panel copy at its own origin.
+    env_origins = torch.zeros(n, 3, device=device)
+    if n > 1:
+        env_origins[:, 0] = torch.arange(n, device=device, dtype=torch.float32) * 10.0
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel), device=device, dtype=torch.float32
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    if not sim.get_sensor_names():
+        print(f"[{args.simulator}] FAIL: no sensors created")
+        return 1
+
+    import math
+
+    move = 0.3  # meters to advance the robot toward the panel (+X base frame)
+    yaw = math.radians(40.0)  # body yaw that swings the forward panel out of frame
+
+    base_rot = list(init.rot)  # (x, y, z, w) actor-state quaternion order
+
+    def _quat_mul_yaw(q_xyzw, yaw_rad):
+        """Compose a world-Z yaw onto the base orientation (xyzw) so the robot turns in place."""
+        cz, sz = math.cos(yaw_rad / 2), math.sin(yaw_rad / 2)
+        yq = [0.0, 0.0, sz, cz]  # yaw about +Z (x, y, z, w)
+        x1, y1, z1, w1 = yq
+        x2, y2, z2, w2 = q_xyzw
+        return [
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        ]
+
+    def _place(x_offset: float, rot_xyzw) -> None:
+        states = sim.get_actor_states(["robot"], torch.arange(n, device=device)).clone()
+        states[:, :3] = env_origins + torch.tensor(list(init.pos), device=device)
+        states[:, 0] += x_offset
+        states[:, 3:7] = torch.tensor(rot_xyzw, device=device)
+        states[:, 7:] = 0.0
+        sim.set_actor_states(["robot"], torch.arange(n, device=device), states)
+        step(sim, max(2, steps_for_seconds(sim, 0.05)))
+        sim.render_sensors()
+
+    cam_name, cam = next(iter(config.sensor.items()))
+    _place(0.0, base_rot)
+    before = [
+        _panel_median_depth(sim.get_camera_data(cam_name, "rgb")[e], sim.get_camera_data(cam_name, "depth")[e])
+        for e in range(n)
+    ]
+    before_red = [_red_fraction(sim.get_camera_data(cam_name, "rgb")[e]) for e in range(n)]
+
+    # 1. Translation: advance +X toward the panel; its depth should drop by ~move.
+    _place(move, base_rot)
+    after = [
+        _panel_median_depth(sim.get_camera_data(cam_name, "rgb")[e], sim.get_camera_data(cam_name, "depth")[e])
+        for e in range(n)
+    ]
+
+    # 2. Rotation: from the original spot, yaw the robot 40deg. A camera that follows body
+    #    orientation swings the forward panel out of frame (red fraction collapses).
+    _place(0.0, _quat_mul_yaw(base_rot, yaw))
+    yawed_red = [_red_fraction(sim.get_camera_data(cam_name, "rgb")[e]) for e in range(n)]
+
+    fails: list[str] = []
+    for e in range(n):
+        if before[e] is None or after[e] is None:
+            fails.append(f"{args.simulator}/env{e}: panel not visible before/after move ({before[e]}, {after[e]})")
+            continue
+        drop = before[e] - after[e]
+        print(
+            f"[{args.simulator}] env{e}: panel depth {before[e]:.3f}m -> {after[e]:.3f}m "
+            f"(drop {drop:.3f}m, moved {move}m); "
+            f"red {before_red[e]:.3f} -> {yawed_red[e]:.3f} after 40deg yaw"
+        )
+        if abs(drop - move) > 0.25 * move:
+            fails.append(
+                f"{args.simulator}/env{e}: panel depth dropped {drop:.3f}m, expected ~{move}m after moving the "
+                f"mount body (camera did not follow its body in translation)"
+            )
+        # After a 40deg yaw the forward panel should largely leave frame: red fraction at most a
+        # third of its head-on value.
+        if before_red[e] > 0.02 and yawed_red[e] > 0.34 * before_red[e]:
+            fails.append(
+                f"{args.simulator}/env{e}: red fraction {before_red[e]:.3f} -> {yawed_red[e]:.3f} after 40deg yaw; "
+                f"panel did not leave frame (camera did not follow its body in rotation)"
+            )
+
+    # 3. Per-env independence (n > 1): set every robot head-on, then yaw only env 0. Env 0's red
+    # should collapse while the other envs stay framed.
+    if n > 1 and not fails:
+        all_ids = torch.arange(n, device=device)
+        states = sim.get_actor_states(["robot"], all_ids).clone()
+        states[:, :3] = env_origins + torch.tensor(list(init.pos), device=device)
+        states[:, 3:7] = torch.tensor(base_rot, device=device)
+        states[0, 3:7] = torch.tensor(_quat_mul_yaw(base_rot, yaw), device=device)  # env 0 only
+        states[:, 7:] = 0.0
+        sim.set_actor_states(["robot"], all_ids, states)
+        step(sim, max(2, steps_for_seconds(sim, 0.05)))
+        sim.render_sensors()
+        per_env_red = [_red_fraction(sim.get_camera_data(cam_name, "rgb")[e]) for e in range(n)]
+        print(f"[{args.simulator}] per-env red after yawing ONLY env0: {[round(r, 3) for r in per_env_red]}")
+        if per_env_red[0] > 0.34 * before_red[0]:
+            fails.append(
+                f"{args.simulator}: env0 was yawed but still sees the panel "
+                f"(red {per_env_red[0]:.3f}); per-env pose not applied"
+            )
+        fails.extend(
+            f"{args.simulator}/env{e}: red {per_env_red[e]:.3f} dropped though only env0 moved "
+            f"(env frames not independent; backend broadcasts one env's render)"
+            for e in range(1, n)
+            if before_red[e] > 0.02 and per_env_red[e] < 0.5 * before_red[e]
+        )
+
+    if args.result_file:
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        for f in fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        return 1
+    print(f"[{args.simulator}] PASS: camera follows its mount body across {n} env(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/camera_geometry_assert.py
+++ b/src/holosoma/tests/simulators/camera_geometry_assert.py
@@ -1,0 +1,208 @@
+"""Quantitative cross-backend camera-geometry assertions.
+
+Verifies the camera's projection is geometrically correct, with numeric thresholds applied
+identically on every backend:
+
+  1. Centering: the panel's silhouette centroid sits at the image center (within tol).
+  2. Resolution: the frame is exactly W x H.
+  3. Field of view: the panel's measured pixel half-height matches the pinhole projection
+     predicted from ``vertical_fov``, the camera-to-panel distance, and the panel's real size:
+         px_half = (H/2) * (s / d) / tan(fovy/2)
+  4. No distortion: the silhouette is left-right and top-bottom symmetric about the center,
+     and its aspect ratio matches the (square) panel.
+
+The panel is a flat bright-red rectangle of known size at a known distance directly ahead,
+segmentable by R dominance.
+
+Run per backend:
+    python tests/simulators/camera_geometry_assert.py --simulator mujoco
+    python tests/simulators/camera_geometry_assert.py --simulator mjwarp --num-envs 2
+Exits 0 PASS, 1 FAIL, 77 SKIP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import math
+import sys
+
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+SKIP_EXIT_CODE = 77
+
+
+def _red_mask(env_img):
+    """Boolean [H,W] mask of red-panel pixels (R clearly dominant over G and B)."""
+    r = env_img[..., 0].to(int)
+    g = env_img[..., 1].to(int)
+    b = env_img[..., 2].to(int)
+    return (r > g + 40) & (r > b + 40)
+
+
+def _measure(mask):
+    """Return (count, row_centroid, col_centroid, row_extent, col_extent) of a boolean mask."""
+    import torch
+
+    ys, xs = torch.nonzero(mask, as_tuple=True)
+    if ys.numel() == 0:
+        return 0, 0.0, 0.0, 0.0, 0.0
+    return (
+        int(ys.numel()),
+        float(ys.float().mean()),
+        float(xs.float().mean()),
+        float(ys.max() - ys.min() + 1),
+        float(xs.max() - xs.min() + 1),
+    )
+
+
+def _check_geometry(img, cam, cam_to_panel_dist, panel_half_size, label):
+    """All geometry assertions on one env's frame. Returns list of failure strings."""
+    fails = []
+    h, w, _ = img.shape
+    mask = _red_mask(img)
+    count, rc, cc, r_ext, c_ext = _measure(mask)
+
+    # Require the panel to cover at least 2% of the frame before measuring geometry.
+    if count < 0.02 * h * w:
+        return [f"{label}: panel barely visible ({count}/{h * w} red px); cannot assert geometry"]
+
+    # 1. Centering: silhouette centroid at image center within 8% of the dimension.
+    cx_tol, cy_tol = 0.08 * w, 0.08 * h
+    if abs(cc - (w - 1) / 2) > cx_tol:
+        fails.append(f"{label}: horizontal centroid {cc:.1f} not centered (center {(w - 1) / 2:.1f}, tol {cx_tol:.1f})")
+    if abs(rc - (h - 1) / 2) > cy_tol:
+        fails.append(f"{label}: vertical centroid {rc:.1f} not centered (center {(h - 1) / 2:.1f}, tol {cy_tol:.1f})")
+
+    # 3. Field of view: predicted pixel half-height for a pinhole camera.
+    #    full_px_height = H * (panel_full_size) / (2 * d * tan(fovy/2))
+    fovy = math.radians(cam.vertical_fov)
+    predicted_px_height = h * (2 * panel_half_size) / (2 * cam_to_panel_dist * math.tan(fovy / 2))
+    # 15% tolerance absorbs per-engine silhouette bleed of ~1-2px/side at 64px.
+    if abs(r_ext - predicted_px_height) > 0.15 * predicted_px_height:
+        fails.append(
+            f"{label}: panel pixel height {r_ext:.1f} != FOV-predicted {predicted_px_height:.1f} "
+            f"(fovy={cam.vertical_fov}deg, d={cam_to_panel_dist:.2f}m, size={2 * panel_half_size}m); "
+            f"FOV/projection mismatch"
+        )
+
+    # 4. No distortion: square panel gives a near-square silhouette; symmetric margins.
+    aspect = c_ext / max(1.0, r_ext)
+    if not (0.85 <= aspect <= 1.18):
+        fails.append(f"{label}: silhouette aspect {aspect:.2f} not ~1.0 (square panel) -> distortion/shear")
+    # Left vs right margin and top vs bottom margin should match (symmetry about center).
+    ys, xs = mask.nonzero(as_tuple=True)
+    left_m, right_m = float(xs.min()), float(w - 1 - xs.max())
+    top_m, bot_m = float(ys.min()), float(h - 1 - ys.max())
+    if abs(left_m - right_m) > 0.10 * w:
+        fails.append(f"{label}: L/R margins {left_m:.1f}/{right_m:.1f} asymmetric -> off-axis/distortion")
+    if abs(top_m - bot_m) > 0.10 * h:
+        fails.append(f"{label}: T/B margins {top_m:.1f}/{bot_m:.1f} asymmetric -> off-axis/distortion")
+    return fails
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument("--result-file", default=None, help="write PASS/FAIL here before teardown")
+    args = parser.parse_args()
+
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    config = build_run_sim_config(sim_arg, "panel-target", args.robot, args.terrain, sensors=_camera_presets.front_cam)
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config, device=device, training=dataclasses.replace(config.training, num_envs=args.num_envs)
+    )
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import torch
+
+    n = args.num_envs
+    # All envs co-located at the origin so every env's robot and panel align.
+    env_origins = torch.zeros(n, 3, device=device)
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel), device=device, dtype=torch.float32
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    # Pin the robot to a known upright pose at each env origin so the (pelvis-mounted) camera aligns
+    # with the panel placed ahead (IsaacGym jitters the spawn xy; other backends are already at origin).
+    import torch as _torch
+
+    def _pin_robot() -> None:
+        robot_states = sim.get_actor_states(["robot"], _torch.arange(n, device=device)).clone()
+        robot_states[:, :3] = env_origins + _torch.tensor(list(init.pos), device=device)
+        robot_states[:, 3:7] = _torch.tensor(list(init.rot), device=device)
+        robot_states[:, 7:] = 0.0
+        sim.set_actor_states(["robot"], _torch.arange(n, device=device), robot_states)
+
+    _pin_robot()
+    step(sim, 2)
+
+    names = sim.get_sensor_names()
+    if not names:
+        print(f"[{args.simulator}] FAIL: no sensors created")
+        return 1
+
+    step(sim, max(2, steps_for_seconds(sim, 0.05)))
+    # Re-pin immediately before capture: the robot is un-actuated, so the settle steps above let the
+    # pelvis drift/tilt and drag its mounted camera off the panel (an env3-only flake — the projection
+    # math is env-independent, so a real FOV bug fails all envs). Root writes are immediate on every
+    # backend and render_sensors() does its own fetch/step_graphics, so pinning here fixes the pose the
+    # camera renders from without an extra settle.
+    _pin_robot()
+    sim.render_sensors()
+
+    cam_name, cam = next(iter(config.sensor.items()))
+    # Camera-to-panel-face distance: panel center at x=_PANEL_DISTANCE, minus the camera mount x
+    # offset, minus the panel half-thickness (0.01 m).
+    cam_to_panel = _camera_presets._PANEL_DISTANCE - cam.mount.position[0] - 0.01
+    panel_half = _camera_presets._PANEL_HALF_SIZE
+
+    fails: list[str] = []
+    img_all = sim.get_camera_data(cam_name, "rgb")  # [N,H,W,3]
+    if tuple(img_all.shape) != (n, cam.height, cam.width, 3) or img_all.dtype != torch.uint8:
+        print(f"[{args.simulator}] FAIL: shape/dtype {tuple(img_all.shape)} {img_all.dtype}")
+        return 1
+    for e in range(n):
+        env_fails = _check_geometry(img_all[e], cam, cam_to_panel, panel_half, f"{args.simulator}/env{e}")
+        for f in env_fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        fails += env_fails
+        if not env_fails:
+            print(f"[{args.simulator}] env{e}: geometry OK (centered, square, FOV-consistent silhouette)")
+
+    # Persist the verdict before teardown (it can mask the exit code): "OK" on success per the
+    # run_harness convention, else the failure detail.
+    if args.result_file:
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        return 1
+    print(f"[{args.simulator}] PASS: camera geometry correct across {n} env(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/camera_multi_assert.py
+++ b/src/holosoma/tests/simulators/camera_multi_assert.py
@@ -1,0 +1,110 @@
+"""Cross-backend multi-camera attribution assertion harness.
+
+Two cameras on the robot base see different content: ``front_cam`` frames the red panel ahead,
+``down_cam`` looks straight down at the ground. Asserts ``get_camera_data(name)`` returns each
+camera's own view. Exits 0 PASS / 1 FAIL / 77 SKIP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+SKIP_EXIT_CODE = 77
+
+
+def _red_fraction(env_rgb) -> float:
+    """Fraction of red-panel pixels in one env frame."""
+    r, g, b = env_rgb[..., 0].to(int), env_rgb[..., 1].to(int), env_rgb[..., 2].to(int)
+    mask = (r > g + 40) & (r > b + 40)
+    return float(mask.float().mean())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument("--result-file", default=None, help="write OK/FAIL here before teardown")
+    args = parser.parse_args()
+
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    config = build_run_sim_config(sim_arg, "panel-target", args.robot, args.terrain, sensors=_camera_presets.dual_cam)
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config, device=device, training=dataclasses.replace(config.training, num_envs=args.num_envs)
+    )
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import torch
+
+    n = args.num_envs
+    env_origins = torch.zeros(n, 3, device=device)
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel), device=device, dtype=torch.float32
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    names = sim.get_sensor_names()
+    if set(names) != {"front_cam", "down_cam"}:
+        print(f"[{args.simulator}] FAIL: expected front_cam+down_cam, got {names}")
+        return 1
+
+    # Pin the robot upright so front_cam frames the panel ahead.
+    states = sim.get_actor_states(["robot"], torch.arange(n, device=device)).clone()
+    states[:, :3] = env_origins + torch.tensor(list(init.pos), device=device)
+    states[:, 3:7] = torch.tensor(list(init.rot), device=device)
+    states[:, 7:] = 0.0
+    sim.set_actor_states(["robot"], torch.arange(n, device=device), states)
+    step(sim, max(2, steps_for_seconds(sim, 0.05)))
+    sim.render_sensors()
+
+    fails: list[str] = []
+    for e in range(n):
+        front_red = _red_fraction(sim.get_camera_data("front_cam", "rgb")[e])
+        down_red = _red_fraction(sim.get_camera_data("down_cam", "rgb")[e])
+        print(f"[{args.simulator}] env{e}: front_cam red={front_red:.3f}, down_cam red={down_red:.3f}")
+        # front_cam should see the panel (substantial red); down_cam should not.
+        if front_red < 0.05:
+            fails.append(f"{args.simulator}/env{e}: front_cam sees little red ({front_red:.3f}); not framing the panel")
+        if down_red > front_red * 0.5:
+            fails.append(
+                f"{args.simulator}/env{e}: down_cam red {down_red:.3f} not clearly less than front {front_red:.3f} "
+                f"(camera buffers may be swapped/mixed)"
+            )
+
+    if args.result_file:
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        for f in fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        return 1
+    print(f"[{args.simulator}] PASS: per-camera attribution correct across {n} env(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/camera_obs_assert.py
+++ b/src/holosoma/tests/simulators/camera_obs_assert.py
@@ -1,0 +1,178 @@
+"""Cross-backend camera observation-pipeline assertion harness.
+
+Each step runs render_sensors() then ObservationManager.compute(), the order
+BaseTask._post_physics_step uses.
+
+Checks:
+  1. Format: an rgb term with a CHW float01 transform yields [N, 3, H, W] float32 in [0,1] in a
+     concatenate=False group.
+  2. Rate: a camera with update_decimation=3 holds the same frame across a 3-step window while a
+     decimation=1 camera in the same group updates every step.
+
+Exits 0 PASS / 1 FAIL / 77 SKIP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.config_types.observation import ObservationManagerCfg, ObsGroupCfg, ObsTermCfg
+from holosoma.managers.observation.manager import ObservationManager
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+SKIP_EXIT_CODE = 77
+_TERMS = "holosoma.managers.observation.terms.cameras"
+
+
+class _TaskShell:
+    """Minimal env exposing what the camera obs terms and ObservationManager read."""
+
+    def __init__(self, sim, device):
+        self.simulator = sim
+        self.device = device
+        self.num_envs = sim.num_envs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument("--result-file", default=None, help="write OK/FAIL here before teardown")
+    args = parser.parse_args()
+
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    # slow-fast-cam: fast_cam (decimation=1) and slow_cam (decimation=3) at the same mount, both rgb.
+    config = build_run_sim_config(
+        sim_arg, "panel-target", args.robot, args.terrain, sensors=_camera_presets.slow_fast_cam
+    )
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config, device=device, training=dataclasses.replace(config.training, num_envs=args.num_envs)
+    )
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import torch
+
+    n = args.num_envs
+    env_origins = torch.zeros(n, 3, device=device)
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel), device=device, dtype=torch.float32
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    robot_states = sim.get_actor_states(["robot"], torch.arange(n, device=device)).clone()
+    robot_states[:, :3] = env_origins + torch.tensor(list(init.pos), device=device)
+    robot_states[:, 3:7] = torch.tensor(list(init.rot), device=device)
+    robot_states[:, 7:] = 0.0
+    sim.set_actor_states(["robot"], torch.arange(n, device=device), robot_states)
+    step(sim, max(2, steps_for_seconds(sim, 0.05)))
+
+    if set(sim.get_sensor_names()) != {"fast_cam", "slow_cam"}:
+        print(f"[{args.simulator}] FAIL: expected fast_cam+slow_cam, got {sim.get_sensor_names()}")
+        return 1
+
+    _first_cam = next(iter(config.sensor.values()))
+    h, w = _first_cam.height, _first_cam.width
+    # A dict (concatenate=False) group: fast_cam as CHW float01 rgb, slow_cam as plain rgb.
+    rgb_tf = {"layout": "CHW", "scale": "float01"}
+    obs_cfg = ObservationManagerCfg(
+        groups={
+            "image": ObsGroupCfg(
+                concatenate=False,
+                terms={
+                    "fast_rgb": ObsTermCfg(
+                        func=f"{_TERMS}:camera_rgb", params={"sensor": "fast_cam", "transform": rgb_tf}
+                    ),
+                    "slow_rgb": ObsTermCfg(func=f"{_TERMS}:camera_rgb", params={"sensor": "slow_cam"}),
+                },
+            )
+        }
+    )
+    mgr = ObservationManager(obs_cfg, _TaskShell(sim, device), device)
+
+    fails: list[str] = []
+
+    def _obs():
+        """Render the cameras, then compute and return the "image" obs group."""
+        sim.render_sensors()
+        return mgr.compute()["image"]
+
+    # 1. Format: the transformed rgb term is CHW float32 in [0,1] with the configured H,W.
+    first = _obs()
+    fast = first["fast_rgb"]
+    if tuple(fast.shape) != (n, 3, h, w) or fast.dtype != torch.float32:
+        fails.append(f"{args.simulator}: fast_rgb format {tuple(fast.shape)}/{fast.dtype} != ({n},3,{h},{w})/float32")
+    elif not (float(fast.min()) >= 0.0 and float(fast.max()) <= 1.0):
+        fails.append(
+            f"{args.simulator}: fast_rgb out of [0,1] (min={float(fast.min()):.3f} max={float(fast.max()):.3f})"
+        )
+    slow = first["slow_rgb"]
+    if tuple(slow.shape) != (n, h, w, 3) or slow.dtype != torch.uint8:
+        fails.append(
+            f"{args.simulator}: slow_rgb (untransformed) {tuple(slow.shape)}/{slow.dtype} != ({n},{h},{w},3)/uint8"
+        )
+
+    # 2. Rate: step 3 control steps. slow_cam (decimation=3) should hold its first frame for the
+    #    whole window; fast_cam (decimation=1) renders each step. Nudge the robot between steps so a
+    #    held frame is distinguishable from a freshly rendered one.
+    slow0 = first["slow_rgb"].clone()
+    fast0 = first["fast_rgb"].clone()
+    slow_changed = False
+    fast_changed = False
+    for _ in range(1, 3):  # steps 2 and 3 of the decimation=3 window
+        robot_states[:, 0] += 0.05  # shift the camera so a freshly rendered frame differs
+        sim.set_actor_states(["robot"], torch.arange(n, device=device), robot_states)
+        step(sim, 1)
+        obs = _obs()
+        if not torch.equal(obs["slow_rgb"], slow0):
+            slow_changed = True
+        if not torch.equal(obs["fast_rgb"], fast0):
+            fast_changed = True
+    print(
+        f"[{args.simulator}] over a dec=3 window: slow_cam changed={slow_changed} (want False), "
+        f"fast_cam changed={fast_changed} (want True)"
+    )
+    if slow_changed:
+        fails.append(
+            f"{args.simulator}: slow_cam (decimation=3) frame changed within its 3-step hold window; gate not honored"
+        )
+    if not fast_changed:
+        fails.append(
+            f"{args.simulator}: fast_cam (decimation=1) frame never changed while the camera moved; not re-rendering"
+        )
+
+    if args.result_file:
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        for f in fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        return 1
+    print(f"[{args.simulator}] PASS: camera obs pipeline format + decimation rate correct across {n} env(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/camera_orientation_assert.py
+++ b/src/holosoma/tests/simulators/camera_orientation_assert.py
@@ -1,0 +1,140 @@
+"""Cross-backend camera-orientation (handedness) assertion harness.
+
+A non-square camera (width != height) views a red panel off the optical axis, to the robot's left
+(+Y body) and up (+Z body). A correct forward-looking camera images that panel in the top-right
+quadrant; a left-right mirror, top-bottom flip, or width/height transpose moves it elsewhere and
+fails.
+
+Reference mapping (MuJoCo-classic, identity optical basis): a panel at body +Y, +Z, seen by a
+camera looking down body +X, lands top-right (small row, large column).
+
+Exits 0 PASS / 1 FAIL / 77 SKIP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+SKIP_EXIT_CODE = 77
+
+
+def _red_centroid(img):
+    """(row, col, count) of the red-panel pixels in one [H,W,3] frame, or (None, None, 0)."""
+    import torch
+
+    r, g, b = img[..., 0].to(int), img[..., 1].to(int), img[..., 2].to(int)
+    mask = (r > g + 40) & (r > b + 40)
+    ys, xs = torch.nonzero(mask, as_tuple=True)
+    if ys.numel() == 0:
+        return None, None, 0
+    return float(ys.float().mean()), float(xs.float().mean()), int(ys.numel())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument("--result-file", default=None, help="write OK/FAIL here before teardown")
+    args = parser.parse_args()
+
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    # Non-square camera (96x64) with an off-axis panel (left and up): the red lands in one quadrant.
+    config = build_run_sim_config(
+        sim_arg, "panel-offaxis", args.robot, args.terrain, sensors=_camera_presets.front_cam_wide
+    )
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config, device=device, training=dataclasses.replace(config.training, num_envs=args.num_envs)
+    )
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import torch
+
+    n = args.num_envs
+    env_origins = torch.zeros(n, 3, device=device)
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel), device=device, dtype=torch.float32
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    # Pin the robot upright at each origin so the camera aligns with the off-axis panel ahead.
+    robot_states = sim.get_actor_states(["robot"], torch.arange(n, device=device)).clone()
+    robot_states[:, :3] = env_origins + torch.tensor(list(init.pos), device=device)
+    robot_states[:, 3:7] = torch.tensor(list(init.rot), device=device)
+    robot_states[:, 7:] = 0.0
+    sim.set_actor_states(["robot"], torch.arange(n, device=device), robot_states)
+    step(sim, max(2, steps_for_seconds(sim, 0.05)))
+    sim.render_sensors()
+
+    cam_name, cam = next(iter(config.sensor.items()))
+    fails: list[str] = []
+    img_all = sim.get_camera_data(cam_name, "rgb")  # [N,H,W,3]
+    # Shape (N, height, width, 3) with height != width; catches a W/H transpose.
+    if tuple(img_all.shape) != (n, cam.height, cam.width, 3) or img_all.dtype != torch.uint8:
+        msg = (
+            f"{args.simulator}: shape/dtype {tuple(img_all.shape)} {img_all.dtype} "
+            f"!= ({n},{cam.height},{cam.width},3) uint8"
+        )
+        print(f"[{args.simulator}] FAIL: {msg}")
+        if args.result_file:
+            with open(args.result_file, "w") as fh:
+                fh.write("FAIL\n" + msg)
+        return 1
+
+    h, w = cam.height, cam.width
+    for e in range(n):
+        rc, cc, count = _red_centroid(img_all[e])
+        if count < 0.01 * h * w:
+            fails.append(f"{args.simulator}/env{e}: off-axis panel not visible ({count} red px)")
+            continue
+        # Panel is left (+Y) and up (+Z) -> TOP (row < H/2) and RIGHT (col > W/2) of the image.
+        top = rc < h / 2
+        right = cc > w / 2
+        print(
+            f"[{args.simulator}] env{e}: red centroid (row={rc:.1f}/{h}, col={cc:.1f}/{w}) -> "
+            f"{'TOP' if top else 'BOTTOM'}-{'RIGHT' if right else 'LEFT'}"
+        )
+        if not (top and right):
+            fails.append(
+                f"{args.simulator}/env{e}: off-axis (+Y left, +Z up) panel imaged "
+                f"{'TOP' if top else 'BOTTOM'}-{'RIGHT' if right else 'LEFT'}, expected TOP-RIGHT "
+                f"(mirror/flip/transpose in the image buffer)"
+            )
+
+    if args.result_file:
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        for f in fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        return 1
+    print(f"[{args.simulator}] PASS: off-axis panel lands TOP-RIGHT on a non-square frame across {n} env(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/depth_assert.py
+++ b/src/holosoma/tests/simulators/depth_assert.py
@@ -1,0 +1,187 @@
+"""Cross-backend depth behavioral assertion harness.
+
+Same red-panel setup as the RGB geometry test. Panel pixels are located by RGB segmentation (the
+panel is bright red), then their depth is checked against the known distance. Asserts:
+
+  1. shape ``[num_envs, H, W, 1]``, dtype float32, device == sim device.
+  2. Metric: panel pixel depth ~= known camera-to-panel face distance (meters).
+  3. No-hit sentinel: background (no geometry) reads a large value or +inf, not a near distance.
+  4. Image-plane convention: a flat fronto-parallel panel reads ~constant depth, not increasing
+     toward the edges (which distance-to-camera/radial depth would show).
+
+Checks metric agreement, never bit-exact (renderers differ). Exits 0 PASS / 1 FAIL / 77 SKIP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import math
+import sys
+
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+
+def _red_mask(env_rgb):
+    """Boolean [H,W] mask of red-panel pixels (R clearly dominant), same rule as the RGB test."""
+    r, g, b = env_rgb[..., 0].to(int), env_rgb[..., 1].to(int), env_rgb[..., 2].to(int)
+    return (r > g + 40) & (r > b + 40)
+
+
+def _check_depth(rgb, depth, cam_to_panel, panel_half, fov_deg, label):
+    """Depth shape/dtype + metric assertions on one env's frame. Returns failure strings."""
+    import torch
+
+    fails = []
+    h, w, _ = rgb.shape
+    if depth.shape != (h, w, 1) or depth.dtype != torch.float32:
+        return [f"{label}: depth shape/dtype {tuple(depth.shape)} {depth.dtype} != ({h},{w},1) float32"]
+
+    dep = depth[..., 0].float()
+    mask = _red_mask(rgb)
+    if int(mask.sum()) < 0.02 * h * w:
+        return [f"{label}: panel barely visible in RGB ({int(mask.sum())} px); cannot locate depth surface"]
+
+    panel_depth = dep[mask]
+    finite = panel_depth[torch.isfinite(panel_depth)]
+    if finite.numel() < 0.5 * panel_depth.numel():
+        return [f"{label}: panel depth mostly non-finite ({finite.numel()}/{panel_depth.numel()} finite)"]
+    med = float(finite.median())
+    # Inlier core: pixels within 20% of the median, excluding anti-aliased edge pixels whose depth
+    # falls through to the background. Used for the metric and image-plane spread checks.
+    inliers = finite[(finite - med).abs() <= 0.2 * cam_to_panel]
+
+    # 2. Metric: panel depth ~= camera-to-panel face distance, 15% tolerance.
+    if abs(med - cam_to_panel) > 0.15 * cam_to_panel:
+        fails.append(
+            f"{label}: panel median depth {med:.3f}m != expected {cam_to_panel:.3f}m (>15%); "
+            f"per-backend depth NOT normalized to meters"
+        )
+
+    # 3. No-hit: open sky around the panel maps to the +inf sentinel. Assert some background pixels
+    #    are +inf, and finite background is clearly beyond the panel (else depth is inverted/uncalibrated).
+    bg = dep[~mask]
+    if not bool(torch.isinf(bg).any()):
+        fails.append(f"{label}: no +inf no-hit pixels in the background (sentinel missing or finite-far)")
+    bg_finite = bg[torch.isfinite(bg)]
+    bg_ref = float(bg_finite.median()) if bg_finite.numel() else math.inf
+    if bg_ref <= cam_to_panel * 1.2:
+        fails.append(
+            f"{label}: finite background depth {bg_ref:.3f}m not clearly beyond the panel {cam_to_panel:.3f}m "
+            f"(depth inverted/uncalibrated)"
+        )
+
+    # 4. Image-plane: a fronto-parallel flat panel reads ~constant depth (distance-to-camera would
+    #    grow toward the edges by 1/cos(angle)). Inlier-core spread must be small relative to distance.
+    spread = float(inliers.max() - inliers.min())
+    if spread > 0.10 * cam_to_panel:
+        fails.append(
+            f"{label}: panel depth spread {spread:.3f}m > 10% of {cam_to_panel:.3f}m -> not image-plane "
+            f"(looks distance-to-camera/radial)"
+        )
+    return fails
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument("--result-file", default=None, help="write OK/FAIL here before teardown")
+    args = parser.parse_args()
+
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    # front-cam-depth: the forward camera producing both rgb (to locate the panel) and depth.
+    config = build_run_sim_config(
+        sim_arg, "panel-target", args.robot, args.terrain, sensors=_camera_presets.front_cam_depth
+    )
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config, device=device, training=dataclasses.replace(config.training, num_envs=args.num_envs)
+    )
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import torch
+
+    n = args.num_envs
+    env_origins = torch.zeros(n, 3, device=device)
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel), device=device, dtype=torch.float32
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    # Pin the robot upright at the origin so the camera aligns with the panel ahead.
+    robot_states = sim.get_actor_states(["robot"], torch.arange(n, device=device)).clone()
+    robot_states[:, :3] = env_origins + torch.tensor(list(init.pos), device=device)
+    robot_states[:, 3:7] = torch.tensor(list(init.rot), device=device)
+    robot_states[:, 7:] = 0.0
+    sim.set_actor_states(["robot"], torch.arange(n, device=device), robot_states)
+    step(sim, 2)
+
+    if not sim.get_sensor_names():
+        print(f"[{args.simulator}] FAIL: no sensors created")
+        return 1
+
+    step(sim, max(2, steps_for_seconds(sim, 0.05)))
+    sim.render_sensors()
+
+    cam_name, cam = next(iter(config.sensor.items()))
+    cam_to_panel = _camera_presets._PANEL_DISTANCE - cam.mount.position[0] - 0.01  # camera->panel FACE (m)
+
+    fails: list[str] = []
+    rgb_all = sim.get_camera_data(cam_name, "rgb")  # [N,H,W,3] uint8
+    depth_all = sim.get_camera_data(cam_name, "depth")  # [N,H,W,1] float32 meters
+    # The buffer device should equal the sim device.
+    if str(rgb_all.device) != str(sim.sim_device) or str(depth_all.device) != str(sim.sim_device):
+        fails.append(
+            f"{args.simulator}: camera buffers on {rgb_all.device}/{depth_all.device} != sim_device {sim.sim_device}"
+        )
+    print(
+        f"[{args.simulator}] depth shape={tuple(depth_all.shape)} dtype={depth_all.dtype} "
+        f"expected_panel_depth={cam_to_panel:.3f}m"
+    )
+    for e in range(n):
+        env_fails = _check_depth(
+            rgb_all[e],
+            depth_all[e],
+            cam_to_panel,
+            _camera_presets._PANEL_HALF_SIZE,
+            cam.vertical_fov,
+            f"{args.simulator}/env{e}",
+        )
+        for f in env_fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        fails += env_fails
+        if not env_fails:
+            print(f"[{args.simulator}] env{e}: depth OK (metric, image-plane, no-hit sentinel)")
+
+    if args.result_file:
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        return 1
+    print(f"[{args.simulator}] PASS: depth correct across {n} env(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/holosoma/tests/simulators/isaacgym/test_camera_isaacgym.py
+++ b/src/holosoma/tests/simulators/isaacgym/test_camera_isaacgym.py
@@ -1,0 +1,207 @@
+"""Live IsaacGym camera tests (GPU), one sim per subprocess.
+
+Each test runs a camera assert harness against the IsaacGym backend. The geometry harness mounts
+a camera on the robot base looking at a known red panel and checks the [N,H,W,3] uint8 frame's
+panel silhouette is centered, square, and FOV-consistent.
+
+importorskip("isaacgym") and CUDA-gated. Collected by the IsaacGym CI job (-m "not isaacsim").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("isaacgym")
+from holosoma.utils.safe_torch_import import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("IsaacGym requires a CUDA device", allow_module_level=True)
+
+from tests.simulators._run_harness import run_harness
+
+_HARNESS = Path(__file__).resolve().parents[1] / "camera_geometry_assert.py"
+_DEPTH_HARNESS = Path(__file__).resolve().parents[1] / "depth_assert.py"
+_CONTRACT_HARNESS = Path(__file__).resolve().parents[1] / "camera_assert.py"
+_FOLLOW_HARNESS = Path(__file__).resolve().parents[1] / "camera_follow_assert.py"
+_MULTI_HARNESS = Path(__file__).resolve().parents[1] / "camera_multi_assert.py"
+_ACTOR_HARNESS = Path(__file__).resolve().parents[1] / "camera_actor_mount_assert.py"
+_WORLD_HARNESS = Path(__file__).resolve().parents[1] / "world_camera_assert.py"
+_ORIENT_HARNESS = Path(__file__).resolve().parents[1] / "camera_orientation_assert.py"
+_OBS_HARNESS = Path(__file__).resolve().parents[1] / "camera_obs_assert.py"
+
+
+def test_camera_geometry(tmp_path):
+    result_file = tmp_path / "geo_isaacgym.txt"
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-geometry",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_geometry_multi_env(tmp_path):
+    # All envs co-located: every env renders the same geometry.
+    result_file = tmp_path / "geo_isaacgym_multi.txt"
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--num-envs",
+        "4",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-geometry (num_envs=4)",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_depth(tmp_path):
+    # Depth in positive meters, image-plane, +inf no-hit. Panel at a known distance reads ~that.
+    result_file = tmp_path / "depth_isaacgym.txt"
+    run_harness(
+        _DEPTH_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-depth",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_recorder(tmp_path):
+    # A viz config requesting recording yields a non-None camera_sensor_recorder that capture()s a frame.
+    result_file = tmp_path / "rec_isaacgym.txt"
+    run_harness(
+        _CONTRACT_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--check-recorder",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-recorder",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_follow(tmp_path):
+    # Camera tracks its mount body: move the robot, the panel depth drops by the moved distance.
+    result_file = tmp_path / "follow_isaacgym.txt"
+    run_harness(
+        _FOLLOW_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-follow",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_follow_multi_env(tmp_path):
+    # Camera tracks its mount body: move the robot, the panel depth drops by the moved distance.
+    # Multi-env: each env's camera follows its own mount body.
+    result_file = tmp_path / "follow_isaacgym_multi.txt"
+    run_harness(
+        _FOLLOW_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--num-envs",
+        "4",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-follow (num_envs=4)",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_multi(tmp_path):
+    # Two cameras with different views each return their own frame (no buffer mixup).
+    result_file = tmp_path / "multi_isaacgym.txt"
+    run_harness(
+        _MULTI_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-multi",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_actor_mount(tmp_path):
+    # Exercises target_kind='actor': a camera on a scene object resolves, renders, and follows it.
+    result_file = tmp_path / "actor_isaacgym.txt"
+    run_harness(
+        _ACTOR_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-actor-mount",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.parametrize("num_envs", ["1", "3"])
+def test_camera_world_mount(tmp_path, num_envs):
+    # target_kind='world': a free-floating camera fixed in the env frame does NOT follow the robot,
+    # and each env's camera sits at its own origin (set_camera_transform, not attach_camera_to_body).
+    result_file = tmp_path / f"world_isaacgym_{num_envs}.txt"
+    run_harness(
+        _WORLD_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--num-envs",
+        num_envs,
+        "--result-file",
+        str(result_file),
+        label=f"isaacgym/camera-world-mount (num_envs={num_envs})",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_orientation(tmp_path):
+    # Off-axis panel on a non-square camera lands in the expected image quadrant (catches mirror/flip/transpose).
+    result_file = tmp_path / "orient_isaacgym.txt"
+    run_harness(
+        _ORIENT_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-orientation",
+        timeout=600,
+        result_file=result_file,
+    )
+
+
+def test_camera_obs_pipeline(tmp_path):
+    # Drives render_sensors -> camera obs term -> transform -> obs dict; asserts CHW float01 format
+    # and that a decimation=3 camera holds while a decimation=1 camera updates.
+    result_file = tmp_path / "obs_isaacgym.txt"
+    run_harness(
+        _OBS_HARNESS,
+        "--simulator",
+        "isaacgym",
+        "--result-file",
+        str(result_file),
+        label="isaacgym/camera-obs-pipeline",
+        timeout=600,
+        result_file=result_file,
+    )

--- a/src/holosoma/tests/simulators/isaacsim/test_camera_isaacsim.py
+++ b/src/holosoma/tests/simulators/isaacsim/test_camera_isaacsim.py
@@ -1,0 +1,192 @@
+"""Live IsaacSim camera tests (GPU), one sim per subprocess.
+
+Each test runs a camera assert harness against the IsaacSim backend. The geometry harness mounts
+a TiledCamera on the robot base looking at a known red panel and checks the [N,H,W,3] uint8
+frame's panel silhouette is centered, square, and FOV-consistent. Pass/fail is read from the
+harness's --result-file sentinel, since IsaacSim teardown can mask the exit code.
+
+Marked ``isaacsim`` so the IsaacSim CI job (-m "isaacsim") collects it. importorskip("isaaclab")
+and CUDA-gated. The CI job exports OMNI_KIT_ACCEPT_EULA=YES.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.isaacsim
+
+pytest.importorskip("isaaclab")
+torch = pytest.importorskip("torch")
+if not torch.cuda.is_available():
+    pytest.skip("IsaacSim requires a CUDA device", allow_module_level=True)
+
+from tests.simulators._run_harness import run_harness  # noqa: E402
+
+_HARNESS = Path(__file__).resolve().parents[1] / "camera_geometry_assert.py"
+_DEPTH_HARNESS = Path(__file__).resolve().parents[1] / "depth_assert.py"
+_CONTRACT_HARNESS = Path(__file__).resolve().parents[1] / "camera_assert.py"
+_FOLLOW_HARNESS = Path(__file__).resolve().parents[1] / "camera_follow_assert.py"
+_MULTI_HARNESS = Path(__file__).resolve().parents[1] / "camera_multi_assert.py"
+_ACTOR_HARNESS = Path(__file__).resolve().parents[1] / "camera_actor_mount_assert.py"
+_WORLD_HARNESS = Path(__file__).resolve().parents[1] / "world_camera_assert.py"
+_ORIENT_HARNESS = Path(__file__).resolve().parents[1] / "camera_orientation_assert.py"
+_OBS_HARNESS = Path(__file__).resolve().parents[1] / "camera_obs_assert.py"
+
+
+def test_camera_geometry(tmp_path):
+    result_file = tmp_path / "geo_isaacsim.txt"
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-geometry",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+def test_camera_depth(tmp_path):
+    # Depth in meters, image-plane, +inf no-hit. Panel at a known distance reads ~that.
+    result_file = tmp_path / "depth_isaacsim.txt"
+    run_harness(
+        _DEPTH_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-depth",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+def test_camera_recorder(tmp_path):
+    # A viz config requesting recording yields a non-None camera_sensor_recorder that capture()s a frame.
+    result_file = tmp_path / "rec_isaacsim.txt"
+    run_harness(
+        _CONTRACT_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--check-recorder",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-recorder",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+def test_camera_follow(tmp_path):
+    # Camera tracks its mount body: move the robot, the panel depth drops by the moved distance.
+    result_file = tmp_path / "follow_isaacsim.txt"
+    run_harness(
+        _FOLLOW_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-follow",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+def test_camera_multi(tmp_path):
+    # Two cameras with different views each return their own frame (no buffer mixup).
+    result_file = tmp_path / "multi_isaacsim.txt"
+    run_harness(
+        _MULTI_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-multi",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+def test_camera_actor_mount(tmp_path):
+    # Exercises target_kind='actor': a camera on a scene object resolves, renders, and follows it.
+    result_file = tmp_path / "actor_isaacsim.txt"
+    run_harness(
+        _ACTOR_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-actor-mount",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.parametrize("num_envs", ["1", "3"])
+def test_camera_world_mount(tmp_path, num_envs):
+    # target_kind='world': a free-floating camera (child of the env prim) fixed in the env frame
+    # does NOT follow the robot, and each env's camera sits at its own origin.
+    result_file = tmp_path / f"world_isaacsim_{num_envs}.txt"
+    run_harness(
+        _WORLD_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--num-envs",
+        num_envs,
+        "--result-file",
+        str(result_file),
+        label=f"isaacsim/camera-world-mount (num_envs={num_envs})",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+def test_camera_follow_multi_env(tmp_path):
+    # num_envs=4: yaw only env 0 and assert the other envs' frames are unchanged.
+    result_file = tmp_path / "follow_isaacsim_multi.txt"
+    run_harness(
+        _FOLLOW_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--num-envs",
+        "4",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-follow (num_envs=4)",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+def test_camera_orientation(tmp_path):
+    # Off-axis panel on a non-square camera lands in the expected image quadrant (catches mirror/flip/transpose).
+    result_file = tmp_path / "orient_isaacsim.txt"
+    run_harness(
+        _ORIENT_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-orientation",
+        timeout=700,
+        result_file=result_file,
+    )
+
+
+def test_camera_obs_pipeline(tmp_path):
+    # Drives render_sensors -> camera obs term -> transform -> obs dict; asserts CHW float01 format
+    # and that a decimation=3 camera holds while a decimation=1 camera updates.
+    result_file = tmp_path / "obs_isaacsim.txt"
+    run_harness(
+        _OBS_HARNESS,
+        "--simulator",
+        "isaacsim",
+        "--result-file",
+        str(result_file),
+        label="isaacsim/camera-obs-pipeline",
+        timeout=700,
+        result_file=result_file,
+    )

--- a/src/holosoma/tests/simulators/mujoco/test_camera_mujoco.py
+++ b/src/holosoma/tests/simulators/mujoco/test_camera_mujoco.py
@@ -1,0 +1,347 @@
+"""Live MuJoCo camera tests (classic CPU and Warp GPU), one sim per subprocess.
+
+Each test runs a camera assert harness under both MuJoCo backends. The geometry harness mounts a
+<camera> on the robot base looking at a known red panel and checks the [N,H,W,3] uint8 frame's
+panel silhouette is centered, square, and FOV-consistent.
+
+  - classic: ClassicBackend (CPU, single env). Needs a GL context for mujoco.Renderer (DISPLAY
+    for GLX). mujoco_classic marker.
+  - mjwarp: WarpBackend (GPU), batched renderer, multi-env. mujoco_warp marker and CUDA gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mujoco")
+from holosoma.utils.safe_torch_import import torch
+from tests.simulators._run_harness import run_harness
+
+_HARNESS = Path(__file__).resolve().parents[1] / "camera_geometry_assert.py"
+_DEPTH_HARNESS = Path(__file__).resolve().parents[1] / "depth_assert.py"
+_CONTRACT_HARNESS = Path(__file__).resolve().parents[1] / "camera_assert.py"
+_FOLLOW_HARNESS = Path(__file__).resolve().parents[1] / "camera_follow_assert.py"
+_MULTI_HARNESS = Path(__file__).resolve().parents[1] / "camera_multi_assert.py"
+_ACTOR_HARNESS = Path(__file__).resolve().parents[1] / "camera_actor_mount_assert.py"
+_WORLD_HARNESS = Path(__file__).resolve().parents[1] / "world_camera_assert.py"
+_ORIENT_HARNESS = Path(__file__).resolve().parents[1] / "camera_orientation_assert.py"
+_OBS_HARNESS = Path(__file__).resolve().parents[1] / "camera_obs_assert.py"
+
+
+@pytest.mark.mujoco_classic
+def test_camera_geometry_classic(tmp_path):
+    result_file = tmp_path / "geo_mujoco.txt"
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "mujoco",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-geometry",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+@pytest.mark.parametrize("num_envs", ["1", "3"])
+def test_camera_geometry_warp(tmp_path, num_envs):
+    # Co-located envs: every world renders the same geometry in the batched [N,H,W,3] output.
+    result_file = tmp_path / f"geo_mjwarp_{num_envs}.txt"
+    run_harness(
+        _HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--num-envs",
+        num_envs,
+        "--result-file",
+        str(result_file),
+        label=f"mjwarp/camera-geometry (num_envs={num_envs})",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_classic
+def test_camera_depth_classic(tmp_path):
+    # Depth in meters, image-plane, +inf no-hit. Panel at a known distance reads ~that.
+    result_file = tmp_path / "depth_mujoco.txt"
+    run_harness(
+        _DEPTH_HARNESS,
+        "--simulator",
+        "mujoco",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-depth",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+def test_camera_depth_warp(tmp_path):
+    # Batched get_depth(depth_scale=far) -> meters with +inf no-hit.
+    result_file = tmp_path / "depth_mjwarp.txt"
+    run_harness(
+        _DEPTH_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--result-file",
+        str(result_file),
+        label="mjwarp/camera-depth",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_classic
+def test_camera_recorder_classic(tmp_path):
+    # A viz config requesting recording yields a non-None camera_sensor_recorder that capture()s a frame.
+    result_file = tmp_path / "rec_mujoco.txt"
+    run_harness(
+        _CONTRACT_HARNESS,
+        "--simulator",
+        "mujoco",
+        "--check-recorder",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-recorder",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+def test_camera_recorder_warp(tmp_path):
+    result_file = tmp_path / "rec_mjwarp.txt"
+    run_harness(
+        _CONTRACT_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--check-recorder",
+        "--result-file",
+        str(result_file),
+        label="mjwarp/camera-recorder",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_classic
+def test_camera_follow_classic(tmp_path):
+    # Camera tracks its mount body: move the robot toward the panel, the panel depth drops by the moved distance.
+    result_file = tmp_path / "follow_mujoco.txt"
+    run_harness(
+        _FOLLOW_HARNESS,
+        "--simulator",
+        "mujoco",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-follow",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+def test_camera_follow_warp(tmp_path):
+    result_file = tmp_path / "follow_mjwarp.txt"
+    run_harness(
+        _FOLLOW_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--result-file",
+        str(result_file),
+        label="mjwarp/camera-follow",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_classic
+def test_camera_multi_classic(tmp_path):
+    # Two cameras with different views each return their own frame (no buffer mixup).
+    result_file = tmp_path / "multi_mujoco.txt"
+    run_harness(
+        _MULTI_HARNESS,
+        "--simulator",
+        "mujoco",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-multi",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+def test_camera_multi_warp(tmp_path):
+    result_file = tmp_path / "multi_mjwarp.txt"
+    run_harness(
+        _MULTI_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--result-file",
+        str(result_file),
+        label="mjwarp/camera-multi",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_classic
+def test_camera_actor_mount_classic(tmp_path):
+    # target_kind="actor": a camera on a scene object resolves, renders, and follows it.
+    result_file = tmp_path / "actor_mujoco.txt"
+    run_harness(
+        _ACTOR_HARNESS,
+        "--simulator",
+        "mujoco",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-actor-mount",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+def test_camera_actor_mount_warp(tmp_path):
+    result_file = tmp_path / "actor_mjwarp.txt"
+    run_harness(
+        _ACTOR_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--result-file",
+        str(result_file),
+        label="mjwarp/camera-actor-mount",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_classic
+def test_camera_world_mount_classic(tmp_path):
+    # target_kind="world": a free-floating camera fixed in the env frame does NOT follow the robot.
+    result_file = tmp_path / "world_mujoco.txt"
+    run_harness(
+        _WORLD_HARNESS,
+        "--simulator",
+        "mujoco",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-world-mount",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+@pytest.mark.parametrize("num_envs", ["1", "3"])
+def test_camera_world_mount_warp(tmp_path, num_envs):
+    result_file = tmp_path / f"world_mjwarp_{num_envs}.txt"
+    run_harness(
+        _WORLD_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--num-envs",
+        num_envs,
+        "--result-file",
+        str(result_file),
+        label=f"mjwarp/camera-world-mount (num_envs={num_envs})",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_classic
+def test_camera_orientation_classic(tmp_path):
+    # Off-axis panel on a non-square camera lands in the expected image quadrant (catches mirror/flip/transpose).
+    result_file = tmp_path / "orient_mujoco.txt"
+    run_harness(
+        _ORIENT_HARNESS,
+        "--simulator",
+        "mujoco",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-orientation",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+def test_camera_orientation_warp(tmp_path):
+    result_file = tmp_path / "orient_mjwarp.txt"
+    run_harness(
+        _ORIENT_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--result-file",
+        str(result_file),
+        label="mjwarp/camera-orientation",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_classic
+def test_camera_obs_pipeline_classic(tmp_path):
+    # Drives render_sensors -> camera obs term -> transform -> obs dict each step; asserts CHW
+    # float01 format and that a decimation=3 camera holds while a decimation=1 camera updates.
+    result_file = tmp_path / "obs_mujoco.txt"
+    run_harness(
+        _OBS_HARNESS,
+        "--simulator",
+        "mujoco",
+        "--result-file",
+        str(result_file),
+        label="mujoco/camera-obs-pipeline",
+        timeout=300,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+def test_camera_obs_pipeline_warp(tmp_path):
+    result_file = tmp_path / "obs_mjwarp.txt"
+    run_harness(
+        _OBS_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--result-file",
+        str(result_file),
+        label="mjwarp/camera-obs-pipeline",
+        timeout=400,
+        result_file=result_file,
+    )
+
+
+@pytest.mark.mujoco_warp
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MuJoCo-Warp requires a CUDA device")
+def test_camera_follow_multi_env_warp(tmp_path):
+    # num_envs=4 at distinct origins: yaw only env 0 and assert the other envs' frames are unchanged.
+    result_file = tmp_path / "follow_multi_mjwarp.txt"
+    run_harness(
+        _FOLLOW_HARNESS,
+        "--simulator",
+        "mjwarp",
+        "--num-envs",
+        "4",
+        "--result-file",
+        str(result_file),
+        label="mjwarp/camera-follow (num_envs=4)",
+        timeout=500,
+        result_file=result_file,
+    )

--- a/src/holosoma/tests/simulators/world_camera_assert.py
+++ b/src/holosoma/tests/simulators/world_camera_assert.py
@@ -1,0 +1,230 @@
+"""Cross-backend free-floating (``target_kind="world"``) camera behavioral assertion harness.
+
+A world camera anchors to each env's frame, NOT to any body, so moving or yawing the robot must
+NOT change what it sees. This is the behavioral inverse of ``camera_follow_assert`` (which asserts
+a robot_link camera DOES track its body).
+
+Setup mirrors the follow test: a world camera fixed at the robot's spawn spot looks forward (+X) at
+a red panel 1.0 m ahead. We render (baseline), then (1) advance the robot toward the panel and
+(2) yaw it 40deg. A world camera's panel depth and red-fraction must stay ~constant through both
+(the robot moving in front of it may perturb pixels slightly, but the panel stays framed at the
+same depth). For num_envs>1 we also check the per-env views are independent (each env's world
+camera sits at that env's origin). Exits 0 PASS, 1 FAIL, 77 SKIP.
+
+  python world_camera_assert.py --simulator mujoco
+  python world_camera_assert.py --simulator mjwarp   --num-envs 3
+  python world_camera_assert.py --simulator isaacgym --num-envs 3
+  python world_camera_assert.py --simulator isaacsim --num-envs 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import sys
+
+if sys.path and sys.path[0].endswith("simulators"):
+    sys.path.pop(0)
+
+from holosoma.utils.sim_utils import setup_simulation_environment
+from tests.simulators._sim_harness import build_run_sim_config, step, steps_for_seconds
+
+SKIP_EXIT_CODE = 77
+_CAM = "world_cam"
+
+
+def _red_mask(rgb):
+    return (rgb[..., 0].to(int) > rgb[..., 1].to(int) + 40) & (rgb[..., 0].to(int) > rgb[..., 2].to(int) + 40)
+
+
+def _red_fraction(rgb):
+    """Fraction of red-panel pixels in one [H,W,3] frame."""
+    return float(_red_mask(rgb).float().mean())
+
+
+def _panel_median_depth(rgb, depth):
+    """Median depth (meters) over the red-panel pixels of one env frame, or None if not visible."""
+    import torch
+
+    mask = _red_mask(rgb)
+    if int(mask.sum()) < 0.02 * rgb.shape[0] * rgb.shape[1]:
+        return None
+    panel = depth[..., 0][mask]
+    finite = panel[torch.isfinite(panel)]
+    return float(finite.median()) if finite.numel() else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--simulator", required=True, choices=["mujoco", "mjwarp", "isaacgym", "isaacsim"])
+    parser.add_argument("--robot", default="g1-29dof")
+    parser.add_argument("--terrain", default="terrain_locomotion_plane")
+    parser.add_argument("--num-envs", type=int, default=1)
+    parser.add_argument("--headless", choices=["true", "false"], default="true")
+    parser.add_argument("--result-file", default=None, help="write OK/FAIL here before teardown")
+    args = parser.parse_args()
+
+    from tests.simulators import _camera_presets
+
+    headless = args.headless == "true"
+    sim_arg = "mujoco" if args.simulator == "mjwarp" else args.simulator
+    config = build_run_sim_config(sim_arg, "panel-target", args.robot, args.terrain, sensors=_camera_presets.world_cam)
+    if args.simulator == "mjwarp":
+        config = _camera_presets.as_mjwarp(config)
+
+    device = "cuda:0" if args.simulator != "mujoco" else "cpu"
+    config = dataclasses.replace(
+        config, device=device, training=dataclasses.replace(config.training, num_envs=args.num_envs)
+    )
+
+    env, device, _app = setup_simulation_environment(config, device=device)
+    sim = env.sim
+    sim.set_headless(headless)
+    sim.setup()
+    sim.setup_terrain()
+    sim.load_assets()
+    import math
+
+    import torch
+
+    n = args.num_envs
+    # Spread envs along +X so each gets its own panel copy at its own origin. The world camera must
+    # sit at each env's origin (per-env frame), so each env sees its own panel.
+    env_origins = torch.zeros(n, 3, device=device)
+    if n > 1:
+        env_origins[:, 0] = torch.arange(n, device=device, dtype=torch.float32) * 10.0
+    init = config.robot.init_state
+    base_init = torch.tensor(
+        list(init.pos) + list(init.rot) + list(init.lin_vel) + list(init.ang_vel), device=device, dtype=torch.float32
+    )
+    sim.create_envs(n, env_origins, base_init)
+    sim.prepare_sim()
+
+    if not sim.get_sensor_names():
+        print(f"[{args.simulator}] FAIL: no sensors created")
+        return 1
+
+    move = 0.3  # meters to advance the robot toward the panel (+X base frame)
+    yaw = math.radians(40.0)  # body yaw
+    base_rot = list(init.rot)  # (x, y, z, w) actor-state quaternion order
+
+    def _quat_mul_yaw(q_xyzw, yaw_rad):
+        """Compose a world-Z yaw onto the base orientation (xyzw)."""
+        cz, sz = math.cos(yaw_rad / 2), math.sin(yaw_rad / 2)
+        yq = [0.0, 0.0, sz, cz]  # yaw about +Z (x, y, z, w)
+        x1, y1, z1, w1 = yq
+        x2, y2, z2, w2 = q_xyzw
+        return [
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        ]
+
+    # Keep the robot OUT of the world camera's forward sightline. The camera sits on the camera↔panel
+    # axis (y=0) looking +X; the robot spawns on that same axis, so advancing it +X toward the panel —
+    # or the un-actuated robot collapsing under gravity during the settle step — puts a limb between
+    # the (fixed) camera and the panel and occludes it, which is exactly what this test must NOT
+    # conflate with camera motion. Shove the robot 1.5 m to the side (clear of the ~0.6 m half-width
+    # 60° frustum at the ~1 m panel distance) so it still moves/yaws to prove the world camera doesn't
+    # follow it, without ever occluding the panel.
+    robot_y_offset = -1.5
+
+    def _place(x_offset: float, rot_xyzw) -> None:
+        all_ids = torch.arange(n, device=device)
+        states = sim.get_actor_states(["robot"], all_ids).clone()
+        states[:, :3] = env_origins + torch.tensor(list(init.pos), device=device)
+        states[:, 0] += x_offset
+        states[:, 1] += robot_y_offset
+        states[:, 3:7] = torch.tensor(rot_xyzw, device=device)
+        states[:, 7:] = 0.0
+        sim.set_actor_states(["robot"], all_ids, states)
+        step(sim, max(2, steps_for_seconds(sim, 0.05)))
+        sim.render_sensors()
+
+    def _panel_depths():
+        return [
+            _panel_median_depth(sim.get_camera_data(_CAM, "rgb")[e], sim.get_camera_data(_CAM, "depth")[e])
+            for e in range(n)
+        ]
+
+    def _reds():
+        return [_red_fraction(sim.get_camera_data(_CAM, "rgb")[e]) for e in range(n)]
+
+    # Baseline: robot at spawn, world camera framing the panel head-on.
+    _place(0.0, base_rot)
+    base_depth = _panel_depths()
+    base_red = _reds()
+
+    fails: list[str] = [
+        f"{args.simulator}/env{e}: world camera does not see the panel at baseline"
+        for e in range(n)
+        if base_depth[e] is None
+    ]
+    if fails:
+        for f in fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        if args.result_file:
+            with open(args.result_file, "w") as fh:
+                fh.write("FAIL\n" + "\n".join(fails))
+        return 1
+
+    # 1. Advance the robot toward the panel. A WORLD camera does not move, so the panel's depth
+    #    from the (fixed) camera must stay ~constant — unlike a follow camera, whose depth would
+    #    drop by ~move.
+    _place(move, base_rot)
+    moved_depth = _panel_depths()
+
+    # 2. Yaw the robot 40deg. A world camera keeps framing the panel: red fraction stays ~constant
+    #    (a follow camera would swing the panel out of frame).
+    _place(0.0, _quat_mul_yaw(base_rot, yaw))
+    yawed_red = _reds()
+
+    for e in range(n):
+        print(
+            f"[{args.simulator}] env{e}: panel depth base {base_depth[e]:.3f}m -> after-robot-move "
+            f"{moved_depth[e] if moved_depth[e] is None else round(moved_depth[e], 3)}m; "
+            f"red {base_red[e]:.3f} -> after-40deg-yaw {yawed_red[e]:.3f}"
+        )
+        if moved_depth[e] is None:
+            fails.append(f"{args.simulator}/env{e}: panel left the world-camera frame after the robot moved")
+            continue
+        # The world camera is fixed, so its panel depth must be ~unchanged (tolerance 5 cm; the
+        # robot passing in front can nibble panel pixels but not shift the panel's distance).
+        if abs(moved_depth[e] - base_depth[e]) > 0.05:
+            fails.append(
+                f"{args.simulator}/env{e}: world-camera panel depth changed {base_depth[e]:.3f}m -> "
+                f"{moved_depth[e]:.3f}m when the ROBOT moved {move}m; a world camera must not follow the robot."
+            )
+        # Panel must stay framed after the yaw: red fraction at least half its baseline (a follow
+        # camera would collapse it).
+        if base_red[e] > 0.02 and yawed_red[e] < 0.5 * base_red[e]:
+            fails.append(
+                f"{args.simulator}/env{e}: world-camera red fraction {base_red[e]:.3f} -> {yawed_red[e]:.3f} after a "
+                f"robot yaw; a world camera must keep framing the panel (it does not follow the robot)."
+            )
+
+    # 3. Per-env independence (n > 1): every env's world camera should see its own panel at the same
+    #    baseline depth (each sits at its own env origin, not env 0's).
+    if n > 1 and not fails:
+        spread = max(base_depth) - min(base_depth)
+        print(f"[{args.simulator}] per-env baseline panel depths: {[round(d, 3) for d in base_depth]}")
+        if spread > 0.05:
+            fails.append(
+                f"{args.simulator}: per-env world-camera panel depths vary by {spread:.3f}m "
+                f"({[round(d, 3) for d in base_depth]}); each env's world camera should sit at its own origin."
+            )
+
+    if args.result_file:
+        with open(args.result_file, "w") as fh:
+            fh.write("OK" if not fails else "FAIL\n" + "\n".join(fails))
+    if fails:
+        for f in fails:
+            print(f"[{args.simulator}] FAIL: {f}")
+        return 1
+    print(f"[{args.simulator}] PASS: world camera stays fixed in the env frame across {n} env(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/mujoco_ci_tests.sh
+++ b/tests/ci/mujoco_ci_tests.sh
@@ -5,6 +5,13 @@ set -ex
 
 cd /workspace/holosoma
 
+# Headless GL for the classic MuJoCo camera renderer (mujoco.Renderer). The CI container has no
+# X server/DISPLAY, so the default GLX path dies with "gladLoadGL error"; the NVIDIA base image
+# (nvcr.io/nvidia/isaac-sim) ships libEGL + the GLVND nvidia vendor, so EGL renders offscreen on
+# the GPU. Verified on GPU hardware headless. Set before any mujoco import (pytest subprocesses
+# inherit it). mjwarp uses its own GPU renderer and is unaffected.
+export MUJOCO_GL=egl
+
 source scripts/source_mujoco_setup.sh
 pip install -e 'src/holosoma[unitree,booster]'
 pip install -e src/holosoma_inference


### PR DESCRIPTION
# PR — `feat(sensors): backend-agnostic mounted cameras + camera-egress plugins`

## Summary

Adds a **backend-agnostic mounted-camera system** and the **camera-egress plugins** that ship rendered
frames off the sim. Declare any number of cameras in one top-level `sensor:` config; mount them on a
robot link, a scene actor, or the world; render RGB and/or depth on all four backends (MuJoCo Classic
CPU, MuJoCo Warp GPU, IsaacGym, IsaacSim); read frames through one unified `get_camera_data` API with a
shared cross-device cache; feed them to visual-policy **observation terms**; and stream them out via
**plugins** (`plugin.<key>:ros2-image` / `viz` / …) — ROS2 `Image`/`CompressedImage` publish, a live cv2
window, or an mp4. Built on the plugin family (base branch): camera egress is a plugin like any other, so
it works in both `run_sim` and training. This is the sensor/vision layer of the stack.

## Behavior changes

### Newly supported (opt-in; no-op default — no existing task/env affected)

- **`sensor:` camera config family, selectable as `--sensor.<name>:<variant>`.** New
  `CameraSensorConfig` (`config_types/sensor.py:...`) — backend-agnostic core fields
  (width/height/vertical_fov/near/far/data_types/update_decimation) + a `SensorMountConfig`
  (`robot_link` / `actor` / `world`) + per-backend sub-configs — resolved from `CAMERA_REGISTRY`
  (`config_values/sensor.py:27`, group `holosoma.config.sensor`). Surfaced as a dynamic-dict field:
  `sensor` on `RunSimConfig` (`run_sim.py:83`) / `ExperimentConfig` (`experiment.py:129`) /
  `EnvConfig` (`env.py:30`), threaded into `FullSimConfig.sensors` (`full_sim.py:34`, plural). Empty by
  default. G1 building-block cameras (`g1-head`, `g1-stereo-left/right`, `g1-*-wrist`, `g1-waist-*`)
  ship in `config_values/wbt/g1/sensor.py` — composed per-key on the CLI.
- **Per-backend camera rendering, unified read.** Each backend renders due cameras into a
  `SensorManager`/`CameraRuntime` registry (`simulator/shared/camera_sensor.py`) with a lazy
  cross-device cache; frames are read back through `BaseSimulator.get_camera_data(name, modality,
  device=…)` (`base_simulator.py:772`) — `uint8 [N,H,W,3]` R,G,B for rgb, `float32 [N,H,W,1]` meters
  (image-plane, `+inf` no-hit) for depth. IsaacSim uses its native tiled camera; MuJoCo-Warp uses its
  batched renderer; IsaacGym / MuJoCo-Classic render per camera. `render_sensors` runs once per control
  frame as a core `FRAME_END` hook, registered **before** any consumer plugin so buffers are fresh on
  read (`base_simulator.py:183`).
- **Camera observation terms** — `camera_rgb` / `camera_depth`
  (`managers/observation/terms/cameras.py:32,50`) read `get_camera_data` and apply an optional
  `ImageTransform` (`simulator/shared/image_transform.py`: resize → scale → layout → flatten) for
  visual policies; the observation manager handles image-shaped (non-flat) terms
  (`managers/observation/manager.py`).
- **Camera-egress plugins** — a `CameraConsumerPlugin` base
  (`simulator/plugins/camera_consumer.py:85`) self-serves each step's fresh frames (one shared
  `get_camera_data(device="cpu")` host copy per (camera, modality), sliced per wanted env) and hands them
  to concrete sinks; registers `publish` on `FRAME_END` + `stop` on `CLOSE`. Concrete plugins:
  - **`ros2-image` / `ros2-stereo` / `ros2-waist-depth` / `-color` / `-raw+color`** — publish camera
    routes as `sensor_msgs/Image` or `CompressedImage` (+ latched `CameraInfo`), one node fanning out to
    many routes, with an async drop-oldest worker per route
    (`simulator/plugins/ros2/ros2_image_plugin.py:...`, presets `config_values/plugin.py:48-143`). Depth
    routes publish raw metric (`32FC1`/`16UC1`) or colorize to RGB.
  - **`viz` / `viz-record`** — tile watched (camera, modality, env) panels into a live cv2 window and/or
    an mp4 at teardown (`simulator/plugins/viz/viz_plugin.py:...`, presets `config_values/plugin.py:145,148`).
  - ROS-free helpers (`encode`, `camera_info`, `worker`, `depth_color`, `image_grid`) live beside the
    impls; `rclpy`/`cv2` load only when a preset's `get_cls()` fires, so the config layer stays
    import-light.

### Removed / fail-loud (config surface)

- **Egress plugins validate their wanted streams at construction.** A route naming a camera/modality/env
  the sim doesn't provide raises `ValueError` at build time (`camera_consumer.py` stream validation), not
  mid-run. Per-step publish failures are isolated (logged, never propagated to the sim loop).
- **Cross-camera constraints validated** — e.g. MuJoCo-Warp render-flag agreement across the assembled
  camera dict (`config_types/sensor.py` `validate_camera_dict`), enforced at the config boundary.
- **ROS2 image routes validate format/modality** at construction (an rgb route needs an rgb format; a
  depth route takes a depth format for raw metric or an rgb format to colorize;
  `config_types/plugin.py` route validator).

### Latent / edge-case

- **`render()` is driven every step on all backends** (the run_sim/step loop calls it); headless it is a
  no-op that must tolerate a `None` viewer. Cameras render via `render_sensors`, independent of the
  interactive viewer.
- **Depth `+inf` no-hit sentinel** flows through `get_camera_data` untouched; the image-transform and
  colorize paths handle it (clip/scale), and the obs-term clip path skips image tensors so it isn't
  collapsed to a clip limit.

## Migration guide

**Users who declare no cameras see no change** — `sensor:` defaults empty and the whole path is inert.
Camera/egress authors:

**1 · Declare cameras as a dynamic-dict field**
```bash
# one head RGB camera on the robot, published over ROS2
python -m holosoma.run_sim --sensor.head_cam:g1-head plugin.pub:ros2-image

# stereo head + tile a live viz window; per-key leaf overrides
python -m holosoma.run_sim --sensor.head_cam_left:g1-stereo-left --sensor.head_cam_right:g1-stereo-right \
    --sensor.head_cam_left.width 224 plugin.viz:viz
```
The dict key is the sensor name (the `get_camera_data` key); the variant after `:` is the registry preset.
Egress-plugin routes reference cameras by that name.

**2 · Read frames in code**
```python
rgb   = sim.get_camera_data("head_cam", "rgb",   device="cpu")   # uint8  [N,H,W,3] R,G,B
depth = sim.get_camera_data("head_cam", "depth", device="cpu")   # float32 [N,H,W,1] meters, +inf no-hit
```

**3 · Visual-policy observations** — add `camera_rgb` / `camera_depth` obs terms
(`managers/observation/terms/cameras.py`), keyed to a sensor name, with an optional `ImageTransform`
(resize/scale/layout/flatten).

**4 · Write your own egress sink** — subclass `CameraConsumerPlugin`
(`simulator/plugins/camera_consumer.py`): declare `wanted_streams()`, implement `start` / `publish` /
`stop`; pair with a `PluginConfig` in `PLUGIN_REGISTRY`. Select it as `plugin.<key>:<preset>` like any
plugin. ROS2/cv2 sinks import their transport lazily.

**5 · New config fields (additive)** — `sensor: dict[str, CameraSensorConfig]` on
`RunSim`/`Experiment`/`Env` (threaded into `FullSimConfig.sensors`, plural), default `{}`; camera-egress
presets register in the existing `PLUGIN_REGISTRY` alongside `clock_publish`/`gantry_control`/`odometry`.
No existing config needs an edit.
