### PR TITLE
ci(pytest): let the simulator test jobs fail the Pytests run

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,7 +29,6 @@ jobs:
     name: Run ${{ matrix.simulator }} Tests with ${{ matrix.multigpu == 'True' && 'multi-gpu' || 'single-gpu' }}
     runs-on:
     - codebuild-holosoma-a10g-${{ matrix.multigpu == 'True' && 'x4' || 'x1' }}-gpu-build-${{ github.run_id }}-${{ github.run_attempt }}
-    continue-on-error: true
     container:
       image: ${{ vars.ECR_REGISTRY }}/holosoma-${{ matrix.simulator }}:latest
       options: "--gpus all --runtime=nvidia --shm-size=12g"
@@ -59,7 +58,6 @@ jobs:
     name: Run ${{ matrix.simulator }} Tests end-to-end with ${{ matrix.multigpu == 'True' && 'multi-gpu' || 'single-gpu' }}
     runs-on:
     - codebuild-holosoma-a10g-${{ matrix.multigpu == 'True' && 'x4' || 'x1' }}-gpu-build-${{ github.run_id }}-${{ github.run_attempt }}
-    continue-on-error: true
     container:
       # needs both hsgym and hsinference envs
       image: ${{ vars.ECR_REGISTRY }}/holosoma:latest

--- a/src/holosoma/tests/test_ci_workflow_gates.py
+++ b/src/holosoma/tests/test_ci_workflow_gates.py
@@ -1,0 +1,48 @@
+"""The test jobs in .github/workflows/pytest.yaml must be able to fail the workflow run (pure, no simulator).
+
+``continue-on-error: true`` at JOB level makes a job's failure invisible to the run that contains it:
+the job's own check-run concludes ``failure`` while the ``Pytests`` run concludes ``success``. Both
+simulator jobs (``tests``, ``e2e-tests``) carried it from 75691e1, a runner-selection PR, so every
+isaacgym / isaacsim / mujoco / requires_inference test in this repo ran where a red result could not
+fail the run. Observed in production, not inferred: PR #170 merged while three sim job check-runs
+from run 29469569515 had already concluded ``failure`` and that same ``Pytests`` run read ``success``.
+
+Read this file with a YAML parser rather than by eye. The neighbouring ``fail-fast: false`` under
+``strategy`` is about the matrix and invites misreading the indentation, while ``continue-on-error``
+sits at job level and is what decouples the job's result from the run's.
+
+NOT COVERED HERE: a step-level ``continue-on-error`` reaches the same end (the step fails, the job
+succeeds), and this asserts only the job-level flag. Nor does it say anything about which checks are
+required to merge -- that lives in branch protection, outside this repo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "pytest.yaml"
+
+
+def _jobs() -> dict:
+    """Return pytest.yaml's ``jobs`` mapping, refusing to answer off an empty or wrong-file parse."""
+    assert WORKFLOW.is_file(), f"no workflow at {WORKFLOW} -- repo layout moved, so nothing was checked"
+    text = WORKFLOW.read_text()
+    jobs = (yaml.safe_load(text) or {}).get("jobs")
+    # Both assertions are vacuity refusals: an empty parse, or a file that no longer runs the
+    # suite, would satisfy the check below by construction rather than by being correct.
+    assert isinstance(jobs, dict) and jobs, f"no jobs parsed out of {WORKFLOW}"
+    assert "pytest" in text, f"{WORKFLOW} no longer runs pytest -- is this still the test workflow?"
+    return jobs
+
+
+@pytest.mark.no_sim
+def test_no_pytest_job_swallows_its_own_failure():
+    swallowing = sorted(name for name, job in _jobs().items() if job.get("continue-on-error", False) is not False)
+    assert not swallowing, (
+        f"job-level 'continue-on-error' on {WORKFLOW.name} job(s): {', '.join(swallowing)}. Those jobs' "
+        "check-runs go red while the workflow run concludes success, so their tests cannot fail the run. "
+        "Remove the flag, or set it to false."
+    )


### PR DESCRIPTION
# ci(pytest): let the simulator test jobs fail the Pytests run

**Branch:** `dev/asetapen/pytest-jobs-must-be-able-to-fail-the-run`

## Summary

Both the `tests` and `e2e-tests` jobs in `.github/workflows/pytest.yaml` carry `continue-on-error: true` at JOB level, which decouples a job's result from the run's: the job's own check-run still goes red while the `Pytests` run concludes `success`, so anything reading the run sees green. Every simulator test in the repository sits behind those two jobs, so applying `conftest.py`'s own marker rule, 167 of 873 `def test_*` definitions across 42 files (19.1%, a floor, because it counts source definitions and `@parametrize` multiplies items) cannot fail the run: isaacgym 10 files / 29 defs, isaacsim 11 / 38, mujoco 20 / 99, plus the one `requires_inference` e2e test. This is not theoretical: PR #170 merged while three of its simulator jobs were red, the run containing them concluded `success`, and nothing on the PR page said the tests had failed. Across the last 79 merged PRs, 9 merged over at least one already-red job check-run against only 4 over an already-failed run-level conclusion, and that gap is this defect measured from the other side. The flags were not a deliberate policy choice either: both arrived incidentally in a PR about GPU runner selection (#69) whose message does not mention them, and neither site carries a comment. This change removes the two lines and adds a test that keeps them out, and it has to land BEFORE any status check is made required rather than after, because requiring the run-level `Pytests` check while these flags stand would read green in exactly the case the requirement exists for.

## How to test this CR

```sh
# 1. The guard passes on this branch.
python3 -m pytest --noconftest -q src/holosoma/tests/test_ci_workflow_gates.py
# -> 1 passed

# 2. It FAILS on unfixed main, naming the offending jobs. Feed it main's workflow:
git show origin/main:.github/workflows/pytest.yaml > .github/workflows/pytest.yaml
python3 -m pytest --noconftest -q src/holosoma/tests/test_ci_workflow_gates.py
# -> 1 failed, AssertionError names "e2e-tests, tests"
git checkout -- .github/workflows/pytest.yaml

# 3. This PR's own CI run holds both directions. Read it BY ATTEMPT: the default
#    view shows only attempt 2.
gh run view 32219812531 --attempt 1   # failure, off a single red job
gh run view 32219812531 --attempt 2   # success, all eight green
```

## Changelog

- Remove the two job-level `continue-on-error: true` lines from `.github/workflows/pytest.yaml`, so a red simulator job fails the `Pytests` run. That is the only signal a reader of the PR, or a required check, can act on.
- Add `src/holosoma/tests/test_ci_workflow_gates.py`, which fails when any job in that workflow carries a truthy job-level `continue-on-error`.

### Let the simulator jobs fail the run

- `fail-fast: false` under `strategy` is deliberately untouched. It is a different property (it stops one red matrix cell cancelling its siblings, so all four simulator cells still report independently) and it does not decouple a job's result from the run's.
- The other two `continue-on-error: true` sites in the repository are untouched: `docker-build.yaml`'s `build` job and `nightly-training.yaml`'s `training` job, where a nightly may well want it.

### Lock the fix with a workflow gate test

- Parses the workflow with `yaml.safe_load` and names the offending jobs in the assertion message. An explicit `continue-on-error: false` passes.
- Marked `no_sim`, so it runs in `no-sim-tests`, a job that CAN fail the run. Placed in any simulator lane it would have been silenced by the very defect it guards.
- Refuses to answer off a vacuous parse: it fails loudly if the `jobs` mapping is empty, or if the workflow no longer runs pytest at all, because either would satisfy a "no job carries the flag" assertion by construction.
- Iterates the `jobs` mapping rather than encoding the two job names it was written against, so it also covers the next simulator lane somebody adds.

## Testing

### Unit tests

- `src/holosoma/tests/test_ci_workflow_gates.py`, 1 test, `1 passed` against the real file in this checkout.
- Twelve arms, each a throwaway repo root holding a copy of the committed test file plus one `pytest.yaml` variant, so arms differ only in the workflow they read. Eight are mine and four were scored independently against the same test bytes. It PASSES on this branch and on an explicit `continue-on-error: false`. It FAILS, naming the offending job, on unfixed `main`, on either flag alone, on an expression form, on a quoted `'false'`, and on a `brand-new-sim-job` that did not exist when the test was written. Three vacuity arms ERROR rather than pass: an empty `jobs` mapping, a workflow that runs no pytest, and the file deleted.
- The brand-new-job arm is the one that matters for review, and my own eight structurally cannot supply it: each varies the flag on one of the two jobs that already exist, so none of them can distinguish a check that iterates the `jobs` mapping from one that hardcodes the two names.
- The expression and quoted-string arms are CHARACTERISED rather than fixed: `yaml.safe_load` yields a string for both, and the check treats any non-`False` value as truthy. For the expression form that is the direction you want, since a conditional `continue-on-error` on a pytest job has no legitimate use.
- The quoted `'false'` arm is not a false positive, and that is measured rather than argued. GitHub's own parser (`actions/runner`, `Sdk/WorkflowParser`, built and executed locally over twelve variants of this workflow) parses plain `false`, `true` and `False` to a boolean and `${{ }}` as an expression, and REJECTS `'false'`, `"false"` and `'true'` alike with `Unexpected value ...`, so it is the quoting rather than the value. Such a workflow never runs at all. The control that makes that reading discriminating is `name: 'false'` on the string-typed `name` field, which PARSES: the rejection is a string in a boolean field, not a blanket refusal of quoted scalars.

### Integration tests

- This PR's own CI run, 32219812531, settles the two things no local run can. `src/holosoma/tests/test_ci_workflow_gates.py .` appears in the `Run No-Simulator Tests` job (515 passed, 38 skipped, 21 deselected), so the test really is selected by `-m "no_sim"` and really does run in a job that can fail the workflow.
- Both directions live in that one run, read BY ATTEMPT. Attempt 1 concluded `failure` off a single red job (`Run isaacsim Tests with single-gpu`, the other seven green). Attempt 2, after re-running that one job on the same tree, concluded `success` with all eight green. So a red job now fails the run and an all-green run still passes. On `main` today, attempt 1's shape concludes `success` instead, which is the defect.
- Two instruments independent of the test in this branch confirm the change from outside it. A census that re-derives lane membership from `conftest.py`'s documented rule reads 167 of 873 test defs un-failable on `main` and 0 of 874 here, the total moving by exactly the one definition this branch adds. A separate per-job workflow parser reads 2 of 7 test-running jobs un-failable on `main` and 0 of 7 here, while its two unrelated checks (both about `docker-build.yaml`, untouched here) stay red, so the move is attributable to this change and not to a scoring shift.

### Functional testing

- [ ] Simulation (mujoco)
- [ ] Robot (G1-XYZ)

Both boxes are unchecked deliberately and neither is owed: this change edits a workflow and adds a test, and alters no runtime, simulator or robot behaviour. CI run 32219812531 is the functional evidence, and it exercised the full simulator matrix.

### Not covered

- It asserts the JOB-level flag only. A step-level `continue-on-error` on a pytest step reaches the same end (the step fails, the job succeeds) and PASSES this test. That is measured, not assumed: it is the step-level arm scored above.
- It does not make any check required for merge. No status check is required to merge `main` today (the active ruleset carries 9 rules and none of them is `required_status_checks`), and that lives in branch protection, outside this repository.
- It does not close the TRIGGER gap, and that has been confirmed independently rather than resting on my reading alone. `pytest.yaml` runs on changes to `src/**`, `tests/**` and `scripts/source_*`, so a PR that re-added these flags and touched nothing else would not run this test at all; the next PR touching source or tests catches it. Widening the path filter would put the GPU matrix on every workflow edit, which is a separate decision, so it is disclosed here rather than fixed.
- The quoted-string finding is the RUNNER's parser executed locally, not the service, which evaluates job-level `continue-on-error` in code that is not public. A survey of public workflow files corroborates rather than proves it: no live instance of a quoted string in a genuine boolean position, and most raw search hits turned out to be `with:` action inputs, where a string is legal. Pushing a scratch workflow carrying the spelling on a deliberately failing job would settle it against the service directly, and that has NOT been done here.
- Lint and types are clean on the new file at mypy 1.14.1, the pinned version, but at ruff 0.15.12 rather than the pinned 0.11.8, so the PINNED ruff was not the one run.
- The cost side of this trade, worth knowing before merging: attempt 1's red was a `pip install` failure before pytest ran, not a test failure. This change makes that class of flake BLOCKING where the old flags made it invisible. That is the intended direction, and the follow-up it argues for is a retry around the dependency install, not restoring the flag.
