### PR TITLE
fix(isaacsim): disable DLSS AA so camera-sensor tests don't hang the docker-build gate

### DIFF
--- a/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
@@ -33,7 +33,7 @@ from isaaclab.sensors import (
     TiledCameraCfg,
     patterns,
 )
-from isaaclab.sim import PhysxCfg, SimulationCfg, SimulationContext
+from isaaclab.sim import PhysxCfg, RenderCfg, SimulationCfg, SimulationContext
 from isaaclab.sim.utils import bind_physics_material
 from isaaclab.terrains import TerrainGeneratorCfg, TerrainImporterCfg
 from isaaclab.terrains.utils import create_prim_from_mesh
@@ -112,6 +112,14 @@ class IsaacSim(BaseSimulator):
             dt=1.0 / self.simulator_config.sim.fps,
             render_interval=self.simulator_config.sim.render_interval_steps,
             device=self.sim_device,
+            # Disable the DLSS anti-aliasing pass (RenderCfg defaults to DLSS). DLSS is an AI
+            # upscaler meant for large viewports; on our small perception cameras it warns
+            # "Render resolution below minimal input resolution of 300" and, on some headless
+            # GPUs/runners (e.g. the A10G CI runner, vs. an Ada L40S dev box), its init blocks
+            # indefinitely in a native call — hanging every TiledCamera render. FXAA-off/no-AA
+            # is correct for these cameras regardless (nothing to upscale) and keeps camera
+            # rendering deterministic across GPUs.
+            render=RenderCfg(antialiasing_mode="Off"),
             physx=PhysxCfg(
                 bounce_threshold_velocity=self.simulator_config.sim.physx.bounce_threshold_velocity,
                 solver_type=self.simulator_config.sim.physx.solver_type,


### PR DESCRIPTION
## Problem

The `main` **Docker Build** run for #170 failed its blocking `Gate: isaacsim tests (sha image)` ([run 29478427690](https://github.com/amazon-far/holosoma/actions/runs/29478427690/job/87568597321)). All **11 isaacsim camera-sensor tests** (new in #170) hit `subprocess.TimeoutExpired` at 700s each and were SIGKILL'd (`returncode: -9`), ballooning the gate from ~12m (its historical runtime) to **2h41m** and blocking `:latest` promotion for every image.

The subprocesses were **not** crashing or failing an assertion — they boot IsaacSim fully and hang. The last line of captured output before every hang is:

```
[rtx.postprocessing.plugin] DLSS increasing input dimensions: Render resolution of (37, 37) is below minimal input resolution of 300.
```

(These tests never passed before: #170's own `pytest.yaml` isaacsim lane is `continue-on-error: true`, so the same 2h35m hang was masked as "success". This blocking docker-build gate is simply the first place they had to pass.)

## Root cause

IsaacLab's `RenderCfg` defaults `antialiasing_mode` to **DLSS**. DLSS is an AI upscaler intended for large viewports; on the tiny (64×64) perception cameras these tests use it is meaningless (hence the "below minimal input resolution of 300" warning), and on the **A10G CI runner** its init blocks indefinitely in a native call — hanging every `TiledCamera` render. The isaacsim **training** smoke tests in the same job passed because they run with `enable_cameras=False`: no RTX render products are created, so DLSS never engages.

## Fix

Set `SimulationCfg.render = RenderCfg(antialiasing_mode="Off")` (one construction site; covers the whole backend). No AA is correct for these cameras regardless — there is nothing to upscale — and it keeps camera rendering deterministic across GPUs.

## Verification

Reproduced and fixed on an L40S dev box (`hssim` env, IsaacSim 5.1 / IsaacLab 2.3):

- **Before:** default DLSS — camera geometry test passes on the L40S but emits the DLSS warning (the A10G is where it hangs).
- **After:** `antialiasing_mode="Off"` — `camera_geometry_assert.py --simulator isaacsim` still prints `env0: geometry OK` / `PASS`, writes `OK` to its result-file, **and the DLSS warning is gone** from the log.

The full validation across all 11 camera scenarios runs on the A10G in this PR's isaacsim gate.