### PR TITLE
fix(retargeting): derive DoF slice width instead of hardcoding 29-DoF

### DIFF
--- a/src/holosoma_retargeting/holosoma_retargeting/data_conversion/convert_data_format_mj.py
+++ b/src/holosoma_retargeting/holosoma_retargeting/data_conversion/convert_data_format_mj.py
@@ -163,7 +163,11 @@ class MotionLoader:
             self.motion_base_poss_input = motion[:, :3]
             self.motion_base_rots_input = motion[:, 3:7]
 
-        self.motion_dof_poss_input = motion[:, 7:36]
+        # DoF width is robot-dependent, not fixed.
+        # Layout: [base(7)] [dof(N)] [object(7) iff has_dynamic_object]. Derive N from
+        # the array width so any-DoF robots convert correctly (was: motion[:, 7:36]).
+        _dof_end = motion.shape[1] - (7 if self.has_dynamic_object else 0)
+        self.motion_dof_poss_input = motion[:, 7:_dof_end]
 
         if self.has_dynamic_object:
             if self.use_omniretarget_data:


### PR DESCRIPTION
Derive the per-frame DoF slice width from the motion array shape in `MotionLoader.load()` instead of hardcoding `motion[:, 7:36]`. The old bound assumed a fixed `7` base columns + `29` DoF columns, so it was only correct for a 29-DoF robot; for any other DoF count (e.g. 31-DoF) the trailing DoF columns were silently dropped, producing wrong DoF data that then mismatched the downstream DoF index map. The motion layout is `[base(7)] [dof(N)] [object(7) iff has_dynamic_object]`, so we now compute the DoF end from the row width and the object block.

- Slice `motion[:, 7:_dof_end]` where `_dof_end = motion.shape[1] - (7 if self.has_dynamic_object else 0)`.
- No behavior change for the 29-DoF case; conversion is now correct for arbitrary DoF counts.