### PR TITLE
fix(inference): print WBT controls for policy subclasses

### DIFF
--- a/src/holosoma_inference/holosoma_inference/config/tests/test_run_policy.py
+++ b/src/holosoma_inference/holosoma_inference/config/tests/test_run_policy.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from holosoma_inference import run_policy as run_policy_module
 from holosoma_inference.config.config_values.inference import get_annotated_inference_config
+from holosoma_inference.policies.locomotion import LocomotionPolicy
+from holosoma_inference.policies.wbt import WholeBodyTrackingPolicy
 
 
 def test_main_defers_default_inference_config_factory(monkeypatch):
@@ -99,3 +101,32 @@ def test_main_secondary_override_on_default_secondary(monkeypatch):
     for c in parse_calls:
         assert "config" not in c["tyro_kwargs"]
     assert parse_calls[1]["default"] is default_secondary
+
+
+def _captured_control_guide(monkeypatch, policy_class):
+    lines = []
+
+    class _Logger:
+        def info(self, message=""):
+            lines.append(str(message))
+
+    monkeypatch.setattr(run_policy_module, "logger", _Logger())
+    run_policy_module._print_control_guide(policy_class, use_joystick=False)
+    return lines
+
+
+def test_control_guide_covers_wbt_subclasses(monkeypatch):
+    class _ExtensionWBTPolicy(WholeBodyTrackingPolicy):
+        pass
+
+    lines = _captured_control_guide(monkeypatch, _ExtensionWBTPolicy)
+
+    assert any("Start motion clip" in line for line in lines)
+    assert not any("Switch walking/standing mode" in line for line in lines)
+
+
+def test_control_guide_keeps_locomotion_controls(monkeypatch):
+    lines = _captured_control_guide(monkeypatch, LocomotionPolicy)
+
+    assert any("Switch walking/standing mode" in line for line in lines)
+    assert not any("Start motion clip" in line for line in lines)

--- a/src/holosoma_inference/holosoma_inference/run_policy.py
+++ b/src/holosoma_inference/holosoma_inference/run_policy.py
@@ -20,6 +20,7 @@ from loguru import logger
 from holosoma_inference.config.config_types.inference import InferenceConfig
 from holosoma_inference.config.config_values.inference import get_annotated_inference_config
 from holosoma_inference.policies.dual_mode import DualModePolicy, _select_policy_class
+from holosoma_inference.policies.wbt import WholeBodyTrackingPolicy
 from holosoma_inference.utils.config_registry import parse_config
 from holosoma_inference.utils.misc import restore_terminal_settings
 from holosoma_inference.utils.session_recorder import SessionRecorder
@@ -27,7 +28,7 @@ from holosoma_inference.utils.session_recorder import SessionRecorder
 
 def _print_control_guide(policy_class, use_joystick: bool, dual_mode: bool = False):
     """Print control guide for users."""
-    is_wbt = policy_class.__name__ == "WholeBodyTrackingPolicy"
+    is_wbt = issubclass(policy_class, WholeBodyTrackingPolicy)
 
     logger.info("=" * 80)
     logger.info("🎮 POLICY CONTROLS")


### PR DESCRIPTION
`_print_control_guide` identified WBT runs by exact class name:

```python
is_wbt = policy_class.__name__ == "WholeBodyTrackingPolicy"
```

WBT variants are registered under the `holosoma.policies.wbt` entry-point group, and those are subclasses. Running one printed the **locomotion** controls (`=`, `w/s`, `a/d`, `z`) and omitted `m - Start motion clip`, the key the operator needs to start the motion. `issubclass` fixes it.

Guide text only — no behaviour change. Two tests cover the subclass and locomotion branches; the first fails on `main`.