### PR TITLE
Let the SDK bridge control a named DOF subset

### DIFF
--- a/src/holosoma/holosoma/bridge/base/basic_sdk2py_bridge.py
+++ b/src/holosoma/holosoma/bridge/base/basic_sdk2py_bridge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from abc import ABC, abstractmethod
 
@@ -23,10 +25,25 @@ class BasicSdk2Bridge(ABC):
         # Store simulator reference for generic access
         self.simulator = simulator
 
-        # Uses simulator actuator count (truly simulator-agnostic)
-        self.num_motor = simulator.num_dof  # Generic actuator count
+        # The DOFs this bridge controls (subset of the simulator's DOFs, in bridge order). Default
+        # (empty controlled/excluded config) is every DOF, matching the historical 1:1 SDK-motor <->
+        # sim-DOF behavior. A robot with more sim DOFs than the SDK models (so a co-controller owns
+        # the rest) narrows it via RobotBridgeConfig.controlled_dof_names / excluded_dof_names.
+        self.dof_indices = self._resolve_dof_indices(simulator, robot_config)
+        # None when the subset is every DOF in natural order -> simulator applies the fast full-width
+        # ctrl write; a list -> the simulator scatters into ONLY these DOFs' ctrl slots.
+        self._apply_indices: list[int] | None = (
+            None if self.dof_indices == list(range(simulator.num_dof)) else self.dof_indices
+        )
+
+        # SDK motor count is the size of the controlled subset (was: simulator.num_dof).
+        self.num_motor = len(self.dof_indices)
         self.torques = np.zeros(self.num_motor)  # Avoids config/model mismatches
-        self.torque_limit = np.array(self.robot.dof_effort_limit_list)
+        self.torque_limit = np.array([self.robot.dof_effort_limit_list[i] for i in self.dof_indices])
+
+        # robot_type presented to the SDK (its type gate + motor-vector sizing). Falls back to the
+        # asset's own robot_type, so this changes nothing unless bridge.sdk_robot_type is set.
+        self.sdk_robot_type = robot_config.bridge.sdk_robot_type or robot_config.asset.robot_type
 
         # joystick
         self.key_map = {
@@ -51,6 +68,45 @@ class BasicSdk2Bridge(ABC):
 
         # Initialize SDK-specific components
         self._init_sdk_components()
+
+    def _resolve_dof_indices(self, simulator, robot_config: RobotConfig) -> list[int]:
+        """Resolve which simulator DOFs this bridge controls, as indices into ``simulator.dof_names``.
+
+        ``controlled_dof_names`` (allow-list, in order) wins over ``excluded_dof_names``
+        (control-everything-else). Both empty -> every DOF in natural order (the default, so an
+        SDK that owns the whole robot is unchanged). Names are validated against the loaded robot.
+        """
+        bridge_cfg = robot_config.bridge
+
+        # Default (no subset configured): control every DOF. Uses only num_dof, so it needs no
+        # dof_names — keeps the historical whole-robot behavior for any simulator.
+        if not bridge_cfg.controlled_dof_names and not bridge_cfg.excluded_dof_names:
+            return list(range(simulator.num_dof))
+
+        dof_names = list(simulator.dof_names)
+        name_to_idx = {n: i for i, n in enumerate(dof_names)}
+
+        if bridge_cfg.controlled_dof_names:
+            indices, missing = [], []
+            for name in bridge_cfg.controlled_dof_names:
+                idx = name_to_idx.get(name)
+                (indices.append(idx) if idx is not None else missing.append(name))
+            if missing:
+                raise ValueError(
+                    f"bridge.controlled_dof_names {missing} not in the loaded robot (dof_names={dof_names})."
+                )
+        else:  # excluded_dof_names (controlled empty, but not both — the both-empty case returned above)
+            excluded = set(bridge_cfg.excluded_dof_names)
+            unknown = excluded - set(name_to_idx)
+            if unknown:
+                raise ValueError(
+                    f"bridge.excluded_dof_names {sorted(unknown)} not in the loaded robot (dof_names={dof_names})."
+                )
+            indices = [i for i, n in enumerate(dof_names) if n not in excluded]
+
+        if not indices:
+            raise ValueError("bridge DOF subset resolved to empty; nothing to control.")
+        return indices
 
     @abstractmethod
     def _init_sdk_components(self):
@@ -89,9 +145,10 @@ class BasicSdk2Bridge(ABC):
         numpy.ndarray
             Computed torques with limits applied
         """
-        # Get actual state from simulator
-        q_actual = self.simulator.dof_pos[0]
-        dq_actual = self.simulator.dof_vel[0]
+        # Get actual state from simulator, narrowed to the DOFs this bridge controls (so the SDK's
+        # num_motor-length kp/q_target broadcast against a matching-length state vector).
+        q_actual = self.simulator.dof_pos[0][self.dof_indices]
+        dq_actual = self.simulator.dof_vel[0][self.dof_indices]
 
         # Convert inputs to torch tensors if needed
         device = q_actual.device
@@ -256,14 +313,15 @@ class BasicSdk2Bridge(ABC):
         Returns:
             tuple: (positions, velocities, accelerations) as numpy arrays
         """
-        # Use generic simulator interface - works for all simulators
-        positions = self.simulator.dof_pos[0].detach().cpu().numpy()
-        velocities = self.simulator.dof_vel[0].detach().cpu().numpy()
+        # Use generic simulator interface - works for all simulators. Narrowed to the controlled
+        # DOFs so publish_low_state reports exactly the SDK's num_motor joints.
+        positions = self.simulator.dof_pos[0][self.dof_indices].detach().cpu().numpy()
+        velocities = self.simulator.dof_vel[0][self.dof_indices].detach().cpu().numpy()
 
         if not hasattr(self.simulator, "dof_acc"):
             raise RuntimeError("DOF acceleration not available (is the bridge enabled?)")
 
-        accelerations = self.simulator.dof_acc[0].detach().cpu().numpy()
+        accelerations = self.simulator.dof_acc[0][self.dof_indices].detach().cpu().numpy()
 
         return positions, velocities, accelerations
 
@@ -281,7 +339,11 @@ class BasicSdk2Bridge(ABC):
         # Bridge operates on env 0 by default
         env_id = getattr(self, "env_id", 0)
         forces = self.simulator.get_dof_forces(env_id)
-        return forces[: self.num_motor].detach().cpu().numpy()
+        # Force sensors may be disabled (enable_dof_force_sensors=False) -> empty tensor; a
+        # fancy-index would raise, so pass the empty tensor through as the full-width path does.
+        if forces.numel() == 0:
+            return forces.detach().cpu().numpy()
+        return forces[self.dof_indices].detach().cpu().numpy()
 
     def _get_base_imu_data(self):
         """Get base IMU data: quaternion, angular velocity, linear acceleration (simulator-agnostic).
@@ -347,7 +409,7 @@ class BasicSdk2Bridge(ABC):
         yaw_speed = float(ang_vel_body[2].item())
         return position, quat_wxyz, lin, yaw_speed
 
-    def publish_odom(self):
+    def publish_odom(self):  # noqa: B027  intentional concrete no-op default; SDKs with a base-state channel override it
         """Publish base odometry over the SDK. Default no-op.
 
         SDKs with a base-state channel (Unitree's ``rt/odommodestate`` / ``SportModeState``)

--- a/src/holosoma/holosoma/bridge/base/tests/test_subset_dof_bridge.py
+++ b/src/holosoma/holosoma/bridge/base/tests/test_subset_dof_bridge.py
@@ -1,0 +1,140 @@
+"""Tests for the DOF-subset control surface of ``BasicSdk2Bridge`` — pure, no simulator, no DDS.
+
+The base bridge historically assumed it owned every simulator DOF (``num_motor = simulator.num_dof``,
+full-width torque writes). These tests cover the subset support that lets an SDK drive only a NAMED
+subset of DOFs (``RobotBridgeConfig.controlled_dof_names`` / ``excluded_dof_names``), presenting a
+possibly-different ``robot_type`` to the SDK (``sdk_robot_type``), so a co-controller can own the rest.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from holosoma.bridge.base.basic_sdk2py_bridge import BasicSdk2Bridge
+from holosoma.config_types.robot import RobotBridgeConfig
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+
+class _StubBridge(BasicSdk2Bridge):
+    """Minimal concrete bridge: no SDK, so the abstract hooks are trivial no-ops."""
+
+    def _init_sdk_components(self):
+        pass
+
+    def low_cmd_handler(self, msg=None):
+        pass
+
+    def publish_low_state(self):
+        pass
+
+    def compute_torques(self):
+        pass
+
+
+class _FakeSim:
+    """Exposes exactly the DOF surface the base bridge reads at construction / PD time."""
+
+    def __init__(self, dof_names, device="cpu"):
+        self.dof_names = list(dof_names)
+        self.num_dof = len(self.dof_names)
+        self.device = device
+        n = self.num_dof
+        self.dof_pos = torch.arange(n, dtype=torch.float32).reshape(1, n) * 0.1
+        self.dof_vel = torch.zeros(1, n)
+        self.dof_acc = torch.zeros(1, n)
+
+
+def _robot_config(dof_names, *, controlled=(), excluded=(), sdk_robot_type=None, robot_type="my_robot"):
+    return SimpleNamespace(
+        dof_effort_limit_list=[float(10 * (i + 1)) for i in range(len(dof_names))],
+        asset=SimpleNamespace(robot_type=robot_type),
+        bridge=RobotBridgeConfig(
+            controlled_dof_names=controlled,
+            excluded_dof_names=excluded,
+            sdk_robot_type=sdk_robot_type,
+        ),
+    )
+
+
+_DOFS = ["a", "b", "c", "d", "e", "f"]
+
+
+def _build(**cfg_kwargs):
+    sim = _FakeSim(_DOFS)
+    robot = _robot_config(_DOFS, **cfg_kwargs)
+    return _StubBridge(sim, robot, SimpleNamespace(interface="lo")), sim
+
+
+def test_default_controls_all_dofs_full_width_path():
+    bridge, sim = _build()
+    assert bridge.num_motor == 6
+    assert bridge.dof_indices == list(range(6))
+    # Every DOF in natural order -> None so the simulator takes the fast full-width write.
+    assert bridge._apply_indices is None
+    np.testing.assert_array_equal(bridge.torque_limit, [10, 20, 30, 40, 50, 60])
+
+
+def test_excluded_dofs_narrows_to_complement():
+    bridge, sim = _build(excluded=("c", "e"))
+    assert bridge.num_motor == 4
+    assert bridge.dof_indices == [0, 1, 3, 5]  # a, b, d, f
+    assert bridge._apply_indices == [0, 1, 3, 5]
+    # torque_limit is subset + reordered to the controlled DOFs.
+    np.testing.assert_array_equal(bridge.torque_limit, [10, 20, 40, 60])
+    assert bridge.torques.shape == (4,)
+
+
+def test_controlled_dofs_wins_over_excluded_and_preserves_order():
+    # controlled_dof_names present -> excluded is ignored, order follows controlled.
+    bridge, _ = _build(controlled=("f", "a", "c"), excluded=("a",))
+    assert bridge.dof_indices == [5, 0, 2]
+    assert bridge.num_motor == 3
+    np.testing.assert_array_equal(bridge.torque_limit, [60, 10, 30])
+
+
+def test_unknown_controlled_name_raises():
+    with pytest.raises(ValueError, match="controlled_dof_names"):
+        _build(controlled=("a", "nope"))
+
+
+def test_unknown_excluded_name_raises():
+    with pytest.raises(ValueError, match="excluded_dof_names"):
+        _build(excluded=("ghost",))
+
+
+def test_excluding_every_dof_raises():
+    with pytest.raises(ValueError, match="empty"):
+        _build(excluded=tuple(_DOFS))
+
+
+def test_sdk_robot_type_overrides_asset_type():
+    bridge, _ = _build(sdk_robot_type="g1_29dof", robot_type="my_robot")
+    assert bridge.sdk_robot_type == "g1_29dof"
+
+
+def test_sdk_robot_type_defaults_to_asset_type():
+    bridge, _ = _build(robot_type="my_robot")
+    assert bridge.sdk_robot_type == "my_robot"
+
+
+def test_compute_pd_torques_broadcasts_against_the_subset():
+    bridge, sim = _build(excluded=("c", "e"))  # controls a,b,d,f (idx 0,1,3,5)
+    n = bridge.num_motor
+    # SDK command vectors are num_motor-length; PD must line up with the subset state, not all 6 DOFs.
+    tau_ff = np.ones(n)
+    kp = np.full(n, 2.0)
+    kd = np.zeros(n)
+    q_target = np.full(n, 1.0)
+    dq_target = np.zeros(n)
+
+    torques = bridge._compute_pd_torques(tau_ff, kp, kd, q_target, dq_target)
+
+    assert torques.shape == (n,)
+    q_actual = sim.dof_pos[0][bridge.dof_indices].numpy()
+    expected = np.clip(1.0 + 2.0 * (1.0 - q_actual), -bridge.torque_limit, bridge.torque_limit)
+    np.testing.assert_allclose(torques, expected, rtol=1e-6)

--- a/src/holosoma/holosoma/bridge/booster/booster_sdk2py_bridge.py
+++ b/src/holosoma/holosoma/bridge/booster/booster_sdk2py_bridge.py
@@ -33,7 +33,7 @@ class BoosterSdk2Bridge(BasicSdk2Bridge):
 
         logger.info(f"Booster SDK factory initialized with domain_id={domain_id}")
 
-        robot_type = self.robot.asset.robot_type
+        robot_type = self.sdk_robot_type
         if robot_type in self.SUPPORTED_ROBOT_TYPES:
             self.LowCmd = LowCmd
             self.LowState = LowState

--- a/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge.py
+++ b/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge.py
@@ -29,7 +29,7 @@ class UnitreeSdk2Bridge(BasicSdk2Bridge):
             WirelessController,
         )
 
-        robot_type = self.robot.asset.robot_type
+        robot_type = self.sdk_robot_type
 
         # Validate robot type first
         if robot_type not in self.SUPPORTED_ROBOT_TYPES:

--- a/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge_mp.py
+++ b/src/holosoma/holosoma/bridge/unitree/unitree_sdk2py_bridge_mp.py
@@ -190,7 +190,7 @@ class UnitreeMpSdk2Bridge(UnitreeSdk2Bridge):
 
     def _init_sdk_components(self):
         """Spawn the DDS child; keep only picklable, binding-free stand-ins in the parent."""
-        robot_type = self.robot.asset.robot_type
+        robot_type = self.sdk_robot_type
         if robot_type not in self.SUPPORTED_ROBOT_TYPES:
             raise ValueError(f"Invalid robot type '{robot_type}'. Unitree SDK supports: {self.SUPPORTED_ROBOT_TYPES}")
 

--- a/src/holosoma/holosoma/config_types/robot.py
+++ b/src/holosoma/holosoma/config_types/robot.py
@@ -26,6 +26,29 @@ class RobotBridgeConfig:
     motor_type: str = "serial"
     """Motor communication type ('serial', etc.)."""
 
+    controlled_dof_names: tuple[str, ...] = ()
+    """Explicit allow-list of DOF names this SDK bridge controls, in order. When non-empty this
+    WINS over ``excluded_dof_names``. Empty (default) = control every DOF.
+
+    Use when the robot has more simulated DOFs than the SDK models (so the bridge must drive only
+    a named subset and leave the rest to a co-controller); leave empty when the SDK owns the whole
+    robot."""
+
+    excluded_dof_names: tuple[str, ...] = ()
+    """DOF names to LEAVE OUT of this bridge (control everything else). Used only when
+    ``controlled_dof_names`` is empty. Empty (default) = control every DOF.
+
+    The complement of ``controlled_dof_names``: name the few DOFs a co-controller owns instead of
+    the many the SDK drives."""
+
+    sdk_robot_type: str | None = None
+    """robot_type presented to the SDK bridge (its supported-type gate + motor-vector sizing).
+    ``None`` (default) = use ``asset.robot_type`` unchanged.
+
+    Set this when the asset's ``robot_type`` is not itself an SDK motor model — e.g. a robot whose
+    asset id differs from the SDK's fixed-size motor model it should be driven as. The controlled
+    DOF subset must then match that model's motor count."""
+
 
 @dataclass(frozen=True)
 class RobotInitState:

--- a/src/holosoma/holosoma/simulator/base_simulator/base_simulator.py
+++ b/src/holosoma/holosoma/simulator/base_simulator/base_simulator.py
@@ -432,12 +432,17 @@ class BaseSimulator:
 
     # ----- Control Application Methods -----
 
-    def apply_torques_at_dof(self, torques):
+    def apply_torques_at_dof(self, torques, dof_indices=None):
         """
         Applies the specified torques to the robot's degrees of freedom (DOF).
 
         Args:
-            torques (tensor): Tensor containing torques to apply.
+            torques (tensor): Tensor containing torques to apply. When ``dof_indices`` is None it is
+                the full per-DOF vector; otherwise it is aligned with ``dof_indices``.
+            dof_indices (list[int] | None): When None (default), write every DOF (the historical
+                full-width path). When a list, scatter ``torques`` into ONLY those DOFs' actuators,
+                leaving the other slots as their owner wrote them this substep (so a co-controller
+                driving the complementary DOFs is not clobbered).
         """
         raise NotImplementedError("The 'apply_torques_at_dof' method must be implemented in subclasses.")
 

--- a/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
+++ b/src/holosoma/holosoma/simulator/isaacgym/isaacgym.py
@@ -874,9 +874,28 @@ class IsaacGym(BaseSimulator):
         # ) // self.num_envs
         # return num_actors
 
-    def apply_torques_at_dof(self, torques):
-        """Apply torques with detailed logging to match MuJoCo implementation."""
-        self.gym.set_dof_actuation_force_tensor(self.sim, gymtorch.unwrap_tensor(torques))
+    def apply_torques_at_dof(self, torques, dof_indices=None):
+        """Apply torques with detailed logging to match MuJoCo implementation.
+
+        ``set_dof_actuation_force_tensor`` is a full replacement of the actuation-force buffer, so a
+        subset write must scatter into a persistent full-width buffer (leaving the other DOFs as
+        their owner last wrote them) and then set the whole tensor. The full path (``dof_indices``
+        None) passes the caller's tensor straight through, unchanged from before.
+        """
+        if dof_indices is None:
+            self.gym.set_dof_actuation_force_tensor(self.sim, gymtorch.unwrap_tensor(torques))
+            return
+
+        # Persistent [num_envs, num_dof] buffer: unowned slots keep their previous value across
+        # substeps (mirrors MuJoCo's persistent ctrl), so a co-controller on the other DOFs composes.
+        if getattr(self, "_dof_actuation_forces", None) is None:
+            self._dof_actuation_forces = torch.zeros(
+                self.num_envs, self.num_dof, dtype=torch.float32, device=self.device
+            )
+        idx_t = torch.as_tensor(dof_indices, device=self.device, dtype=torch.long)
+        # torques is aligned with dof_indices (1-D for the single-robot SDK bridge); broadcast over envs.
+        self._dof_actuation_forces[:, idx_t] = torques.reshape(-1).to(self._dof_actuation_forces.dtype)
+        self.gym.set_dof_actuation_force_tensor(self.sim, gymtorch.unwrap_tensor(self._dof_actuation_forces))
 
     def apply_rigid_body_force_at_pos_tensor(self, force_tensor, pos_tensor):
         self.gym.apply_rigid_body_force_at_pos_tensors(

--- a/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
@@ -1039,8 +1039,14 @@ class IsaacSim(BaseSimulator):
         if len(env_ids) > 0:
             self.contact_forces_history[env_ids, :, :, :] = 0.0
 
-    def apply_torques_at_dof(self, torques):
-        self._robot.set_joint_effort_target(torques, joint_ids=self.dof_ids)
+    def apply_torques_at_dof(self, torques, dof_indices=None):
+        # set_joint_effort_target writes only the given joint_ids without clobbering the rest, so a
+        # subset (dof_indices) composes natively with a co-controller on the other DOFs.
+        if dof_indices is None:
+            joint_ids = self.dof_ids
+        else:
+            joint_ids = [self.dof_ids[i] for i in dof_indices]
+        self._robot.set_joint_effort_target(torques, joint_ids=joint_ids)
 
     def draw_debug_viz(self):
         if self.virtual_gantry:

--- a/src/holosoma/holosoma/simulator/mujoco/mujoco.py
+++ b/src/holosoma/holosoma/simulator/mujoco/mujoco.py
@@ -1038,13 +1038,18 @@ class MuJoCo(BaseSimulator):
         if len(env_ids) > 0:
             self.contact_forces_history[env_ids, :, :, :] = 0.0
 
-    def apply_torques_at_dof(self, torques: torch.Tensor) -> None:
+    def apply_torques_at_dof(self, torques: torch.Tensor, dof_indices: list[int] | None = None) -> None:
         """Apply torques with backend-specific optimization.
 
         Parameters
         ----------
         torques : torch.Tensor
-            Torques to apply to each DOF.
+            Torques to apply. Full per-DOF vector when ``dof_indices`` is None; otherwise aligned
+            with ``dof_indices``.
+        dof_indices : list[int] | None
+            When None (default), write every DOF. When a list, scatter ``torques`` into ONLY those
+            DOFs' ctrl slots, leaving the rest as their owner wrote them (so a co-controller on the
+            complementary DOFs is not clobbered).
 
         Raises
         ------
@@ -1058,23 +1063,31 @@ class MuJoCo(BaseSimulator):
             logger.warning("No actuators found in MuJoCo model")
             return
 
+        # The DOFs to write, and their aligned torques. Full path -> every DOF in order.
+        target_dofs = list(range(self.num_dof)) if dof_indices is None else dof_indices
+
         # Check if backend supports direct tensor writes
         ctrl_tensor = self.backend.get_ctrl_tensor()
 
         if ctrl_tensor is not None:
-            # Fast path: Direct zero-copy write (WarpBackend)
-            ctrl_tensor[:] = torques
+            # Fast path: Direct zero-copy write (WarpBackend). ctrl is [num_envs, nu] in DOF order.
+            if dof_indices is None:
+                ctrl_tensor[:] = torques
+            else:
+                idx_t = torch.as_tensor(dof_indices, device=ctrl_tensor.device, dtype=torch.long)
+                ctrl_tensor[:, idx_t] = torques.reshape(-1).to(ctrl_tensor.dtype)
         else:
             # Slow path: Loop-based write (ClassicBackend)
             torques_np = torques.detach().cpu().numpy().flatten()
 
-            # Verify we have the expected number of actuators
-            if len(torques_np) != self.root_model.nu:
-                raise ValueError(f"Torque count mismatch: got {len(torques_np)}, expected {self.root_model.nu}")
+            # Verify torque count matches the DOFs being written.
+            if len(torques_np) != len(target_dofs):
+                raise ValueError(f"Torque count mismatch: got {len(torques_np)}, expected {len(target_dofs)}")
 
-            # Map holosoma DOF indices to MuJoCo actuator indices
-            for i, dof_name in enumerate(self.dof_names):
+            # Map holosoma DOF indices to MuJoCo actuator indices (write only the target DOFs).
+            for i, dof_idx in enumerate(target_dofs):
                 # Add prefix for MuJoCo actuator lookup (dof_names are clean, need prefixed version)
+                dof_name = self.dof_names[dof_idx]
                 actuator_name = self._get_prefixed_name(dof_name)
                 actuator_id = mujoco.mj_name2id(self.root_model, mujoco.mjtObj.mjOBJ_ACTUATOR, actuator_name)
                 if actuator_id == -1:

--- a/src/holosoma/holosoma/simulator/mujoco/tests/test_apply_torques_subset.py
+++ b/src/holosoma/holosoma/simulator/mujoco/tests/test_apply_torques_subset.py
@@ -1,0 +1,106 @@
+"""``MuJoCo.apply_torques_at_dof`` DOF-subset scatter — pure, no full simulator build.
+
+Exercises the REAL method body (bound onto a light stub that supplies exactly the attributes it
+reads) over both backend paths:
+  * Classic (CPU): a real tiny mjModel/mjData with named actuators; assert only the owned actuators'
+    ``ctrl`` slots change and the full path still writes all of them.
+  * Warp fast path: a fake zero-copy ``[num_envs, nu]`` ctrl tensor; assert the subset scatter and
+    the full-width write.
+"""
+
+from __future__ import annotations
+
+import mujoco
+import numpy as np
+import pytest
+
+from holosoma.simulator.mujoco.mujoco import MuJoCo
+from holosoma.utils.safe_torch_import import torch
+
+pytestmark = pytest.mark.no_sim
+
+_DOFS = ["j0", "j1", "j2", "j3"]
+
+_MJCF = """
+<mujoco>
+  <worldbody>
+    <body name="b0"><joint name="j0" type="hinge" axis="0 0 1"/><geom size="0.1"/>
+      <body name="b1"><joint name="j1" type="hinge" axis="0 0 1"/><geom size="0.1"/>
+        <body name="b2"><joint name="j2" type="hinge" axis="0 0 1"/><geom size="0.1"/>
+          <body name="b3"><joint name="j3" type="hinge" axis="0 0 1"/><geom size="0.1"/></body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor name="j0" joint="j0"/><motor name="j1" joint="j1"/>
+    <motor name="j2" joint="j2"/><motor name="j3" joint="j3"/>
+  </actuator>
+</mujoco>
+"""
+
+
+class _ClassicStub:
+    """Attributes ``apply_torques_at_dof`` reads on the ClassicBackend path (ctrl tensor is None)."""
+
+    def __init__(self):
+        self.root_model = mujoco.MjModel.from_xml_string(_MJCF)
+        self.root_data = mujoco.MjData(self.root_model)
+        self.dof_names = list(_DOFS)
+        self.num_dof = len(_DOFS)
+        self.backend = type("B", (), {"get_ctrl_tensor": staticmethod(lambda: None)})()
+
+    def _get_prefixed_name(self, clean_name: str) -> str:
+        return clean_name  # no prefix in this minimal model
+
+    apply_torques_at_dof = MuJoCo.apply_torques_at_dof
+
+
+class _WarpStub:
+    """Attributes for the WarpBackend fast path — a fake zero-copy [num_envs, nu] ctrl tensor."""
+
+    def __init__(self, num_envs=2):
+        self.root_model = mujoco.MjModel.from_xml_string(_MJCF)
+        self.root_data = mujoco.MjData(self.root_model)
+        self.dof_names = list(_DOFS)
+        self.num_dof = len(_DOFS)
+        self._ctrl = torch.zeros(num_envs, len(_DOFS))
+        self.backend = type("B", (), {"get_ctrl_tensor": staticmethod(lambda: self._ctrl)})()
+
+    apply_torques_at_dof = MuJoCo.apply_torques_at_dof
+
+
+def test_classic_subset_writes_only_owned_slots():
+    sim = _ClassicStub()
+    sim.root_data.ctrl[:] = [7.0, 7.0, 7.0, 7.0]  # co-controller's prior values
+    # Own DOFs j1, j3 (indices 1, 3); torques aligned with that list.
+    sim.apply_torques_at_dof(torch.tensor([1.5, 3.5]), dof_indices=[1, 3])
+    np.testing.assert_allclose(sim.root_data.ctrl, [7.0, 1.5, 7.0, 3.5])
+
+
+def test_classic_full_path_writes_all():
+    sim = _ClassicStub()
+    sim.root_data.ctrl[:] = [7.0, 7.0, 7.0, 7.0]
+    sim.apply_torques_at_dof(torch.tensor([1.0, 2.0, 3.0, 4.0]))
+    np.testing.assert_allclose(sim.root_data.ctrl, [1.0, 2.0, 3.0, 4.0])
+
+
+def test_classic_subset_count_mismatch_raises():
+    sim = _ClassicStub()
+    with pytest.raises(ValueError, match="Torque count mismatch"):
+        sim.apply_torques_at_dof(torch.tensor([1.0]), dof_indices=[1, 3])
+
+
+def test_warp_subset_scatters_across_envs_and_leaves_rest():
+    sim = _WarpStub(num_envs=2)
+    sim._ctrl[:] = 7.0
+    sim.apply_torques_at_dof(torch.tensor([1.5, 3.5]), dof_indices=[1, 3])
+    expected = torch.tensor([[7.0, 1.5, 7.0, 3.5], [7.0, 1.5, 7.0, 3.5]])
+    torch.testing.assert_close(sim._ctrl, expected)
+
+
+def test_warp_full_path_writes_all():
+    sim = _WarpStub(num_envs=2)
+    full = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    sim.apply_torques_at_dof(full)
+    torch.testing.assert_close(sim._ctrl, full)

--- a/src/holosoma/holosoma/simulator/shared/simulator_bridge.py
+++ b/src/holosoma/holosoma/simulator/shared/simulator_bridge.py
@@ -155,7 +155,9 @@ class SimulatorBridge:
         torques_tensor = torch.from_numpy(self.robot_bridge.torques).to(
             device=self.simulator.device, dtype=torch.float32
         )
-        self.simulator.apply_torques_at_dof(torques_tensor)
+        # None when the bridge controls every DOF (fast full-width write); a list when it controls a
+        # subset (scatter into only those DOFs, leaving a co-controller's slots untouched).
+        self.simulator.apply_torques_at_dof(torques_tensor, dof_indices=self.robot_bridge._apply_indices)
 
         # Publish simulation clock for e.g, WBT policies
         sim_time = self.simulator.time()


### PR DESCRIPTION
## Motivation

The SDK bridge assumed it owned **every** simulator DOF: `BasicSdk2Bridge` set `num_motor = simulator.num_dof`, applied torques over the whole `ctrl` vector, and gated on `asset.robot_type`. A robot with more simulated DOFs than the SDK models — e.g. extra actuated joints a separate controller drives — could not run the bridge at all: the fixed-size SDK motor vector broadcast against a longer state vector and raised. Working around this previously required wrapping the simulator in an external DOF-subset proxy; this teaches the core bridge to do it natively.

## Change

Three new `RobotBridgeConfig` knobs, resolved once in `BasicSdk2Bridge` into a DOF-index subset:
- `controlled_dof_names` — explicit allow-list (wins when set)
- `excluded_dof_names` — its complement (control everything else)
- `sdk_robot_type` — `robot_type` shown to the SDK's type gate + motor-vector sizing (falls back to `asset.robot_type`)

`apply_torques_at_dof` gains an optional `dof_indices` to scatter torques into **only** those DOFs' actuators, leaving a co-controller's slots untouched.

## Behavior preserving by default

All new fields default empty/`None`. With no config the bridge controls every DOF via the existing full-width write path — **behavior is preserved exactly**, and `apply_torques_at_dof(torques)` (no `dof_indices`) is byte-for-byte the old path on every backend.

## Verification

We ran it on **all four backends** (MuJoCo classic + warp, IsaacGym, IsaacSim). A disjoint-subset-compose check on a real robot confirmed that two independent controllers each writing their own DOF subset land only in their own slots with no clobber. Adds `no_sim` unit tests covering the subset resolution and the MuJoCo scatter.