### PR TITLE
[retargeting] per-window z_floor, per-frame object points, headless data conversion

### DIFF
--- a/src/holosoma_retargeting/holosoma_retargeting/config_types/data_conversion.py
+++ b/src/holosoma_retargeting/holosoma_retargeting/config_types/data_conversion.py
@@ -38,7 +38,7 @@ _ROBOT_JOINT_NAMES_DEFAULT = {
         "right_wrist_roll_joint",
         "right_wrist_pitch_joint",
         "right_wrist_yaw_joint",
-    ]
+    ],
 }
 
 
@@ -79,6 +79,9 @@ class DataConversionConfig:
 
     once: bool = False
     """Run the motion once and exit."""
+
+    headless: bool = False
+    """Run without viewer (headless mode for batch processing)."""
 
     use_omniretarget_data: bool = False
     """Use OmniRetarget data format."""

--- a/src/holosoma_retargeting/holosoma_retargeting/config_types/retargeter.py
+++ b/src/holosoma_retargeting/holosoma_retargeting/config_types/retargeter.py
@@ -12,12 +12,14 @@ class FootLockConfig:
     enable: bool = False
     """Whether to enforce explicit frame-range based foot locking constraints."""
 
-    windows: dict[str, list[tuple[int, int]]] | None = None
+    windows: dict[str, list[tuple[int, int] | tuple[int, int, float]]] | None = None
     """Per-foot inclusive frame windows for locking.
-    Example: {"L_Toe": [(30, 60)], "R_Toe": [(10, 20), (80, 95)]}"""
+    Each window is (start, end) or (start, end, z_floor).
+    If z_floor is given per-window, it overrides the global z_floor for that window.
+    Example: {"L_Toe": [(30, 60, 0.15)], "R_Toe": [(10, 20), (80, 95, 0.30)]}"""
 
     z_floor: float = 0.0
-    """Floor height used by Z pinning constraints."""
+    """Default floor height used by Z pinning constraints (overridden by per-window z)."""
 
     tolerance: float = 5e-3
     """Tolerance for Z floor pinning constraints."""

--- a/src/holosoma_retargeting/holosoma_retargeting/data_conversion/convert_data_format_mj.py
+++ b/src/holosoma_retargeting/holosoma_retargeting/data_conversion/convert_data_format_mj.py
@@ -138,6 +138,7 @@ class MotionLoader:
         if self.motion_file.endswith(".npz"):
             data = np.load(self.motion_file)
             self.input_fps = round(1 / data.get("fps", 1 / self.input_fps))
+            self.input_dt = 1.0 / self.input_fps
             motion = torch.from_numpy(data["qpos"]).to(torch.float32)
         else:
             raise ValueError("Unsupported motion file format. Use .csv or .npz.")
@@ -425,16 +426,22 @@ def run_simulator(args_cli: DataConversionConfig):
     dof_index_list = [joint_names.index(dof_name) for dof_name in dof_name_list]
     print(dof_index_list)
 
-    # Prepare mujoco viewer
-    viewer = mjv.launch_passive(robot, robot_data, show_left_ui=False, show_right_ui=False)
-    viewer.opt.flags[mujoco.mjtVisFlag.mjVIS_PERTFORCE] = 0
-    viewer.opt.flags[mujoco.mjtVisFlag.mjVIS_CONTACTPOINT] = 0
-    viewer.opt.flags[mujoco.mjtVisFlag.mjVIS_TRANSPARENT] = 0
-    viewer.opt.flags[mujoco.mjtVisFlag.mjVIS_COM] = 0
+    # Headless implies once (no viewer means no way to exit the replay loop)
+    run_once = args_cli.once or args_cli.headless
 
-    viewer.cam.distance = 2.0
-    viewer.cam.elevation = -20.0
-    viewer.cam.azimuth = 45.0
+    # Prepare mujoco viewer
+    if not args_cli.headless:
+        viewer = mjv.launch_passive(robot, robot_data, show_left_ui=False, show_right_ui=False)
+        viewer.opt.flags[mujoco.mjtVisFlag.mjVIS_PERTFORCE] = 0
+        viewer.opt.flags[mujoco.mjtVisFlag.mjVIS_CONTACTPOINT] = 0
+        viewer.opt.flags[mujoco.mjtVisFlag.mjVIS_TRANSPARENT] = 0
+        viewer.opt.flags[mujoco.mjtVisFlag.mjVIS_COM] = 0
+
+        viewer.cam.distance = 2.0
+        viewer.cam.elevation = -20.0
+        viewer.cam.azimuth = 45.0
+    else:
+        viewer = None
 
     log: dict[str, Any]
     if has_dynamic_object:
@@ -531,10 +538,10 @@ def run_simulator(args_cli: DataConversionConfig):
             )
 
         mujoco.mj_forward(robot, robot_data)
-        viewer.sync()
-
-        end_time = time.perf_counter()
-        time.sleep(max(0, motion.output_dt - (end_time - start_time)))
+        if viewer is not None:
+            viewer.sync()
+            end_time = time.perf_counter()
+            time.sleep(max(0, motion.output_dt - (end_time - start_time)))
 
         if not file_saved:
             lin_vel_w, ang_vel_w = world_body_velocities(robot, robot_data)
@@ -595,9 +602,10 @@ def run_simulator(args_cli: DataConversionConfig):
             os.makedirs(output_res_folder, exist_ok=True)
             np.savez(args_cli.output_name, **log)
 
-        if args_cli.once and file_saved:
+        if run_once and file_saved:
             print("[INFO]: Motion replay completed, exiting...")
-            viewer.close()
+            if viewer is not None:
+                viewer.close()
             break
 
 

--- a/src/holosoma_retargeting/holosoma_retargeting/src/interaction_mesh_retargeter.py
+++ b/src/holosoma_retargeting/holosoma_retargeting/src/interaction_mesh_retargeter.py
@@ -132,7 +132,6 @@ class InteractionMeshRetargeter:
             self.has_dynamic_object = True
         else:
             self.has_dynamic_object = False
-
         self.nq = self.robot_model.nq
 
         self.q_a_init_idx = q_a_init_idx
@@ -177,6 +176,7 @@ class InteractionMeshRetargeter:
         """Initialize foot lock configuration and normalize window mappings."""
         self.foot_lock = foot_lock or FootLockConfig()
         self._foot_lock_windows: dict[str, tuple[tuple[int, int], ...]] = {"left": (), "right": ()}
+        self._foot_lock_z_floors: dict[str, tuple[float, ...]] = {"left": (), "right": ()}
         if self.foot_lock.windows is None:
             return
         for key, windows in self.foot_lock.windows.items():
@@ -190,14 +190,21 @@ class InteractionMeshRetargeter:
                 continue
 
             normalized_windows: list[tuple[int, int]] = []
+            z_floors: list[float] = []
             for window in windows:
-                if len(window) != 2:
+                if len(window) == 3:
+                    start, end, z = int(window[0]), int(window[1]), float(window[2])
+                elif len(window) == 2:
+                    start, end = int(window[0]), int(window[1])
+                    z = self.foot_lock.z_floor
+                else:
                     raise ValueError(f"Invalid foot lock window for {key}: {window}")
-                start, end = int(window[0]), int(window[1])
                 if end < start:
                     raise ValueError(f"Invalid foot lock window with end < start for {key}: {window}")
                 normalized_windows.append((start, end))
+                z_floors.append(z)
             self._foot_lock_windows[side] = tuple(normalized_windows)
+            self._foot_lock_z_floors[side] = tuple(z_floors)
 
     def _init_self_collision(self, self_collision: SelfCollisionConfig | None) -> None:
         """Initialize self-collision configuration and precompute geom pairs."""
@@ -384,8 +391,10 @@ class InteractionMeshRetargeter:
             human_joint_motions (np.ndarray): (num_frames, num_joints, 3) array.
             object_poses (np.ndarray): (num_frames, 7) array of demo object poses (quat, trans).
             object_poses_augmented (np.ndarray): (num_frames, 7) array of augmented object poses (quat, trans).
-            object_points_local_demo (np.ndarray): Demo object points in local frame (rest pose).
-            object_points_local (np.ndarray): Current object points in local frame (rest pose).
+            object_points_local_demo (np.ndarray | list[np.ndarray]): Demo object points in local frame.
+                Single array for static points, or list of num_frames arrays for per-frame points.
+            object_points_local (np.ndarray | list[np.ndarray]): Current object points in local frame.
+                Single array for static points, or list of num_frames arrays for per-frame points.
             foot_sticking_sequences (list): List of foot sticking sequences for each frame.
             q_a_init (np.ndarray, optional): Initial robot configuration.
             q_a_nominal (np.ndarray, optional): Nominal robot configuration.
@@ -394,6 +403,14 @@ class InteractionMeshRetargeter:
             tuple: (retargeted_motions, obj_pts_demo_list, obj_pts_list, tetrahedra)
         """
         num_frames = human_joint_motions.shape[0]
+        if isinstance(object_points_local_demo, list):
+            assert len(object_points_local_demo) == num_frames, (
+                f"object_points_local_demo length {len(object_points_local_demo)} != num_frames {num_frames}"
+            )
+        if isinstance(object_points_local, list):
+            assert len(object_points_local) == num_frames, (
+                f"object_points_local length {len(object_points_local)} != num_frames {num_frames}"
+            )
         if q_nominal_list is not None:
             q_locked_list = q_nominal_list
         else:
@@ -426,8 +443,16 @@ class InteractionMeshRetargeter:
                         object_quat_demo, object_trans_demo, human_mapped_joints
                     )
 
+                # Per-frame or static object points
+                obj_pts_demo_i = (
+                    object_points_local_demo[i]
+                    if isinstance(object_points_local_demo, list)
+                    else object_points_local_demo
+                )
+                obj_pts_i = object_points_local[i] if isinstance(object_points_local, list) else object_points_local
+
                 source_vertices, source_tetrahedra = create_interaction_mesh(
-                    np.vstack([human_mapped_joints_in_object, object_points_local_demo])
+                    np.vstack([human_mapped_joints_in_object, obj_pts_demo_i])
                 )
                 tetrahedra.append(source_tetrahedra)
 
@@ -435,10 +460,8 @@ class InteractionMeshRetargeter:
                     # Only for visualization
                     object_quat = object_poses_augmented[i, 3:]
                     object_trans = object_poses_augmented[i, :3]
-                    obj_pts_demo = transform_points_local_to_world(
-                        object_quat_demo, object_trans_demo, object_points_local_demo
-                    )
-                    obj_pts = transform_points_local_to_world(object_quat, object_trans, object_points_local)
+                    obj_pts_demo = transform_points_local_to_world(object_quat_demo, object_trans_demo, obj_pts_demo_i)
+                    obj_pts = transform_points_local_to_world(object_quat, object_trans, obj_pts_i)
 
                     obj_pts_demo_list.append(obj_pts_demo)
                     obj_pts_list.append(obj_pts)
@@ -466,7 +489,7 @@ class InteractionMeshRetargeter:
                     q_t_last=retargeted_motions[-1],
                     target_laplacian=target_laplacian,
                     adj_list=adj_list,
-                    obj_pts_local=object_points_local,
+                    obj_pts_local=obj_pts_i,
                     foot_sticking=foot_sticking_sequences[i],
                     w_nominal_tracking=w_nominal_tracking,
                     q_a_nominal=(q_nominal_list[i, self.q_a_indices] if q_nominal_list is not None else None),
@@ -661,10 +684,10 @@ class InteractionMeshRetargeter:
             # Foot lock windows: pin Z to floor within configured frame ranges
             if apply_foot_lock:
                 for key, J_WF in J_WF_dict.items():
-                    if not self._is_foot_locked_in_window(key, frame_idx):
+                    z_anchor = self._is_foot_locked_in_window(key, frame_idx)
+                    if z_anchor is None:
                         continue
 
-                    z_anchor = self.foot_lock.z_floor
                     z_delta = z_anchor - p_WF_dict[key][2]
                     Jz = J_WF[2, self.q_a_indices]
                     constraints += [
@@ -749,8 +772,8 @@ class InteractionMeshRetargeter:
 
         return q_star, cost
 
-    def _is_foot_locked_in_window(self, foot_link_key: str, frame_idx: int) -> bool:
-        """Check whether a foot link is locked by configured frame windows."""
+    def _is_foot_locked_in_window(self, foot_link_key: str, frame_idx: int) -> float | None:
+        """Return z_floor if foot is locked at this frame, else None."""
         key_lower = foot_link_key.lower()
         side = None
         if "left" in key_lower:
@@ -758,9 +781,12 @@ class InteractionMeshRetargeter:
         elif "right" in key_lower:
             side = "right"
         if side is None:
-            return False
+            return None
 
-        return any(start <= frame_idx <= end for start, end in self._foot_lock_windows.get(side, ()))
+        for i, (start, end) in enumerate(self._foot_lock_windows.get(side, ())):
+            if start <= frame_idx <= end:
+                return self._foot_lock_z_floors[side][i]
+        return None
 
     def _compute_self_collision_constraints(self, frame_idx: int):
         """Compute Jacobians and distances for self-collision body pairs.


### PR DESCRIPTION
feat: per-window z_floor, per-frame object points, headless data conversion

- Add per-window z_floor override to FootLockConfig (3-tuple variant)
- Support per-frame object points in interaction mesh retargeter
- Add headless mode to data conversion for batch processing