### PR TITLE
harden(docker): apt upgrade in all Dockerfiles; inference image builds via uv

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV CONDA_ROOT=/root/.holosoma_deps/miniconda3
 ENV PATH=$CONDA_ROOT/bin:$PATH
 
 RUN mkdir -p /var/lib/apt/lists/partial && \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
     build-essential \
     swig \

--- a/docker/isaacgym.Dockerfile
+++ b/docker/isaacgym.Dockerfile
@@ -20,7 +20,7 @@ ENV CONDA_ROOT=/root/.holosoma_deps/miniconda3
 ENV PATH=$CONDA_ROOT/bin:$PATH
 
 RUN mkdir -p /var/lib/apt/lists/partial && \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
     build-essential \
     swig \

--- a/docker/isaacsim.Dockerfile
+++ b/docker/isaacsim.Dockerfile
@@ -12,7 +12,7 @@ ENV CONDA_ROOT=/root/.holosoma_deps/miniconda3
 ENV PATH=$CONDA_ROOT/bin:$PATH
 
 RUN mkdir -p /var/lib/apt/lists/partial && \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
     build-essential \
     swig \

--- a/docker/mujoco.Dockerfile
+++ b/docker/mujoco.Dockerfile
@@ -17,7 +17,7 @@ ENV CONDA_ROOT=/root/.holosoma_deps/miniconda3
 ENV PATH=$CONDA_ROOT/bin:$PATH
 
 RUN mkdir -p /var/lib/apt/lists/partial && \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
     build-essential \
     swig \

--- a/docker/thor/Dockerfile
+++ b/docker/thor/Dockerfile
@@ -44,7 +44,7 @@ ENV PYTHONUNBUFFERED=1
 # survives across layer boundaries and can be PATH-prepended.
 FROM l4t-cuda AS python-base
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
     cmake \
@@ -69,7 +69,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # NVIDIA math + inference libs that rarely change.
 FROM python-base AS long-deps
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     # NVPL math libs (required by CUDA torch wheel on aarch64 SBSA)
     libnvpl-blas0 \
     libnvpl-lapack0 \
@@ -156,7 +156,7 @@ CMD ["--help"]
 # the distribution mainline). Adds ~1.5 GB but is stable across code changes.
 FROM python-base AS ros-jazzy
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     gnupg \
     lsb-release \
     && rm -rf /var/lib/apt/lists/*
@@ -179,7 +179,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
 # Cross-container /cmd_vel interop: FastDDS ↔ CycloneDDS is validated on
 # Jazzy for standard message types (TwistStamped tested on aarch64). Pick
 # whichever RMW your publisher container uses; no alignment required.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ros-jazzy-ros-base \
     ros-jazzy-rmw-fastrtps-cpp \
     ros-jazzy-rmw-cyclonedds-cpp \
@@ -195,7 +195,7 @@ RUN echo "source /opt/ros/jazzy/setup.bash" >> /etc/bash.bashrc
 # NVIDIA math/inference libs on top of the ROS base.
 FROM ros-jazzy AS long-deps-ros
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libnvpl-blas0 \
     libnvpl-lapack0 \
     libcudss0-cuda-13 \

--- a/src/holosoma_inference/docker/Dockerfile
+++ b/src/holosoma_inference/docker/Dockerfile
@@ -5,15 +5,28 @@ ENV LD_LIBRARY_PATH="/usr/lib/python3.10/dist-packages/lib/"
 
 WORKDIR /workspace/
 
+# Patch base-image packages (openssl et al.) to pick up security fixes, then
+# install dev tooling. apt-get upgrade keeps the ros:humble base current with
+# Ubuntu security updates rather than shipping whatever was baked into the base.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y python3-pip vim \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install ohmybash + dev tooling
 RUN bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh)"
-RUN apt-get update && apt-get install -y python3-pip vim
+
+# Install uv (the project's build backend). holosoma_inference declares
+# `build-backend = "uv_build"` in pyproject.toml, so the editable install below
+# is driven by uv's build backend rather than setuptools. Pinning to :latest —
+# bump explicitly here for a deterministic version.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Install holosoma_inference (as the last step, since the cache of this layer will get invalidated frequently)
 # NOTE: This assumes the build context is holosoma/src/ (see build.sh)
 COPY src/holosoma_inference /workspace/holosoma/src/holosoma_inference/
-RUN pip3 install -e "/workspace/holosoma/src/holosoma_inference[unitree]"
-RUN pip3 install -e "/workspace/holosoma/src/holosoma_inference[booster]"
-RUN pip3 install pin
+# `uv pip install --system` builds via the uv_build backend declared in
+# pyproject.toml and installs into the ROS image's system interpreter.
+RUN uv pip install --system -e "/workspace/holosoma/src/holosoma_inference[unitree]"
+RUN uv pip install --system -e "/workspace/holosoma/src/holosoma_inference[booster]"
+RUN uv pip install --system pin
 
 WORKDIR /workspace/holosoma

--- a/src/holosoma_inference/docker/service/Dockerfile.x86
+++ b/src/holosoma_inference/docker/service/Dockerfile.x86
@@ -55,7 +55,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \
     build-essential \
     cmake \
@@ -144,7 +144,7 @@ CMD ["--help"]
 # across code changes. Jazzy is the Noble-native distro (matches Ubuntu 24.04).
 FROM base AS ros-jazzy
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     gnupg \
     lsb-release \
     && rm -rf /var/lib/apt/lists/*
@@ -163,7 +163,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
 # — FastDDS and CycloneDDS have disjoint binary symbol spaces, so the two
 # middlewares coexist cleanly in one process. unitree_sdk2 keeps its bundled
 # CycloneDDS; rclpy uses FastDDS.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ros-jazzy-ros-base \
     ros-jazzy-rmw-fastrtps-cpp \
     ros-jazzy-rmw-cyclonedds-cpp \

--- a/src/holosoma_inference/holosoma_inference_service/docker/Dockerfile.test
+++ b/src/holosoma_inference/holosoma_inference_service/docker/Dockerfile.test
@@ -28,7 +28,7 @@ ENV PYTHONUNBUFFERED=1
 ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
 
 # colcon + venv support for the ament_python service package.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     python3-colcon-common-extensions \
     python3-pip \
     python3-venv \

--- a/src/holosoma_retargeting/docker/Dockerfile
+++ b/src/holosoma_retargeting/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV CONDA_ROOT=/root/.holosoma_deps/miniconda3
 ENV PATH=$CONDA_ROOT/bin:$PATH
 
 RUN mkdir -p /var/lib/apt/lists/partial && \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
     build-essential \
     swig \
@@ -67,7 +67,7 @@ ENV CONDA_ROOT=/root/.holosoma_deps/miniconda3
 ENV PATH=$CONDA_ROOT/bin:$PATH
 
 RUN mkdir -p /var/lib/apt/lists/partial && \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     cmake \
     build-essential \
     swig \


### PR DESCRIPTION
Add apt-get upgrade -y before apt install in every Dockerfile so base-image packages pick up security fixes on rebuild. Also convert the inference image to build via uv (uv_build backend declared in pyproject.toml) instead of pip3.