### PR TITLE
isaacsim: make tracked-body lookup subset-safe

### DIFF
--- a/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
+++ b/src/holosoma/holosoma/simulator/isaacsim/isaacsim.py
@@ -881,8 +881,11 @@ class IsaacSim(BaseSimulator):
 
         this function returns the indice of the body in BFS order
         """
+        if body_name in self.body_names:
+            return self.body_names.index(body_name)
+
         indices, names = self._robot.find_bodies(body_name)
-        indices = [self.body_ids.index(i) for i in indices]
+        indices = [self.body_ids.index(i) for i in indices if i in self.body_ids]
         if len(indices) == 0:
             logger.warning(f"Body {body_name} not found in the contact sensor.")
             return None

--- a/src/holosoma/tests/simulators/isaacsim/test_body_lookup.py
+++ b/src/holosoma/tests/simulators/isaacsim/test_body_lookup.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock
+
+from holosoma.simulator.isaacsim.isaacsim import IsaacSim
+
+
+def _simulator(*, body_names, body_ids, matches):
+    simulator = object.__new__(IsaacSim)
+    simulator.body_names = body_names
+    simulator.body_ids = body_ids
+    simulator._robot = Mock()
+    simulator._robot.find_bodies.return_value = matches
+    return simulator
+
+
+def test_exact_name_returns_tracked_body_index_without_regex_search() -> None:
+    simulator = _simulator(
+        body_names=["pelvis", "torso", "left_ankle"],
+        body_ids=[2, 5, 9],
+        matches=([5], ["torso"]),
+    )
+
+    assert simulator.find_rigid_body_indice("torso") == 1
+    simulator._robot.find_bodies.assert_not_called()
+
+
+def test_regex_fallback_filters_untracked_robot_bodies() -> None:
+    simulator = _simulator(
+        body_names=["pelvis", "tracked_ankle"],
+        body_ids=[2, 9],
+        matches=([4, 9], ["untracked_ankle", "tracked_ankle"]),
+    )
+
+    assert simulator.find_rigid_body_indice(".*ankle") == 1
+
+
+def test_regex_fallback_maps_all_full_model_matches_to_tracked_indices() -> None:
+    simulator = _simulator(
+        body_names=["left_ankle", "right_ankle"],
+        body_ids=[8, 12],
+        matches=([12, 8], ["right_ankle", "left_ankle"]),
+    )
+
+    assert simulator.find_rigid_body_indice(".*ankle") == [1, 0]
+
+
+def test_regex_fallback_returns_none_when_only_untracked_bodies_match() -> None:
+    simulator = _simulator(
+        body_names=["pelvis"],
+        body_ids=[2],
+        matches=([7], ["decorative_torso"]),
+    )
+
+    assert simulator.find_rigid_body_indice("torso") is None


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Make Isaac Sim rigid-body lookup safe when Holosoma tracks only a subset of the robot's bodies.

- Resolve exact body names directly from the tracked body list, avoiding unintended regex matches.
- Filter regex matches to tracked body IDs before mapping them to tracked indices.
- Preserve the existing behavior for zero, one, or multiple tracked matches.
- Add regression tests covering exact lookup, mixed tracked/untracked matches, multiple matches, and untracked-only matches.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.