### PR TITLE
Bump far-unitree-sdk pin to 0.1.6 (adds OdomState)

### DIFF
--- a/src/holosoma/setup.py
+++ b/src/holosoma/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 # Robot SDKs are published to PyPI (FAR forks). The import names are unchanged
 # (`unitree_interface`, `booster_robotics_sdk`) — only the distribution names
 # differ from the historical GitHub-release wheels.
-UNITREE_VERSION = "0.1.5"
+UNITREE_VERSION = "0.1.6"
 BOOSTER_VERSION = "0.1.1"
 
 setup(

--- a/src/holosoma_inference/setup.py
+++ b/src/holosoma_inference/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 # (`unitree_interface`, `booster_robotics_sdk`) — only the distribution names
 # differ from the historical GitHub-release wheels. pip resolves the correct
 # wheel for the running interpreter/platform from the PyPI index.
-UNITREE_VERSION = "0.1.5"
+UNITREE_VERSION = "0.1.6"
 BOOSTER_VERSION = "0.1.1"
 
 unitree_extras = [f"far-unitree-sdk=={UNITREE_VERSION}"]


### PR DESCRIPTION
The [unitree] extras in both holosoma/setup.py and holosoma_inference/setup.py pinned far-unitree-sdk==0.1.5, which predates the base-odometry API. The bridge (holosoma.bridge.unitree.unitree_sdk2py_bridge) imports OdomState for the rt/odommodestate base-odometry publish/read added in #173, so 0.1.5 fails at import: "cannot import name 'OdomState' from 'unitree_interface'". Bump both pins to 0.1.6, the first non-alpha release carrying OdomState.