### PR TITLE
mujoco: support non-contiguous actuated DOFs

### DIFF
--- a/src/holosoma/holosoma/simulator/mujoco/mujoco.py
+++ b/src/holosoma/holosoma/simulator/mujoco/mujoco.py
@@ -23,9 +23,7 @@ from holosoma.simulator.mujoco.backends.base import apply_sensor_scene_flags, mj
 from holosoma.simulator.mujoco.command_registry import CommandRegistry
 from holosoma.simulator.mujoco.fields import prepare_fields, prepare_manager_fields
 from holosoma.simulator.mujoco.scene_manager import MujocoSceneManager
-from holosoma.simulator.mujoco.tensor_views import (
-    create_base_linear_acceleration_view,
-)
+from holosoma.simulator.mujoco.tensor_views import FilteredDofStateView, create_base_linear_acceleration_view
 from holosoma.simulator.mujoco.video_recorder import MuJoCoVideoRecorder
 from holosoma.simulator.shared.object_registry import ObjectType
 from holosoma.simulator.shared.root_states_view import UnifiedRootStatesView
@@ -84,6 +82,28 @@ class MuJoCoScene:
             Environment origins with shape [num_envs, 3].
         """
         return self._env_origins
+
+
+def _configured_dof_names(model_dof_names: list[str], config_dof_names: list[str]) -> list[str]:
+    """Select model joints named by the robot config and verify their order."""
+    config_dof_set = set(config_dof_names)
+    dof_names = [name for name in model_dof_names if name in config_dof_set]
+    if dof_names != config_dof_names:
+        raise ValueError(f"MuJoCo DOF names/order {dof_names} do not match the robot config {config_dof_names}.")
+    return dof_names
+
+
+def _address_span(addresses: list[int]) -> tuple[slice, int, list[int], bool]:
+    """Return the covering slice, width, relative indices, and contiguity."""
+    if not addresses:
+        return slice(0, 0), 0, [], True
+    start, stop = min(addresses), max(addresses) + 1
+    return (
+        slice(start, stop),
+        stop - start,
+        [address - start for address in addresses],
+        addresses == list(range(start, stop)),
+    )
 
 
 class MuJoCo(BaseSimulator):
@@ -428,9 +448,10 @@ class MuJoCo(BaseSimulator):
     def _set_robot_properties(self) -> None:
         """Set robot properties including DOF names, body names, and index mappings.
 
-        Robot elements (DOF joints, bodies) are identified from the per-actor spec
+        Robot elements (joints and bodies) are identified from the per-actor spec
         metadata captured at spawn (``scene_manager.robot_spec_meta``), which holds
-        exactly the robot's own named elements.
+        exactly the robot's own named elements. Public DOFs are the model joints
+        selected by ``robot_config.dof_names`` in matching order.
 
         ``body_names`` is the holosoma-facing, 0-based robot-body list (world body and
         all non-robot bodies excluded). ``body_ids`` is the matching list of raw
@@ -445,8 +466,8 @@ class MuJoCo(BaseSimulator):
         # Build clean<->prefixed name maps from the recorded robot elements first.
         self._build_name_maps()
 
-        # Robot DOFs: the recorded named, non-free joints (clean names).
-        self.dof_names = list(meta.dof_joint_names)
+        # Exclude passive model joints and enforce the cross-simulator config ordering.
+        self.dof_names = _configured_dof_names(meta.dof_joint_names, self.robot_config.dof_names)
         self.num_dof = len(self.dof_names)
 
         # Robot bodies (clean names), in the recorded spec (DFS) order.
@@ -843,25 +864,29 @@ class MuJoCo(BaseSimulator):
         # that set_actor_root_state_tensor uses (it detects this proxy by identity).
         self.all_root_states = UnifiedRootStatesView(self)  # type: ignore[assignment]
 
-        # Calculate indices for DOF positions and velocities
-        dof_pos_indices = (
-            slice(min(self.dof_qpos_addrs), max(self.dof_qpos_addrs) + 1) if self.dof_qpos_addrs else slice(0, 0)
-        )
-        dof_vel_indices = (
-            slice(min(self.dof_qvel_addrs), max(self.dof_qvel_addrs) + 1) if self.dof_qvel_addrs else slice(0, 0)
-        )
-        dof_acc_indices = (
-            slice(min(self.dof_qvel_addrs), max(self.dof_qvel_addrs) + 1) if self.dof_qvel_addrs else slice(0, 0)
-        )
+        # Calculate the full backend spans and each actuator's offset within them.
+        full_pos_slice, full_pos_count, self._actuated_qpos_rel, qpos_contiguous = _address_span(self.dof_qpos_addrs)
+        full_vel_slice, full_vel_count, self._actuated_qvel_rel, qvel_contiguous = _address_span(self.dof_qvel_addrs)
+        self._dof_needs_gather = not (qpos_contiguous and qvel_contiguous)
+        if self._dof_needs_gather:
+            # Backend views cover the full span, including any interleaved passive joints.
+            self._full_dof_pos = self.backend.create_dof_pos_view(full_pos_slice, full_pos_count)
+            self._full_dof_vel = self.backend.create_dof_vel_view(full_vel_slice, full_vel_count)
+            self._full_dof_acc = self.backend.create_dof_acc_view(full_vel_slice, full_vel_count)
 
-        # Create DOF state proxy via backend factory
-        dof_addrs = {"dof_pos_indices": dof_pos_indices, "dof_vel_indices": dof_vel_indices}
-        self.dof_state = self.backend.create_dof_state_view(dof_addrs, self.num_dof)  # type: ignore[assignment]
-
-        # Create individual DOF views via backend factories
-        self.dof_pos = self.backend.create_dof_pos_view(dof_pos_indices, self.num_dof)  # type: ignore[assignment]
-        self.dof_vel = self.backend.create_dof_vel_view(dof_vel_indices, self.num_dof)  # type: ignore[assignment]
-        self.dof_acc = self.backend.create_dof_acc_view(dof_acc_indices, self.num_dof)  # type: ignore[assignment]
+            # Expose filtered tensors so the public state shape remains [num_envs, num_dof].
+            self.dof_pos = torch.zeros(self.num_envs, self.num_dof, device=self.sim_device)
+            self.dof_vel = torch.zeros(self.num_envs, self.num_dof, device=self.sim_device)
+            self.dof_acc = torch.zeros(self.num_envs, self.num_dof, device=self.sim_device)
+            self.dof_state = FilteredDofStateView(self.dof_pos, self.dof_vel)  # type: ignore[assignment]
+            self._gather_actuated_dofs()
+        else:
+            # Preserve the existing zero-copy backend views for contiguous actuator layouts.
+            dof_addrs = {"dof_pos_indices": full_pos_slice, "dof_vel_indices": full_vel_slice}
+            self.dof_state = self.backend.create_dof_state_view(dof_addrs, self.num_dof)  # type: ignore[assignment]
+            self.dof_pos = self.backend.create_dof_pos_view(full_pos_slice, self.num_dof)  # type: ignore[assignment]
+            self.dof_vel = self.backend.create_dof_vel_view(full_vel_slice, self.num_dof)  # type: ignore[assignment]
+            self.dof_acc = self.backend.create_dof_acc_view(full_vel_slice, self.num_dof)  # type: ignore[assignment]
 
         # contact_forces stays the robot-only, num_bodies-wide tensor allocated in
         # create_envs; refresh_sim_tensors gathers robot rows into it each frame. It is
@@ -1026,6 +1051,18 @@ class MuJoCo(BaseSimulator):
             self.contact_forces_history[:] = torch.cat(
                 [self.contact_forces.unsqueeze(1), self.contact_forces_history[:, :-1]], dim=1
             )
+
+        if getattr(self, "_dof_needs_gather", False):
+            self._gather_actuated_dofs()
+
+    def _gather_actuated_dofs(self) -> None:
+        """Gather actuated joints from views that also contain passive joints."""
+        full_pos = self._full_dof_pos if isinstance(self._full_dof_pos, torch.Tensor) else self._full_dof_pos[:]
+        full_vel = self._full_dof_vel if isinstance(self._full_dof_vel, torch.Tensor) else self._full_dof_vel[:]
+        full_acc = self._full_dof_acc if isinstance(self._full_dof_acc, torch.Tensor) else self._full_dof_acc[:]
+        self.dof_pos[:] = full_pos[:, self._actuated_qpos_rel]
+        self.dof_vel[:] = full_vel[:, self._actuated_qvel_rel]
+        self.dof_acc[:] = full_acc[:, self._actuated_qvel_rel]
 
     def clear_contact_forces_history(self, env_ids: torch.Tensor) -> None:
         """Clear contact forces history for specified environments.
@@ -1495,6 +1532,8 @@ class MuJoCo(BaseSimulator):
         # Delegate to backend
         dof_addrs = {"dof_qpos_addrs": self.dof_qpos_addrs, "dof_qvel_addrs": self.dof_qvel_addrs}
         self.backend.set_dof_state(env_ids, dof_states, dof_addrs)
+        if getattr(self, "_dof_needs_gather", False):
+            self._gather_actuated_dofs()
 
     def get_dof_limits_properties(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Get DOF limits properties - simplified IsaacSim pattern.

--- a/src/holosoma/holosoma/simulator/mujoco/scene_manager.py
+++ b/src/holosoma/holosoma/simulator/mujoco/scene_manager.py
@@ -38,7 +38,7 @@ class ActorSpecMeta:
     root_body: str
     # Robot/actor bodies in spec (DFS) order, excluding the implicit worldbody.
     body_names: list[str] = field(default_factory=list)
-    # Named, non-free joints only (the actor's actuated DOFs).
+    # Named, non-free joints; robot configs select the public actuated DOFs.
     dof_joint_names: list[str] = field(default_factory=list)
     # Named actuators.
     actuator_names: list[str] = field(default_factory=list)

--- a/src/holosoma/holosoma/simulator/mujoco/tensor_views.py
+++ b/src/holosoma/holosoma/simulator/mujoco/tensor_views.py
@@ -351,6 +351,33 @@ class MujocoRootStateView:
         return self[:].clone()
 
 
+class FilteredDofStateView(BaseMujocoViewMixin):
+    """IsaacGym-format state view backed by filtered position and velocity tensors."""
+
+    def __init__(self, dof_pos: torch.Tensor, dof_vel: torch.Tensor):
+        self._dof_pos = dof_pos
+        self._dof_vel = dof_vel
+        self.num_envs, self.num_dof = dof_pos.shape
+        self.device = str(dof_pos.device)
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return (self.num_envs * self.num_dof, 2)
+
+    def __getitem__(self, key) -> torch.Tensor:
+        return torch.stack([self._dof_pos, self._dof_vel], dim=-1).reshape(-1, 2)[key]
+
+    def __setitem__(self, key, value) -> None:
+        value = torch.as_tensor(value, device=self.device)
+        if key != slice(None):
+            current = self[:]
+            current[key] = value
+            value = current
+        state = value.reshape(self.num_envs, self.num_dof, 2)
+        self._dof_pos[:] = state[..., 0]
+        self._dof_vel[:] = state[..., 1]
+
+
 class MujocoDofStateView:
     """
     Specialized view for DOF states compatible with IsaacGym's flattened format.

--- a/src/holosoma/tests/simulators/mujoco/test_noncontiguous_dofs.py
+++ b/src/holosoma/tests/simulators/mujoco/test_noncontiguous_dofs.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+mujoco = pytest.importorskip("mujoco")
+pytestmark = pytest.mark.mujoco_classic
+
+from holosoma.simulator.mujoco.backends.classic_backend import ClassicBackend  # noqa: E402
+from holosoma.simulator.mujoco.mujoco import MuJoCo, _address_span, _configured_dof_names  # noqa: E402
+from holosoma.simulator.mujoco.tensor_views import FilteredDofStateView  # noqa: E402
+
+_INTERLEAVED_MJCF = """
+<mujoco>
+  <worldbody>
+    <body>
+      <joint name="left_motor" type="hinge"/>
+      <geom type="sphere" size="0.1"/>
+      <body pos="0 0 0.2">
+        <joint name="passive_joint" type="hinge"/>
+        <geom type="sphere" size="0.1"/>
+        <body pos="0 0 0.2">
+          <joint name="right_motor" type="hinge"/>
+          <geom type="sphere" size="0.1"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor joint="left_motor"/>
+    <motor joint="right_motor"/>
+  </actuator>
+</mujoco>
+"""
+
+
+class Proxy:
+    def __init__(self, value: torch.Tensor):
+        self.value = value
+
+    def __getitem__(self, key):
+        return self.value[key]
+
+
+def test_interleaved_passive_joint_is_excluded_and_preserved_on_write() -> None:
+    model = mujoco.MjModel.from_xml_string(_INTERLEAVED_MJCF)
+    data = mujoco.MjData(model)
+    model_dofs = [model.joint(i).name for i in range(model.njnt)]
+    dof_names = _configured_dof_names(model_dofs, ["left_motor", "right_motor"])
+    joint_ids = [mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name) for name in dof_names]
+    qpos_addrs = [int(model.jnt_qposadr[joint_id]) for joint_id in joint_ids]
+    qvel_addrs = [int(model.jnt_dofadr[joint_id]) for joint_id in joint_ids]
+
+    assert dof_names == ["left_motor", "right_motor"]
+    assert qpos_addrs == [0, 2]
+    assert qvel_addrs == [0, 2]
+
+    passive_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "passive_joint")
+    passive_qpos = int(model.jnt_qposadr[passive_id])
+    passive_qvel = int(model.jnt_dofadr[passive_id])
+    data.qpos[passive_qpos] = 0.75
+    data.qvel[passive_qvel] = -0.25
+
+    backend = object.__new__(ClassicBackend)
+    backend.model = model
+    backend.data = data
+    state = torch.tensor([[1.0, 0.1], [2.0, 0.2]])
+    backend.set_dof_state(torch.tensor([0]), state, {"dof_qpos_addrs": qpos_addrs, "dof_qvel_addrs": qvel_addrs})
+
+    assert data.qpos[qpos_addrs].tolist() == pytest.approx([1.0, 2.0])
+    assert data.qvel[qvel_addrs].tolist() == pytest.approx([0.1, 0.2])
+    assert data.qpos[passive_qpos] == pytest.approx(0.75)
+    assert data.qvel[passive_qvel] == pytest.approx(-0.25)
+
+
+@pytest.mark.parametrize("config_dofs", [["right_motor", "left_motor"], ["left_motor", "missing_motor"]])
+def test_configured_dofs_reject_order_mismatches_and_missing_joints(config_dofs: list[str]) -> None:
+    with pytest.raises(ValueError, match="DOF names/order"):
+        _configured_dof_names(["left_motor", "passive_joint", "right_motor"], config_dofs)
+
+
+def test_address_span_detects_gaps() -> None:
+    assert _address_span([5, 6]) == (slice(5, 7), 2, [0, 1], True)
+    assert _address_span([5, 7]) == (slice(5, 8), 3, [0, 2], False)
+
+
+@pytest.mark.parametrize("use_proxy", [False, True], ids=["tensor", "proxy"])
+def test_gather_excludes_interleaved_passive_joints(use_proxy: bool) -> None:
+    simulator = object.__new__(MuJoCo)
+
+    def wrap(value: torch.Tensor) -> Proxy | torch.Tensor:
+        return Proxy(value) if use_proxy else value
+
+    simulator._full_dof_pos = wrap(torch.tensor([[10.0, 99.0, 20.0]]))
+    simulator._full_dof_vel = wrap(torch.tensor([[1.0, 9.9, 2.0]]))
+    simulator._full_dof_acc = wrap(torch.tensor([[0.1, 0.99, 0.2]]))
+    simulator._actuated_qpos_rel = [0, 2]
+    simulator._actuated_qvel_rel = [0, 2]
+    simulator.dof_pos = torch.zeros(1, 2)
+    simulator.dof_vel = torch.zeros(1, 2)
+    simulator.dof_acc = torch.zeros(1, 2)
+
+    simulator._gather_actuated_dofs()
+
+    torch.testing.assert_close(simulator.dof_pos, torch.tensor([[10.0, 20.0]]))
+    torch.testing.assert_close(simulator.dof_vel, torch.tensor([[1.0, 2.0]]))
+    torch.testing.assert_close(simulator.dof_acc, torch.tensor([[0.1, 0.2]]))
+
+
+def test_filtered_state_view_writes_positions_and_velocities() -> None:
+    positions = torch.zeros(1, 3)
+    velocities = torch.zeros(1, 3)
+    view = FilteredDofStateView(positions, velocities)
+    state = torch.tensor([[1.0, 0.1], [2.0, 0.2], [3.0, 0.3]])
+
+    view[:] = state
+
+    torch.testing.assert_close(positions, state[:, 0].unsqueeze(0))
+    torch.testing.assert_close(velocities, state[:, 1].unsqueeze(0))
+    torch.testing.assert_close(view.clone(), state)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

MuJoCo models can contain passive joints interleaved with actuated joints. Holosoma currently treats every named non-free robot joint as a public DOF and represents the resulting state using contiguous slices. This can include passive joints in the public state tensors and cause their shape and ordering to differ from `robot_config.dof_names`.

This aligns MuJoCo’s public DOF selection with Isaac Sim, which resolves and indexes only the joints listed in `robot_config.dof_names`.

This change:

- selects public DOFs using `robot_config.dof_names`, excluding passive model joints;
- validates that the configured DOF ordering matches the model ordering;
- preserves the existing zero-copy path for contiguous layouts;
- gathers only configured joints when their MuJoCo qpos/qvel addresses are non-contiguous;
- refreshes filtered state after simulation updates and explicit DOF writes;
- adds a minimal `actuated → passive → actuated` MJCF regression covering passive-joint exclusion and state preservation;
- covers both proxy-backed Classic storage and tensor-backed storage used by Warp.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.