### PR TITLE
Add dry run as debug option to debug config

### DIFF
--- a/src/holosoma_inference/holosoma_inference/config/config_types/task.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_types/task.py
@@ -31,6 +31,14 @@ class DebugConfig:
     computes and logs as normal, but send_low_command is skipped so no torque
     is applied. Pair with print_observations to inspect what would be sent."""
 
+    dryer_run: bool = False
+    """Like ``dry_run``, but ALSO fabricate the robot state instead of reading
+    it from a bridge/driver. Swaps in a synthetic interface that returns a
+    plausible standing pose (default_dof_angles, upright IMU, zero velocities)
+    and never opens a DDS connection, so the loop runs with no sim/hardware
+    present at all. Implies ``dry_run`` (never sends commands). Use to smoke-test
+    config loading, ONNX inference, and the obs pipeline off-robot."""
+
 
 @dataclass(frozen=True)
 class Ros2DepthConsumerConfig:

--- a/src/holosoma_inference/holosoma_inference/config/config_types/task.py
+++ b/src/holosoma_inference/holosoma_inference/config/config_types/task.py
@@ -25,6 +25,12 @@ class DebugConfig:
     force_zero_action: bool = False
     """Zero out the scaled policy action (robot holds default pose)."""
 
+    dry_run: bool = False
+    """Run the full policy loop (obs, inference, postprocess) but do NOT send
+    commands to the robot. Safe for bring-up / on-hardware testing: everything
+    computes and logs as normal, but send_low_command is skipped so no torque
+    is applied. Pair with print_observations to inspect what would be sent."""
+
 
 @dataclass(frozen=True)
 class Ros2DepthConsumerConfig:

--- a/src/holosoma_inference/holosoma_inference/policies/base.py
+++ b/src/holosoma_inference/holosoma_inference/policies/base.py
@@ -700,14 +700,27 @@ class BasePolicy:
 
         # Stage 5: Action Pub
         with self.latency_tracker.measure("action_pub"):
-            self.interface.send_low_command(
-                self.cmd_q,
-                self.cmd_dq,
-                self.cmd_tau,
-                robot_state_data[0, 7 : 7 + self.num_dofs],
-                kp_override=kp_override,
-                kd_override=kd_override,
-            )
+            if self.config.task.debug.dry_run:
+                # Dry run: compute everything but send nothing to the robot.
+                # Log once so it's unmistakable no torque is being applied.
+                if not getattr(self, "_dry_run_logged", False):
+                    logger.warning(
+                        colored(
+                            "DRY RUN: policy loop active but send_low_command is SKIPPED "
+                            "(no commands sent to the robot).",
+                            "yellow",
+                        )
+                    )
+                    self._dry_run_logged = True
+            else:
+                self.interface.send_low_command(
+                    self.cmd_q,
+                    self.cmd_dq,
+                    self.cmd_tau,
+                    robot_state_data[0, 7 : 7 + self.num_dofs],
+                    kp_override=kp_override,
+                    kd_override=kd_override,
+                )
 
         # Telemetry hook: fires every control tick in every state (policy,
         # stiff-hold, init ramp) with the final executed command. Default

--- a/src/holosoma_inference/holosoma_inference/policies/base.py
+++ b/src/holosoma_inference/holosoma_inference/policies/base.py
@@ -396,9 +396,39 @@ class BasePolicy:
     # Policy Methods
     # ============================================================================
 
+    @staticmethod
+    def _make_ort_session_options():
+        """ONNX Runtime options tuned for the real-time control loop.
+
+        By default ORT sizes its intra-op thread pool to the CPU count AND pins
+        one worker to each core via sched_setaffinity. That per-thread pin
+        bypasses the kernel's ``isolcpus`` reservation, so the workers land on
+        the isolated RT cores (10-13 here) and contend with the 1 kHz EtherCAT
+        actuator threads. The policy is a small MLP run at 50 Hz (~1 ms
+        single-threaded), so a multi-core pool buys nothing and the pinning is
+        pure harm. Force single-threaded, sequential exec, and — belt and
+        suspenders — disable ORT's thread affinity so it can never pin to an
+        isolated core even if thread counts change.
+        """
+        opts = onnxruntime.SessionOptions()
+        opts.intra_op_num_threads = 1
+        opts.inter_op_num_threads = 1
+        opts.execution_mode = onnxruntime.ExecutionMode.ORT_SEQUENTIAL
+        # Empty affinity string => let the OS scheduler place threads within the
+        # inherited (0-9) mask; ORT does not force per-core pins.
+        try:
+            opts.add_session_config_entry("session.intra_op_thread_affinities", "")
+        except Exception as exc:
+            # Older ORT without this config key: intra_op_num_threads=1 already
+            # avoids building the per-core pinned pool, so this is best-effort.
+            logger.debug(f"ORT intra_op_thread_affinities config unsupported: {exc}")
+        return opts
+
     def setup_policy(self, model_path):
         """Setup ONNX policy model and extract metadata."""
-        self.onnx_policy_session = onnxruntime.InferenceSession(model_path)
+        self.onnx_policy_session = onnxruntime.InferenceSession(
+            model_path, sess_options=self._make_ort_session_options()
+        )
         input_names = [inp.name for inp in self.onnx_policy_session.get_inputs()]
         output_names = [out.name for out in self.onnx_policy_session.get_outputs()]
 

--- a/src/holosoma_inference/holosoma_inference/policies/base.py
+++ b/src/holosoma_inference/holosoma_inference/policies/base.py
@@ -712,9 +712,12 @@ class BasePolicy:
 
         # Stage 5: Action Pub
         with self.latency_tracker.measure("action_pub"):
-            if self.config.task.debug.dry_run or self.config.task.debug.dryer_run:
-                # Dry run: compute everything but send nothing to the robot.
-                # (dryer_run implies dry_run — it also fabricates the state.)
+            # dry_run: the interface is the REAL bridge/driver, so we must NOT
+            # call send_low_command at all. dryer_run: the interface is the
+            # SyntheticInterface, whose send_low_command only publishes to a
+            # synthetic measurement topic (nothing reaches the robot), so we DO
+            # call it — that's what produces the measurable command stream.
+            if self.config.task.debug.dry_run and not self.config.task.debug.dryer_run:
                 # Log once so it's unmistakable no torque is being applied.
                 if not getattr(self, "_dry_run_logged", False):
                     logger.warning(

--- a/src/holosoma_inference/holosoma_inference/policies/base.py
+++ b/src/holosoma_inference/holosoma_inference/policies/base.py
@@ -149,6 +149,18 @@ class BasePolicy:
         if hasattr(self, "_shared_hardware_source"):
             self.interface = self._shared_hardware_source.interface
             return
+        # Dryer run: fabricate state, never open a DDS connection. Bypasses the
+        # SDK backend entirely so the loop runs with no bridge/driver present.
+        if self.config.task.debug.dryer_run:
+            from holosoma_inference.sdk.synthetic_interface import SyntheticInterface
+
+            self.interface = SyntheticInterface(
+                self.robot_config,
+                self.config.task.domain_id,
+                self.config.task.interface,
+                False,
+            )
+            return
         # The SDK's own wireless-controller path is only needed when an
         # "interface" channel is selected.  The "joystick" channel is read
         # via host-side evdev (UsbJoystickInput) and does not touch the SDK.
@@ -700,8 +712,9 @@ class BasePolicy:
 
         # Stage 5: Action Pub
         with self.latency_tracker.measure("action_pub"):
-            if self.config.task.debug.dry_run:
+            if self.config.task.debug.dry_run or self.config.task.debug.dryer_run:
                 # Dry run: compute everything but send nothing to the robot.
+                # (dryer_run implies dry_run — it also fabricates the state.)
                 # Log once so it's unmistakable no torque is being applied.
                 if not getattr(self, "_dry_run_logged", False):
                     logger.warning(

--- a/src/holosoma_inference/holosoma_inference/sdk/synthetic_interface.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/synthetic_interface.py
@@ -1,10 +1,16 @@
 """Synthetic (offline) interface for ``--task.debug.dryer-run``.
 
-Fabricates a plausible standing robot state and never opens a DDS connection,
-so the policy loop runs with no sim bridge or hardware driver present at all.
+Fabricates a plausible standing robot state instead of reading it from a sim
+bridge or hardware driver, so the policy loop runs with nothing else present.
 Used to smoke-test config loading, ONNX inference, and the observation pipeline
-off-robot. ``send_low_command`` is a no-op (dryer_run implies dry_run), but it's
-implemented defensively in case it's ever called directly.
+off-robot.
+
+For measurement, ``send_low_command`` publishes the commands the policy *would*
+send to a **separate synthetic topic** (``/dryer_run/cmd``, ``sensor_msgs/
+JointState``) that no real driver subscribes to — so you can ``ros2 topic hz /
+dryer_run/cmd`` / ``echo`` / ``bag record`` the loop's output while nothing is
+ever sent to the actual robot. If ROS2 is unavailable (pure offline run) it
+degrades to a no-op and stays fully offline.
 """
 
 from __future__ import annotations
@@ -15,13 +21,17 @@ from loguru import logger
 from holosoma_inference.config.config_types import RobotConfig
 from holosoma_inference.sdk.base.base_interface import BaseInterface
 
+# Deliberately NOT a real driver topic (e.g. /alpha/joints/cmd). Nothing on the
+# robot subscribes here, so publishing is safe — it's for measurement only.
+_SYNTHETIC_CMD_TOPIC = "/dryer_run/cmd"
+
 
 class SyntheticInterface(BaseInterface):
-    """Returns a fixed, upright standing state; sends nothing.
+    """Returns a fixed, upright standing state; publishes cmds to a fake topic.
 
-    Layout matches :meth:`BaseInterface.get_low_state`:
+    State layout matches :meth:`BaseInterface.get_low_state`:
     ``[base_pos(3), quat(4), dof_pos(N), lin_vel(3), ang_vel(3), dof_vel(N)]``
-    followed by an optional ``projected_gravity(3)`` (we append it, upright).
+    followed by an appended ``projected_gravity(3)`` (upright).
     """
 
     def __init__(
@@ -30,6 +40,8 @@ class SyntheticInterface(BaseInterface):
         domain_id: int = 0,
         interface_str: str | None = None,
         use_joystick: bool = False,
+        publish_cmd: bool = True,
+        cmd_topic: str = _SYNTHETIC_CMD_TOPIC,
     ):
         super().__init__(robot_config, domain_id, interface_str, use_joystick)
 
@@ -40,6 +52,11 @@ class SyntheticInterface(BaseInterface):
             n = len(getattr(robot_config, "dof_names", []) or [])
             self._dof_pos = np.zeros(n if n > 0 else 1)
         self._num_dof = self._dof_pos.shape[0]
+
+        dof_names = list(getattr(robot_config, "dof_names", []) or [])
+        if len(dof_names) != self._num_dof:
+            dof_names = [f"joint_{i}" for i in range(self._num_dof)]
+        self._dof_names = dof_names
 
         # Upright: identity quaternion (w,x,y,z), gravity straight down in the
         # base frame, zero linear/angular velocity, zero joint velocity.
@@ -55,6 +72,40 @@ class SyntheticInterface(BaseInterface):
             "connection to any bridge/driver is opened."
         )
 
+        # Optional command publishing to a synthetic topic for measurement.
+        self._cmd_topic = cmd_topic
+        self._cmd_pub = None
+        self._node = None
+        self._JointState = None
+        if publish_cmd:
+            self._setup_cmd_publisher()
+
+    def _setup_cmd_publisher(self) -> None:
+        try:
+            import rclpy
+            from rclpy.node import Node
+            from rclpy.qos import QoSProfile, ReliabilityPolicy
+            from sensor_msgs.msg import JointState
+        except Exception as exc:  # ROS2 not sourced → stay fully offline.
+            logger.warning(
+                f"DRYER RUN: command publishing requested but ROS2 is unavailable "
+                f"({exc}); running fully offline — no synthetic cmd topic."
+            )
+            return
+
+        if not rclpy.ok():
+            rclpy.init()
+        self._node = Node("dryer_run_synthetic")
+        qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.RELIABLE)
+        self._cmd_pub = self._node.create_publisher(JointState, self._cmd_topic, qos)
+        self._JointState = JointState
+        logger.warning(
+            f"DRYER RUN: publishing synthetic commands on {self._cmd_topic} "
+            "(sensor_msgs/JointState: name/position/velocity/effort) for "
+            "measurement. No real driver subscribes to this topic — nothing is "
+            "sent to the robot."
+        )
+
     def get_low_state(self) -> np.ndarray:
         return np.concatenate(
             [
@@ -68,8 +119,26 @@ class SyntheticInterface(BaseInterface):
             ]
         ).reshape(1, -1)
 
-    def send_low_command(self, *args, **kwargs) -> None:
-        return None
+    def send_low_command(
+        self,
+        cmd_q: np.ndarray,
+        cmd_dq: np.ndarray,
+        cmd_tau: np.ndarray,
+        dof_pos_latest: np.ndarray = None,
+        kp_override: np.ndarray = None,
+        kd_override: np.ndarray = None,
+    ) -> None:
+        # Only ever publishes to the synthetic measurement topic — never to a
+        # real driver. If publishing is disabled/unavailable, this is a no-op.
+        if self._cmd_pub is None:
+            return
+        msg = self._JointState()
+        msg.header.stamp = self._node.get_clock().now().to_msg()
+        msg.name = self._dof_names
+        msg.position = np.asarray(cmd_q, dtype=float).reshape(-1).tolist()
+        msg.velocity = np.asarray(cmd_dq, dtype=float).reshape(-1).tolist()
+        msg.effort = np.asarray(cmd_tau, dtype=float).reshape(-1).tolist()
+        self._cmd_pub.publish(msg)
 
     def get_joystick_msg(self):
         return None

--- a/src/holosoma_inference/holosoma_inference/sdk/synthetic_interface.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/synthetic_interface.py
@@ -1,0 +1,94 @@
+"""Synthetic (offline) interface for ``--task.debug.dryer-run``.
+
+Fabricates a plausible standing robot state and never opens a DDS connection,
+so the policy loop runs with no sim bridge or hardware driver present at all.
+Used to smoke-test config loading, ONNX inference, and the observation pipeline
+off-robot. ``send_low_command`` is a no-op (dryer_run implies dry_run), but it's
+implemented defensively in case it's ever called directly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from loguru import logger
+
+from holosoma_inference.config.config_types import RobotConfig
+from holosoma_inference.sdk.base.base_interface import BaseInterface
+
+
+class SyntheticInterface(BaseInterface):
+    """Returns a fixed, upright standing state; sends nothing.
+
+    Layout matches :meth:`BaseInterface.get_low_state`:
+    ``[base_pos(3), quat(4), dof_pos(N), lin_vel(3), ang_vel(3), dof_vel(N)]``
+    followed by an optional ``projected_gravity(3)`` (we append it, upright).
+    """
+
+    def __init__(
+        self,
+        robot_config: RobotConfig,
+        domain_id: int = 0,
+        interface_str: str | None = None,
+        use_joystick: bool = False,
+    ):
+        super().__init__(robot_config, domain_id, interface_str, use_joystick)
+
+        default_angles = getattr(robot_config, "default_dof_angles", None)
+        if default_angles is not None and len(default_angles) > 0:
+            self._dof_pos = np.asarray(default_angles, dtype=float)
+        else:
+            n = len(getattr(robot_config, "dof_names", []) or [])
+            self._dof_pos = np.zeros(n if n > 0 else 1)
+        self._num_dof = self._dof_pos.shape[0]
+
+        # Upright: identity quaternion (w,x,y,z), gravity straight down in the
+        # base frame, zero linear/angular velocity, zero joint velocity.
+        self._quat = np.array([1.0, 0.0, 0.0, 0.0])
+        self._projected_gravity = np.array([0.0, 0.0, -1.0])
+
+        self._kp_level = 1.0
+        self._kd_level = 1.0
+
+        logger.warning(
+            "DRYER RUN: using SyntheticInterface — state is fabricated (upright, "
+            f"default pose, zero velocities across {self._num_dof} DOF) and NO "
+            "connection to any bridge/driver is opened."
+        )
+
+    def get_low_state(self) -> np.ndarray:
+        return np.concatenate(
+            [
+                np.zeros(3),  # base_pos
+                self._quat,  # quat (w,x,y,z)
+                self._dof_pos,  # dof_pos
+                np.zeros(3),  # base lin_vel
+                np.zeros(3),  # base ang_vel
+                np.zeros(self._num_dof),  # dof_vel
+                self._projected_gravity,  # projected_gravity (upright)
+            ]
+        ).reshape(1, -1)
+
+    def send_low_command(self, *args, **kwargs) -> None:
+        return None
+
+    def get_joystick_msg(self):
+        return None
+
+    def get_joystick_key(self, wc_msg=None):
+        return None
+
+    @property
+    def kp_level(self):
+        return self._kp_level
+
+    @kp_level.setter
+    def kp_level(self, value):
+        self._kp_level = float(value)
+
+    @property
+    def kd_level(self):
+        return self._kd_level
+
+    @kd_level.setter
+    def kd_level(self, value):
+        self._kd_level = float(value)

--- a/src/holosoma_inference/holosoma_inference/sdk/synthetic_interface.py
+++ b/src/holosoma_inference/holosoma_inference/sdk/synthetic_interface.py
@@ -132,13 +132,26 @@ class SyntheticInterface(BaseInterface):
         # real driver. If publishing is disabled/unavailable, this is a no-op.
         if self._cmd_pub is None:
             return
+        # On shutdown (Ctrl-C / SIGTERM) the rclpy context can be torn down
+        # while a final publish is in flight — guard so exit stays clean.
+        try:
+            import rclpy
+
+            if not rclpy.ok():
+                return
+        except Exception:
+            return
         msg = self._JointState()
         msg.header.stamp = self._node.get_clock().now().to_msg()
         msg.name = self._dof_names
         msg.position = np.asarray(cmd_q, dtype=float).reshape(-1).tolist()
         msg.velocity = np.asarray(cmd_dq, dtype=float).reshape(-1).tolist()
         msg.effort = np.asarray(cmd_tau, dtype=float).reshape(-1).tolist()
-        self._cmd_pub.publish(msg)
+        try:
+            self._cmd_pub.publish(msg)
+        except Exception:
+            # Context invalidated mid-publish during shutdown — ignore.
+            return
 
     def get_joystick_msg(self):
         return None


### PR DESCRIPTION
Add task.debug.dry_run (default False). When set, the policy runs the full loop — obs, inference, postprocess, telemetry — but skips send_low_command, so no torque reaches the robot. Logs a one-time yellow warning so it's unmistakable that commands are suppressed. Intended for on-hardware bring-up: verify the obs pipeline (pair with print_observations) and end-to-end wiring without the robot moving.

Enable via CLI: --task.debug.dry-run

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
