### PR TITLE
bridge: publish base odometry from sim over the SDK (rt/odommodestate)

### DIFF
--- a/src/holosoma/holosoma/bridge/base/basic_sdk2py_bridge.py
+++ b/src/holosoma/holosoma/bridge/base/basic_sdk2py_bridge.py
@@ -314,6 +314,47 @@ class BasicSdk2Bridge(ABC):
 
         return quaternion, gyro, acceleration
 
+    def _get_base_odometry(self):
+        """Get base odometry: position, orientation, body-frame linear velocity, yaw rate.
+
+        Simulator-agnostic — reads the unified ``robot_root_states`` 13-vector
+        ``[pos(3), quat_xyzw(4), lin_vel_world(3), ang_vel_world(3)]``, the sim analog of the
+        robot's onboard sport/odom estimate. World-frame velocities are rotated into the base
+        (body) frame via the same ``quat_rotate_inverse`` helper the IMU gyro uses, matching the
+        real robot's ``SportModeState`` (``rt/odommodestate``) whose ``velocity`` twist is
+        body-frame.
+
+        Returns:
+            tuple: (position, quat_wxyz, lin_vel_body, yaw_speed)
+                - position: [x, y, z] world/odom frame (3 floats)
+                - quat_wxyz: [w, x, y, z] SDK order (4 floats)
+                - lin_vel_body: [vx, vy, vz] body frame (3 floats)
+                - yaw_speed: body-frame yaw rate [rad/s] (float)
+        """
+        env_id = getattr(self, "env_id", 0)
+        root = self.simulator.robot_root_states[env_id]  # [13]
+        quat_xyzw = root[3:7]  # [x, y, z, w]
+        lin_vel_world = root[7:10].unsqueeze(0)
+        ang_vel_world = root[10:13].unsqueeze(0)
+        lin_vel_body = quat_rotate_inverse(quat_xyzw.unsqueeze(0), lin_vel_world, w_last=True).squeeze(0)
+        ang_vel_body = quat_rotate_inverse(quat_xyzw.unsqueeze(0), ang_vel_world, w_last=True).squeeze(0)
+
+        position = root[0:3].detach().cpu().tolist()
+        # robot_root_states quaternion is [x, y, z, w]; the SDK OdomState wants [w, x, y, z].
+        q = quat_xyzw.detach().cpu().tolist()
+        quat_wxyz = [q[3], q[0], q[1], q[2]]
+        lin = lin_vel_body.detach().cpu().tolist()
+        yaw_speed = float(ang_vel_body[2].item())
+        return position, quat_wxyz, lin, yaw_speed
+
+    def publish_odom(self):
+        """Publish base odometry over the SDK. Default no-op.
+
+        SDKs with a base-state channel (Unitree's ``rt/odommodestate`` / ``SportModeState``)
+        override this. Only invoked by ``SimulatorBridge.step`` when ``BridgeConfig.publish_odom``
+        is set, so bridges without such a channel (e.g. booster) simply do nothing.
+        """
+
     def _get_sensor_data(self):
         """Get sensor data (Mujoco-only).
 

--- a/src/holosoma/holosoma/bridge/unitree/tests/_fake_unitree_interface.py
+++ b/src/holosoma/holosoma/bridge/unitree/tests/_fake_unitree_interface.py
@@ -7,8 +7,8 @@ CycloneDDS-free stand-in that the child (and parent test) can inject onto ``sys.
 round-trip, and hands back a deterministic incoming command.
 
 It mimics only the surface the bridge touches: ``RobotType``/``MessageType`` enums, ``UnitreeInterface``
-(``publish_low_state``/``read_incoming_command``/``publish_wireless_controller``), and the
-``LowState``/``MotorCommand``/``WirelessController`` data holders.
+(``publish_low_state``/``publish_odom_state``/``read_incoming_command``/``publish_wireless_controller``),
+and the ``LowState``/``MotorCommand``/``WirelessController``/``OdomState`` data holders.
 """
 
 from __future__ import annotations
@@ -70,6 +70,14 @@ class WirelessController:
         self.keys = 0
 
 
+class OdomState:
+    def __init__(self):
+        self.position = [0.0, 0.0, 0.0]
+        self.velocity = [0.0, 0.0, 0.0]
+        self.yaw_speed = 0.0
+        self.quat = [0.0, 0.0, 0.0, 0.0]
+
+
 # Where publishes are recorded and the canned incoming command is read (set by the test via env var
 # so both the spawned child and the parent agree on the path).
 _RECORD_PATH_ENV = "FAKE_UNITREE_RECORD"
@@ -106,6 +114,17 @@ class UnitreeInterface:
                 "omega": list(low_state.imu.omega),
                 "accel": list(low_state.imu.accel),
                 "tick": low_state.tick,
+            },
+        )
+
+    def publish_odom_state(self, odom_state: OdomState):
+        self._record(
+            "publish_odom_state",
+            {
+                "position": list(odom_state.position),
+                "velocity": list(odom_state.velocity),
+                "yaw_speed": odom_state.yaw_speed,
+                "quat": list(odom_state.quat),
             },
         )
 

--- a/src/holosoma/holosoma/bridge/unitree/tests/test_unitree_mp_bridge.py
+++ b/src/holosoma/holosoma/bridge/unitree/tests/test_unitree_mp_bridge.py
@@ -76,8 +76,13 @@ class _FakeSim:
         self.dof_vel = torch.zeros(1, num_motor)
         self.dof_acc = torch.zeros(1, num_motor)
         # root state: pos(3) quat(3:7 = x,y,z,w = identity) lin(7:10) ang(10:13)
+        # Distinct, non-trivial pos/vel so publish_odom's world->body rotation and xyzw->wxyz
+        # conversion are actually exercised (identity quat => body == world, so values pass through).
         root = torch.zeros(1, 13)
+        root[0, 0:3] = torch.tensor([1.0, 2.0, 3.0])  # position
         root[0, 6] = 1.0  # w = 1 (identity quat)
+        root[0, 7:10] = torch.tensor([0.5, 0.0, 0.0])  # world linear velocity
+        root[0, 10:13] = torch.tensor([0.0, 0.0, 0.3])  # world angular velocity (yaw rate)
         self.robot_root_states = root
         self.base_linear_acc = torch.zeros(1, 3)
 
@@ -147,6 +152,9 @@ def test_mp_bridge_end_to_end(fake_binding_on_path, monkeypatch):
         # publish_low_state: parent computes fields from sim state, child records them.
         bridge.publish_low_state()
 
+        # publish_odom: parent reads robot_root_states, rotates world->body, ships to child.
+        bridge.publish_odom()
+
         # read incoming command from the child (canned deterministic values).
         bridge.low_cmd_handler()
         assert list(bridge.low_cmd.tau_ff) == [1.0] * num_motor
@@ -179,6 +187,14 @@ def test_mp_bridge_end_to_end(fake_binding_on_path, monkeypatch):
     np.testing.assert_allclose(pub["payload"]["q"], [0.0, 0.1], atol=1e-6)
     assert pub["payload"]["quat"] == [1.0, 0.0, 0.0, 0.0]
     assert pub["payload"]["tick"] == int(1.5 * 1e3)
+
+    # publish_odom: position passes through; identity quat -> body velocity == world velocity;
+    # quat converted x,y,z,w -> w,x,y,z = identity; yaw_speed is the body-frame z angular rate.
+    odom = next(r for r in records if r["kind"] == "publish_odom_state")
+    np.testing.assert_allclose(odom["payload"]["position"], [1.0, 2.0, 3.0], atol=1e-6)
+    np.testing.assert_allclose(odom["payload"]["velocity"], [0.5, 0.0, 0.0], atol=1e-6)
+    np.testing.assert_allclose(odom["payload"]["quat"], [1.0, 0.0, 0.0, 0.0], atol=1e-6)
+    np.testing.assert_allclose(odom["payload"]["yaw_speed"], 0.3, atol=1e-6)
 
 
 def test_mp_bridge_close_is_idempotent(fake_binding_on_path, monkeypatch):

--- a/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge.py
+++ b/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge.py
@@ -23,6 +23,7 @@ class UnitreeSdk2Bridge(BasicSdk2Bridge):
             LowState,
             MessageType,
             MotorCommand,
+            OdomState,
             RobotType,
             UnitreeInterface,
             WirelessController,
@@ -47,6 +48,7 @@ class UnitreeSdk2Bridge(BasicSdk2Bridge):
         self.low_state = LowState(self.num_motor)
         self.low_cmd = MotorCommand(self.num_motor)
         self.wireless_controller = WirelessController()
+        self.odom_state = OdomState()
 
     def low_cmd_handler(self, msg=None):
         """Handle Unitree low-level command messages."""
@@ -93,6 +95,20 @@ class UnitreeSdk2Bridge(BasicSdk2Bridge):
         # Publish using C++ interface
         if self.joystick is not None:
             self.interface.publish_wireless_controller(self.wireless_controller)
+
+    def publish_odom(self):
+        """Publish base odometry as SportModeState on rt/odommodestate.
+
+        Makes the simulator publish the same base-state channel the real robot's onboard
+        sport/loco mode does, so a downstream consumer (e.g. the telemetry node's
+        read_odom_state -> /telemetry/odom) is identical in sim and on hardware.
+        """
+        position, quat_wxyz, lin_vel_body, yaw_speed = self._get_base_odometry()
+        self.odom_state.position = position
+        self.odom_state.velocity = lin_vel_body
+        self.odom_state.yaw_speed = yaw_speed
+        self.odom_state.quat = quat_wxyz
+        self.interface.publish_odom_state(self.odom_state)
 
     def compute_torques(self):
         """Compute torques using Unitree's unified command structure."""

--- a/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge_mp.py
+++ b/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge_mp.py
@@ -12,6 +12,7 @@ half MUST stay in the parent. Only the four DDS operations move to the child:
 
     * constructing ``UnitreeInterface`` (opens CycloneDDS),
     * ``publish_low_state``       (parent computes the fields from sim state, ships plain lists),
+    * ``publish_odom_state``      (parent computes base odom from sim state, ships plain lists),
     * ``read_incoming_command``   (child polls DDS, ships a picklable command back),
     * ``publish_wireless_controller`` (parent reads the joystick, ships the axes/keys).
 
@@ -86,7 +87,14 @@ def _worker(
     # Construct the binding (opens CycloneDDS) BEFORE signalling readiness, so a DDS init failure is
     # reported to the parent as an error instead of leaving it to block on the first RPC forever.
     try:
-        from unitree_interface import LowState, MessageType, RobotType, UnitreeInterface, WirelessController
+        from unitree_interface import (
+            LowState,
+            MessageType,
+            OdomState,
+            RobotType,
+            UnitreeInterface,
+            WirelessController,
+        )
 
         interface = UnitreeInterface(
             interface_name,
@@ -94,10 +102,12 @@ def _worker(
             getattr(MessageType, message_type_name),
         )
         # The child owns only the C++ objects the DDS calls need: a reusable LowState the parent fills
-        # each publish, and a WirelessController for joystick publishing. The incoming command lives in
-        # the parent (as a picklable LowCommand), so no MotorCommand is held here.
+        # each publish, a WirelessController for joystick publishing, and an OdomState for base
+        # odometry publishing. The incoming command lives in the parent (as a picklable LowCommand),
+        # so no MotorCommand is held here.
         low_state = LowState(num_motor)
         wireless_controller = WirelessController()
+        odom_state = OdomState()
     except Exception as exc:
         res_q.put(("err", exc))
         os._exit(0)
@@ -122,6 +132,14 @@ def _worker(
                     low_state.imu.accel = accel
                     low_state.tick = tick
                     interface.publish_low_state(low_state)  # CRC calculated in C++
+                    res_q.put(("ok", None))
+                elif method == "publish_odom_state":
+                    position, velocity, yaw_speed, quat = args
+                    odom_state.position = position
+                    odom_state.velocity = velocity
+                    odom_state.yaw_speed = yaw_speed
+                    odom_state.quat = quat
+                    interface.publish_odom_state(odom_state)
                     res_q.put(("ok", None))
                 elif method == "read_incoming_command":
                     cmd = interface.read_incoming_command()
@@ -262,6 +280,16 @@ class UnitreeMpSdk2Bridge(UnitreeSdk2Bridge):
             acceleration.detach().cpu().numpy().tolist(),
             int(self.sim_time * 1e3),
         )
+
+    def publish_odom(self):
+        """Compute base odom from sim state (parent), ship it to the child to publish.
+
+        Mirrors publish_low_state: the inherited _get_base_odometry reads robot_root_states and
+        rotates world->body velocity in the parent (binding-free), then plain float lists cross to
+        the child, which owns the C++ OdomState and writes SportModeState on rt/odommodestate.
+        """
+        position, quat_wxyz, lin_vel_body, yaw_speed = self._get_base_odometry()
+        self._call("publish_odom_state", position, lin_vel_body, yaw_speed, quat_wxyz)
 
     def publish_wireless_controller(self):
         """Populate the parent stand-in from the joystick (base class), ship it to the child."""

--- a/src/holosoma/holosoma/config_types/simulator.py
+++ b/src/holosoma/holosoma/config_types/simulator.py
@@ -242,6 +242,13 @@ class BridgeConfig:
     use_ros: bool = False
     """Whether to use ROS for communication."""
 
+    publish_odom: bool = False
+    """Publish base odometry over the SDK (SportModeState on rt/odommodestate) each step.
+
+    Off by default. Turn on when the sim should feed base odometry through the Unitree SDK bridge
+    (so a downstream telemetry read_odom_state -> /telemetry/odom is identical to hardware). Only
+    SDKs with a base-state channel act on it; others (booster) treat publish_odom as a no-op."""
+
 
 @dataclass(frozen=True)
 class SimulatorInitConfig:

--- a/src/holosoma/holosoma/simulator/shared/simulator_bridge.py
+++ b/src/holosoma/holosoma/simulator/shared/simulator_bridge.py
@@ -134,6 +134,11 @@ class SimulatorBridge:
         # Publish robot state to SDK
         self.robot_bridge.publish_low_state()
 
+        # Publish base odometry over the SDK (SportModeState on rt/odommodestate) when configured.
+        # Off by default.
+        if self.bridge_config.publish_odom:
+            self.robot_bridge.publish_odom()
+
         # Handle joystick input if available
         if hasattr(self.robot_bridge, "joystick") and self.robot_bridge.joystick:
             self.robot_bridge.publish_wireless_controller()


### PR DESCRIPTION
Publish base odometry from the simulator over the SDK, so the sim emits the same base-state channel the real robot's onboard sport/loco mode does (`SportModeState` on `rt/odommodestate`). A downstream telemetry `read_odom_state -> /telemetry/odom` is then identical in sim and on hardware.

## What
- `BasicSdk2Bridge._get_base_odometry` — simulator-agnostic read of the unified `robot_root_states` `[pos, quat_xyzw, lin_vel_world, ang_vel_world]`, rotating world→body velocity via `quat_rotate_inverse` and converting quat xyzw→wxyz. Default `publish_odom()` is a no-op, so SDKs without a base-state channel (booster) do nothing.
- `UnitreeSdk2Bridge.publish_odom` fills an `OdomState` and calls `interface.publish_odom_state`.
- `UnitreeMpSdk2Bridge.publish_odom` computes fields in the binding-free parent and ships plain floats to the DDS child via a new `publish_odom_state` RPC (mirrors `publish_low_state`, keeps CycloneDDS out of the rclpy process).
- `SimulatorBridge.step` calls `publish_odom` only when `BridgeConfig.publish_odom` is set (default `False`).

## Tests
`test_unitree_mp_bridge.py` round-trips odom through the spawned child: position pass-through, world→body velocity, xyzw→wxyz quat, yaw_speed. Runs under `no_sim`.

